### PR TITLE
feat(phase-1C): chat-back + LocalMarkdownMemoryStore I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,6 +2127,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3998,6 +3999,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/mori-core/Cargo.toml
+++ b/crates/mori-core/Cargo.toml
@@ -19,3 +19,6 @@ schemars = { workspace = true }
 chrono = { workspace = true }
 reqwest = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/mori-core/src/memory/markdown.rs
+++ b/crates/mori-core/src/memory/markdown.rs
@@ -9,14 +9,32 @@
 //! └── ...
 //! ```
 //!
-//! Phase 1 只先做 trait 骨架,實際 read/write 在後續 PR 補上。
+//! 索引行格式:
+//! ```text
+//! - [Display Name](file_id.md) — short description
+//! ```
+//!
+//! Memory 檔格式:
+//! ```text
+//! ---
+//! name: User prefers terse responses
+//! description: Established 2026-05-06
+//! type: preference
+//! created: 2026-05-06T14:23:00Z
+//! last_used: 2026-05-07T09:15:00Z
+//! ---
+//!
+//! User prefers responses without:
+//! - Unnecessary preamble
+//! ```
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
+use chrono::Utc;
 use futures_util::stream::{self, BoxStream};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use super::{Memory, MemoryEvent, MemoryIndexEntry, MemoryStore};
+use super::{Memory, MemoryEvent, MemoryIndexEntry, MemoryStore, MemoryType};
 
 pub struct LocalMarkdownMemoryStore {
     root: PathBuf,
@@ -41,39 +59,363 @@ impl LocalMarkdownMemoryStore {
     pub fn root(&self) -> &PathBuf {
         &self.root
     }
+
+    fn index_path(&self) -> PathBuf {
+        self.root.join("MEMORY.md")
+    }
+
+    fn memory_path(&self, id: &str) -> PathBuf {
+        self.root.join(format!("{id}.md"))
+    }
+
+    /// 把 core memory 直接攤平成一段純文字,適合塞進 system prompt。
+    ///
+    /// Phase 1C 為了讓 LLM「知道你是誰」,我們會在每次 chat 時讀整個索引 +
+    /// 全部 memory 內容當作背景。如果 memory 多了會嫌長,phase 5+ 再做
+    /// 「LLM 自己挑相關 memory」邏輯。
+    pub fn read_all_as_context(&self) -> Result<String> {
+        let entries = blocking_read_index(&self.index_path())?;
+        if entries.is_empty() {
+            return Ok(String::new());
+        }
+        let mut out = String::new();
+        out.push_str("# 你已知關於使用者的事\n\n");
+        for entry in &entries {
+            let path = self.memory_path(&entry.id);
+            if let Ok(memory) = blocking_read_memory(&path) {
+                out.push_str(&format!("## {} ({:?})\n", memory.name, memory.memory_type));
+                out.push_str(&memory.body);
+                out.push_str("\n\n");
+            }
+        }
+        Ok(out)
+    }
 }
 
 #[async_trait]
 impl MemoryStore for LocalMarkdownMemoryStore {
     async fn read_index(&self) -> Result<Vec<MemoryIndexEntry>> {
-        // TODO(phase 1B): parse MEMORY.md → Vec<MemoryIndexEntry>
-        Ok(Vec::new())
+        blocking_read_index(&self.index_path())
     }
 
-    async fn read(&self, _id: &str) -> Result<Option<Memory>> {
-        // TODO(phase 1B): read <id>.md, parse frontmatter + body
-        Ok(None)
+    async fn read(&self, id: &str) -> Result<Option<Memory>> {
+        let path = self.memory_path(id);
+        if !path.exists() {
+            return Ok(None);
+        }
+        Ok(Some(blocking_read_memory(&path)?))
     }
 
-    async fn write(&self, _memory: Memory) -> Result<()> {
-        // TODO(phase 1B): write <id>.md with YAML frontmatter,
-        //                 update MEMORY.md index entry
+    async fn write(&self, mut memory: Memory) -> Result<()> {
+        if memory.created.timestamp() == 0 {
+            memory.created = Utc::now();
+        }
+        memory.last_used = Utc::now();
+
+        let path = self.memory_path(&memory.id);
+        std::fs::write(&path, format_memory(&memory)).context("write memory file")?;
+
+        upsert_index_entry(
+            &self.index_path(),
+            &MemoryIndexEntry {
+                id: memory.id.clone(),
+                name: memory.name.clone(),
+                description: memory.description.clone(),
+                memory_type: memory.memory_type.clone(),
+            },
+        )?;
+
+        tracing::info!(id = %memory.id, "memory written");
         Ok(())
     }
 
-    async fn search(&self, _query: &str, _limit: usize) -> Result<Vec<Memory>> {
-        // TODO(phase 1B): grep across files, return matching Memory
-        // TODO(phase 5):  add sqlite-vec backed implementation
-        Ok(Vec::new())
+    async fn search(&self, query: &str, limit: usize) -> Result<Vec<Memory>> {
+        // Phase 1C: grep — 搜 name / description / body 是否含 query。
+        // Phase 5+ 換成 sqlite-vec embedding。
+        let needle = query.to_lowercase();
+        let entries = blocking_read_index(&self.index_path())?;
+        let mut out = Vec::new();
+        for entry in entries {
+            let path = self.memory_path(&entry.id);
+            let mem = match blocking_read_memory(&path) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            if mem.name.to_lowercase().contains(&needle)
+                || mem.description.to_lowercase().contains(&needle)
+                || mem.body.to_lowercase().contains(&needle)
+            {
+                out.push(mem);
+                if out.len() >= limit {
+                    break;
+                }
+            }
+        }
+        Ok(out)
     }
 
-    async fn delete(&self, _id: &str) -> Result<()> {
-        // TODO(phase 1B)
+    async fn delete(&self, id: &str) -> Result<()> {
+        let path = self.memory_path(id);
+        if path.exists() {
+            std::fs::remove_file(&path).context("remove memory file")?;
+        }
+        remove_index_entry(&self.index_path(), id)?;
         Ok(())
     }
 
     fn observe(&self) -> BoxStream<'static, MemoryEvent> {
-        // TODO(phase 1B): broadcast events on write/update/delete
+        // Phase 1C: 不發 events。Phase 5+ 接 inotify / FSEvents 才有意義。
         Box::pin(stream::empty())
+    }
+}
+
+// ─── 純檔案 I/O 與解析 ──────────────────────────────────────────────
+
+fn blocking_read_index(path: &Path) -> Result<Vec<MemoryIndexEntry>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let text = std::fs::read_to_string(path).context("read index")?;
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let line = line.trim_start();
+        if !line.starts_with("- [") {
+            continue;
+        }
+        let after_open = match line.strip_prefix("- [") {
+            Some(s) => s,
+            None => continue,
+        };
+        let close_bracket = match after_open.find("](") {
+            Some(i) => i,
+            None => continue,
+        };
+        let name = &after_open[..close_bracket];
+        let after_paren = &after_open[close_bracket + 2..];
+        let close_paren = match after_paren.find(')') {
+            Some(i) => i,
+            None => continue,
+        };
+        let file = &after_paren[..close_paren];
+        let id = file.strip_suffix(".md").unwrap_or(file).to_string();
+        let rest = &after_paren[close_paren + 1..];
+        let description = rest
+            .trim_start_matches([' ', '—', '-', '–'])
+            .trim()
+            .to_string();
+        out.push(MemoryIndexEntry {
+            id,
+            name: name.to_string(),
+            description,
+            memory_type: MemoryType::Other("unknown".into()),
+        });
+    }
+    Ok(out)
+}
+
+fn blocking_read_memory(path: &Path) -> Result<Memory> {
+    let text = std::fs::read_to_string(path).context("read memory file")?;
+    let id = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_string();
+    parse_memory(&id, &text)
+}
+
+fn parse_memory(id: &str, text: &str) -> Result<Memory> {
+    let mut name = id.replace('_', " ");
+    let mut description = String::new();
+    let mut memory_type = MemoryType::Other("unknown".into());
+    let mut created = Utc::now();
+    let mut last_used = Utc::now();
+    let body;
+
+    if let Some(rest) = text.strip_prefix("---\n") {
+        if let Some(end) = rest.find("\n---\n") {
+            let header = &rest[..end];
+            body = rest[end + 5..].trim().to_string();
+            for line in header.lines() {
+                let (key, value) = match line.split_once(':') {
+                    Some((k, v)) => (k.trim(), v.trim().trim_matches('"').trim_matches('\'')),
+                    None => continue,
+                };
+                match key {
+                    "name" => name = value.to_string(),
+                    "description" => description = value.to_string(),
+                    "type" => memory_type = parse_memory_type(value),
+                    "created" => {
+                        if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(value) {
+                            created = ts.with_timezone(&Utc);
+                        }
+                    }
+                    "last_used" => {
+                        if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(value) {
+                            last_used = ts.with_timezone(&Utc);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        } else {
+            body = text.to_string();
+        }
+    } else {
+        body = text.to_string();
+    }
+
+    Ok(Memory {
+        id: id.to_string(),
+        name,
+        description,
+        memory_type,
+        created,
+        last_used,
+        body,
+    })
+}
+
+fn parse_memory_type(s: &str) -> MemoryType {
+    match s.to_lowercase().as_str() {
+        "user_identity" | "user-identity" | "useridentity" => MemoryType::UserIdentity,
+        "preference" => MemoryType::Preference,
+        "skill_outcome" | "skill-outcome" | "skilloutcome" => MemoryType::SkillOutcome,
+        "project" => MemoryType::Project,
+        "reference" => MemoryType::Reference,
+        other => MemoryType::Other(other.to_string()),
+    }
+}
+
+fn format_memory(m: &Memory) -> String {
+    let type_str = match &m.memory_type {
+        MemoryType::UserIdentity => "user_identity".to_string(),
+        MemoryType::Preference => "preference".to_string(),
+        MemoryType::SkillOutcome => "skill_outcome".to_string(),
+        MemoryType::Project => "project".to_string(),
+        MemoryType::Reference => "reference".to_string(),
+        MemoryType::Other(s) => s.clone(),
+    };
+    format!(
+        "---\nname: {}\ndescription: {}\ntype: {}\ncreated: {}\nlast_used: {}\n---\n\n{}\n",
+        m.name,
+        m.description,
+        type_str,
+        m.created.to_rfc3339(),
+        m.last_used.to_rfc3339(),
+        m.body.trim_end()
+    )
+}
+
+fn upsert_index_entry(index_path: &Path, entry: &MemoryIndexEntry) -> Result<()> {
+    let mut lines: Vec<String> = if index_path.exists() {
+        std::fs::read_to_string(index_path)?
+            .lines()
+            .map(String::from)
+            .collect()
+    } else {
+        vec!["# Mori Memory Index".into(), String::new()]
+    };
+    let new_line = format!(
+        "- [{}]({}.md) — {}",
+        entry.name, entry.id, entry.description
+    );
+
+    let needle = format!("]({}.md)", entry.id);
+    let mut replaced = false;
+    for line in lines.iter_mut() {
+        if line.contains(&needle) {
+            *line = new_line.clone();
+            replaced = true;
+            break;
+        }
+    }
+    if !replaced {
+        if !lines.last().map(|l| l.is_empty()).unwrap_or(false) {
+            lines.push(String::new());
+        }
+        lines.push(new_line);
+    }
+    std::fs::write(index_path, lines.join("\n") + "\n")?;
+    Ok(())
+}
+
+fn remove_index_entry(index_path: &Path, id: &str) -> Result<()> {
+    if !index_path.exists() {
+        return Ok(());
+    }
+    let needle = format!("]({}.md)", id);
+    let kept: Vec<String> = std::fs::read_to_string(index_path)?
+        .lines()
+        .filter(|l| !l.contains(&needle))
+        .map(String::from)
+        .collect();
+    std::fs::write(index_path, kept.join("\n") + "\n")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn write_then_read_roundtrips() {
+        let dir = tempdir().unwrap();
+        let store = LocalMarkdownMemoryStore::new(dir.path().to_path_buf()).unwrap();
+
+        let mem = Memory {
+            id: "user_lang".into(),
+            name: "Prefers 繁中".into(),
+            description: "User writes in Traditional Chinese".into(),
+            memory_type: MemoryType::Preference,
+            created: Utc::now(),
+            last_used: Utc::now(),
+            body: "Always reply in 繁體中文.".into(),
+        };
+
+        store.write(mem.clone()).await.unwrap();
+
+        let read = store.read("user_lang").await.unwrap().unwrap();
+        assert_eq!(read.name, "Prefers 繁中");
+        assert_eq!(read.body, "Always reply in 繁體中文.");
+        assert!(matches!(read.memory_type, MemoryType::Preference));
+
+        let index = store.read_index().await.unwrap();
+        assert_eq!(index.len(), 1);
+        assert_eq!(index[0].id, "user_lang");
+    }
+
+    #[tokio::test]
+    async fn search_finds_in_body() {
+        let dir = tempdir().unwrap();
+        let store = LocalMarkdownMemoryStore::new(dir.path().to_path_buf()).unwrap();
+        store
+            .write(Memory {
+                id: "a".into(),
+                name: "A".into(),
+                description: "".into(),
+                memory_type: MemoryType::Other("note".into()),
+                created: Utc::now(),
+                last_used: Utc::now(),
+                body: "Coffee at the forest cafe.".into(),
+            })
+            .await
+            .unwrap();
+        store
+            .write(Memory {
+                id: "b".into(),
+                name: "B".into(),
+                description: "".into(),
+                memory_type: MemoryType::Other("note".into()),
+                created: Utc::now(),
+                last_used: Utc::now(),
+                body: "Buy groceries.".into(),
+            })
+            .await
+            .unwrap();
+
+        let hits = store.search("forest", 10).await.unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].id, "a");
     }
 }

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use mori_core::llm::groq::GroqProvider;
-use mori_core::llm::LlmProvider;
+use mori_core::llm::{ChatMessage, LlmProvider};
+use mori_core::memory::markdown::LocalMarkdownMemoryStore;
 use mori_core::{PHASE, VERSION};
 use parking_lot::Mutex;
 use serde::Serialize;
@@ -27,8 +28,13 @@ pub enum Phase {
     Recording { started_at_ms: i64 },
     /// 已停止錄音,正在打 Whisper API
     Transcribing,
-    /// 拿到逐字稿
-    Done { transcript: String },
+    /// transcript 拿到了,正在問 LLM
+    Responding { transcript: String },
+    /// 完整一輪結束 — 同時帶 transcript 跟 LLM 回應
+    Done {
+        transcript: String,
+        response: String,
+    },
     /// 錯誤(任何階段都可以掉到這)
     Error { message: String },
 }
@@ -39,13 +45,15 @@ impl Default for Phase {
     }
 }
 
-#[derive(Default)]
 pub struct AppState {
     pub phase: Mutex<Phase>,
     pub recorder: Mutex<Option<Recorder>>,
     /// 透過 GroqProvider::discover_api_key() 在啟動時嘗試取得;
     /// 若無,transcribe 階段會回 Error。
     pub groq_api_key: Mutex<Option<String>>,
+    /// 長期記憶 store。Phase 1C 是 LocalMarkdownMemoryStore;
+    /// phase 7+ 換成 SyncedMemoryStore 不重寫上層程式碼。
+    pub memory: Arc<LocalMarkdownMemoryStore>,
 }
 
 impl AppState {
@@ -97,8 +105,8 @@ fn handle_hotkey_toggle(app: AppHandle, state: Arc<AppState>) {
         Phase::Recording { .. } => {
             stop_and_transcribe(app, state);
         }
-        Phase::Transcribing => {
-            tracing::info!("toggle while transcribing — ignored");
+        Phase::Transcribing | Phase::Responding { .. } => {
+            tracing::info!("toggle while busy — ignored");
         }
     }
 }
@@ -172,11 +180,13 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
 
     let api_key = state.groq_api_key.lock().clone();
 
+    let memory = state.memory.clone();
+
     tauri::async_runtime::spawn(async move {
-        let result: anyhow::Result<String> = async {
+        // Stage 1: Whisper
+        let transcribe_result: anyhow::Result<(String, GroqProvider)> = async {
             let audio = recorder.stop().context("stop recorder")?;
             let duration = audio.duration_secs();
-            // 計算音量:RMS,讓我們知道是不是麥克風根本沒收到聲音
             let rms = if audio.samples.is_empty() {
                 0.0
             } else {
@@ -204,14 +214,9 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
             }
 
             let wav = audio.to_wav_bytes().context("encode WAV")?;
-
-            // Debug:把最後一次錄音存到 /tmp,使用者可以播聽看
             let debug_path = std::env::temp_dir().join("mori-last-recording.wav");
-            if let Err(e) = std::fs::write(&debug_path, &wav) {
-                tracing::warn!(?e, "failed to write debug WAV");
-            } else {
-                tracing::info!(path = %debug_path.display(), "wrote debug WAV");
-            }
+            let _ = std::fs::write(&debug_path, &wav);
+            tracing::info!(path = %debug_path.display(), "wrote debug WAV");
 
             let key = api_key.context(
                 "no GROQ_API_KEY configured. \
@@ -219,27 +224,97 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
             )?;
             let provider =
                 GroqProvider::new(key, GroqProvider::DEFAULT_CHAT_MODEL.to_string());
-            let text = provider.transcribe(wav).await.context("groq transcribe")?;
-            Ok(text)
+            let transcript = provider.transcribe(wav).await.context("groq transcribe")?;
+            tracing::info!(chars = transcript.chars().count(), "transcribed");
+            Ok((transcript, provider))
         }
         .await;
 
-        match result {
-            Ok(transcript) => {
-                tracing::info!(chars = transcript.chars().count(), "transcribed");
-                state.set_phase(&app, Phase::Done { transcript });
-            }
+        let (transcript, provider) = match transcribe_result {
+            Ok(t) => t,
             Err(e) => {
-                tracing::error!(?e, "transcribe pipeline failed");
+                tracing::error!(?e, "transcribe failed");
                 state.set_phase(
                     &app,
                     Phase::Error {
                         message: format!("{e:#}"),
                     },
                 );
+                return;
+            }
+        };
+
+        // Stage 2: Mori 用 LLM 回應
+        state.set_phase(
+            &app,
+            Phase::Responding {
+                transcript: transcript.clone(),
+            },
+        );
+
+        let chat_result: anyhow::Result<String> = async {
+            let memory_context = memory.read_all_as_context().unwrap_or_default();
+            let system_prompt = build_system_prompt(&memory_context);
+            tracing::debug!(
+                memory_chars = memory_context.chars().count(),
+                "calling LLM with system prompt"
+            );
+
+            let messages = vec![
+                ChatMessage {
+                    role: "system".into(),
+                    content: system_prompt,
+                },
+                ChatMessage {
+                    role: "user".into(),
+                    content: transcript.clone(),
+                },
+            ];
+            let resp = provider.chat(messages, vec![]).await.context("groq chat")?;
+            let text = resp
+                .content
+                .ok_or_else(|| anyhow::anyhow!("LLM returned no content"))?;
+            Ok(text)
+        }
+        .await;
+
+        match chat_result {
+            Ok(response) => {
+                tracing::info!(chars = response.chars().count(), "Mori responded");
+                state.set_phase(&app, Phase::Done { transcript, response });
+            }
+            Err(e) => {
+                tracing::error!(?e, "chat failed");
+                state.set_phase(
+                    &app,
+                    Phase::Error {
+                        message: format!("LLM 回應失敗:{e:#}"),
+                    },
+                );
             }
         }
     });
+}
+
+/// 建構 Mori 的 system prompt — 角色設定 + 當前時間 + 長期記憶。
+fn build_system_prompt(memory_context: &str) -> String {
+    let now = chrono::Local::now().format("%Y-%m-%d %H:%M (%a)").to_string();
+    let mut prompt = String::new();
+    prompt.push_str(
+        "你是 Mori,一個輕巧、貼心的桌面 AI 管家。背景設定:你是來自 world-tree \
+         森林的精靈,被使用者帶到桌面當日常陪伴與助手。\n\n",
+    );
+    prompt.push_str("回覆規則:\n");
+    prompt.push_str("- 一律使用繁體中文,語氣自然、簡潔\n");
+    prompt.push_str("- 不寫前言或客套(例如「好的」、「沒問題」、「以下是」)— 直接進主題\n");
+    prompt.push_str("- 若使用者問你做不到的事(例如操作系統、開檔案),老實說「目前還沒這個能力」\n");
+    prompt.push_str("- 回覆長度配合提問:閒聊就一兩句,問題要解釋才展開\n\n");
+    prompt.push_str(&format!("現在時間:{now}\n"));
+    if !memory_context.is_empty() {
+        prompt.push_str("\n");
+        prompt.push_str(memory_context);
+    }
+    prompt
 }
 
 // ─── main ───────────────────────────────────────────────────────────
@@ -254,8 +329,6 @@ fn main() {
 
     tracing::info!("Mori starting — phase {}", PHASE);
 
-    let state = Arc::new(AppState::default());
-
     // 確保 ~/.mori/config.json 存在(第一次跑就會寫一份 stub)
     let config_path = match GroqProvider::bootstrap_mori_config() {
         Ok(p) => Some(p),
@@ -264,6 +337,22 @@ fn main() {
             None
         }
     };
+
+    // 建立長期記憶 store。第一次跑會在 ~/.mori/memory/ 建空索引。
+    let memory_root = LocalMarkdownMemoryStore::default_root()
+        .expect("could not determine ~/.mori/memory path");
+    let memory = Arc::new(
+        LocalMarkdownMemoryStore::new(memory_root.clone())
+            .expect("failed to initialize memory store"),
+    );
+    tracing::info!(path = %memory_root.display(), "memory store ready");
+
+    let state = Arc::new(AppState {
+        phase: Mutex::new(Phase::default()),
+        recorder: Mutex::new(None),
+        groq_api_key: Mutex::new(None),
+        memory,
+    });
 
     if let Some(key) = GroqProvider::discover_api_key() {
         tracing::info!("found GROQ_API_KEY");

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,11 +21,18 @@
 - [x] State machine:Idle → Recording → Transcribing → Done / Error
 - [x] React UI:phase-aware hero panel,錄音狀態動畫 + transcript 顯示
 
-### Phase 1C — 後續(下個 PR)
-- [ ] `LocalMarkdownMemoryStore` 真實 read / write
-- [ ] `EchoSkill`:把 LLM 回應接到 UI(加入 chat 階段,不只 transcribe)
-- [ ] `RememberSkill`:把當前 transcript 寫入 memory
+### Phase 1C — Chat-back + 真實記憶 I/O(2026-05-07)
+- [x] `LocalMarkdownMemoryStore` 真實 read / write / search / delete
+- [x] Pipeline 加入 LLM chat 階段:transcript → gpt-oss-120b → response
+- [x] `Phase::Responding` / `Phase::Done { transcript, response }` 雙塊顯示
+- [x] System prompt 整合 Mori persona + core memory + 當前時間
+- [x] 單元測試:write/read roundtrip + search
+
+### Phase 1D — 後續(下個 PR)
+- [ ] `RememberSkill`:LLM tool call,讓 Mori 自己決定要不要寫記憶
+- [ ] `Skill` trait dispatch 真正接通(目前 chat 是直接 hardcode)
 - [ ] 系統 tray icon(隱藏視窗時仍可叫出)
+- [ ] 對話歷史(連續對話)— 目前每次都是 stateless
 
 ## Phase 2 — 基礎 Skills(2026-06)
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,8 @@ type Phase =
   | { kind: "idle" }
   | { kind: "recording"; started_at_ms: number }
   | { kind: "transcribing" }
-  | { kind: "done"; transcript: string }
+  | { kind: "responding"; transcript: string }
+  | { kind: "done"; transcript: string; response: string }
   | { kind: "error"; message: string };
 
 function App() {
@@ -80,12 +81,30 @@ function App() {
             <p className="hero-hint">Whisper turbo 通常幾秒</p>
           </>
         )}
+        {phase.kind === "responding" && (
+          <>
+            <div className="hero-dot spin" />
+            <p className="hero-text">Mori 正在思考…</p>
+            <div className="speech-block">
+              <span className="speech-label">你說</span>
+              <p className="speech-text">{phase.transcript || "(空白)"}</p>
+            </div>
+            <p className="hero-hint">gpt-oss-120b 通常 1-2 秒</p>
+          </>
+        )}
         {phase.kind === "done" && (
           <>
             <div className="hero-dot done" />
             <p className="hero-text">完成</p>
-            <p className="transcript">{phase.transcript || "(空白)"}</p>
-            <p className="hero-hint">按熱鍵錄下一段</p>
+            <div className="speech-block">
+              <span className="speech-label">你說</span>
+              <p className="speech-text">{phase.transcript || "(空白)"}</p>
+            </div>
+            <div className="speech-block mori">
+              <span className="speech-label">Mori</span>
+              <p className="speech-text">{phase.response || "(無回應)"}</p>
+            </div>
+            <p className="hero-hint">按 F8 / 按鈕錄下一段</p>
           </>
         )}
         {phase.kind === "error" && (

--- a/src/styles.css
+++ b/src/styles.css
@@ -73,6 +73,10 @@ header h1 {
   border-color: var(--accent);
 }
 
+.hero-responding {
+  border-color: var(--accent);
+}
+
 .hero-error {
   border-color: var(--error);
 }
@@ -176,6 +180,45 @@ header h1 {
   line-height: 1.6;
   text-align: left;
   width: 100%;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: var(--font-sans);
+}
+
+/* 「你說」/ 「Mori」 雙塊樣式 */
+.speech-block {
+  margin: 6px 0;
+  padding: 10px 12px;
+  background: var(--bg);
+  border-radius: 6px;
+  width: 100%;
+  text-align: left;
+  border-left: 3px solid var(--fg-dim);
+}
+
+.speech-block.mori {
+  border-left-color: var(--accent);
+  background: linear-gradient(90deg, rgba(86, 211, 100, 0.08), var(--bg) 30%);
+}
+
+.speech-label {
+  display: block;
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--fg-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 4px;
+}
+
+.speech-block.mori .speech-label {
+  color: var(--accent);
+}
+
+.speech-text {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
   white-space: pre-wrap;
   word-break: break-word;
   font-family: var(--font-sans);


### PR DESCRIPTION
## Summary

Phase 1C makes Mori **actually reply**. The phase 1B pipeline stopped at the transcript; this PR chains it into `gpt-oss-120b` and shows the response.

```
audio → Whisper → transcript → LLM (with persona + memory in system prompt) → response
                                             ↑
                                  ~/.mori/memory/ contents
                                  injected here so Mori
                                  remembers across sessions
```

## State machine

```
Idle → Recording → Transcribing → Responding → Done(transcript, response)
                                       ↘                            ↗
                                          Error → Idle (next toggle)
```

## What's new

### `mori-core/memory/markdown.rs`(was stubs, now real I/O)

- `read_index` parses `MEMORY.md` `- [name](id.md) — desc` lines
- `read` parses YAML frontmatter + body
- `write` serializes `Memory` back + upserts index entry
- `search` case-insensitive grep across name/description/body
- `delete` removes file + index entry
- Helper `read_all_as_context()` flattens all memories into a markdown chunk for the system prompt
- 2 unit tests: write→read roundtrip, search-finds-in-body. Use `tempfile` (added to dev-deps).

### Mori's persona (baked into system prompt)

```
你是 Mori,一個輕巧、貼心的桌面 AI 管家。背景設定:你是來自 world-tree
森林的精靈,被使用者帶到桌面當日常陪伴與助手。

回覆規則:
- 一律使用繁體中文,語氣自然、簡潔
- 不寫前言或客套(例如「好的」、「沒問題」、「以下是」)— 直接進主題
- 若使用者問你做不到的事(例如操作系統、開檔案),老實說「目前還沒這個能力」
- 回覆長度配合提問:閒聊就一兩句,問題要解釋才展開

現在時間:{當下日期時間}

[+ ~/.mori/memory/ 內容]
```

### UI (`App.tsx` + `styles.css`)

- `Responding` state shows "Mori 正在思考…" + already-known transcript
- `Done` state shows two side-by-side speech blocks:
  - **「你說」** with grey left border
  - **「Mori」** with green left border + subtle gradient
- Idle hint updated: "按 F8 / 按鈕錄下一段"

### How memory works right now

`~/.mori/memory/` starts empty → system prompt gets only persona + time.

You can manually drop `.md` files in there with the documented frontmatter format (see `docs/memory.md`) and Mori will read them next turn. **Phase 1D** will add a `RememberSkill` so Mori writes memory itself when you say "記住我喜歡 vim" etc.

## Test plan

Local /home/ct verified:
- [x] `cargo check --workspace` clean
- [x] `cargo test -p mori-core --lib` — 2/2 pass (write/read roundtrip + search)
- [x] `npm run build` + `tsc -b` clean

Acer verification (your turn):
- [ ] Pull branch, `npm run tauri dev`
- [ ] Press button → speak → see Whisper transcript appear under "你說"
- [ ] See "Mori 正在思考…" briefly
- [ ] See Mori's reply appear under "Mori" (繁中, terse, in-character)
- [ ] Drop a manual memory file into `~/.mori/memory/` (e.g. `user_lang.md`) — confirm Mori uses it next turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)