### PR TITLE
feat(phase 1D+1E): SkillRegistry + RememberSkill + multi-turn + RecallMemorySkill

### DIFF
--- a/crates/mori-core/src/agent.rs
+++ b/crates/mori-core/src/agent.rs
@@ -1,26 +1,23 @@
 //! Agent 迴圈 — 把 LLM、Skill registry、Memory store 拼成 Mori 的「大腦」。
 //!
-//! Phase 1D 採用「single round of tool use」模式:
+//! Phase 1E:多輪 tool calling 迴圈。
 //!
 //! ```text
 //!   user input
 //!      │
 //!      ▼
-//!   provider.chat(messages, tools)
-//!      │
-//!      ├─ 有 content,沒 tool_calls → 直接回傳 content
-//!      │
-//!      ├─ 有 tool_calls(可能也有 content)→
-//!      │      execute(tool_calls)
-//!      │      回傳 = LLM content(若有)+ skills 的 user_messages(疊在後面)
-//!      │
-//!      └─ 都沒有 → 回傳空字串(罕見、防禦性 fallback)
+//!   loop (max N rounds):
+//!     provider.chat(messages, tools)
+//!        │
+//!        ├─ 沒 tool_calls → 回傳 content 當 final response
+//!        │
+//!        └─ 有 tool_calls → execute each via SkillRegistry,
+//!                          把 assistant message + tool result messages
+//!                          append 進 messages,迴圈繼續(LLM 看到結果再答)
 //! ```
 //!
-//! 不做多輪 tool-call 迴圈(LLM 看到 tool 結果後再講話)— 那需要把
-//! ChatMessage 擴展成支援 assistant.tool_calls + tool.tool_call_id,留到
-//! phase 2+ 真正需要時再做。phase 1D 的 RememberSkill 是「fire and forget」,
-//! 單輪就夠了。
+//! Tool 結果回傳給 LLM 後,LLM 自然語言整合 → 給使用者最終回應。
+//! 例如:RecallMemorySkill 把 memory body 餵回 → LLM 用記憶內容答話。
 
 use std::sync::Arc;
 
@@ -29,6 +26,8 @@ use anyhow::{Context as _, Result};
 use crate::context::Context;
 use crate::llm::{ChatMessage, LlmProvider};
 use crate::skill::{SkillOutput, SkillRegistry};
+
+const MAX_ROUNDS: usize = 5;
 
 /// 一輪 agent 執行的完整結果。
 pub struct AgentTurn {
@@ -55,77 +54,101 @@ impl Agent {
         Self { provider, skills }
     }
 
-    /// 跑一輪:給定 system prompt + 使用者輸入 → 拿到 Mori 的回覆。
+    /// 跑一輪互動。多輪 tool call 迴圈最多 [`MAX_ROUNDS`] 次,超過視為異常。
     pub async fn respond(
         &self,
         system_prompt: &str,
         user_input: &str,
         ctx: &Context,
     ) -> Result<AgentTurn> {
-        let messages = vec![
-            ChatMessage {
-                role: "system".into(),
-                content: system_prompt.to_string(),
-            },
-            ChatMessage {
-                role: "user".into(),
-                content: user_input.to_string(),
-            },
+        let mut messages = vec![
+            ChatMessage::system(system_prompt),
+            ChatMessage::user(user_input),
         ];
         let tools = self.skills.tool_definitions();
+        let mut all_skill_calls: Vec<SkillCallRecord> = Vec::new();
+
         tracing::debug!(
             tool_count = tools.len(),
             tool_names = ?tools.iter().map(|t| t.name.as_str()).collect::<Vec<_>>(),
-            "agent: chat with tools"
+            "agent: starting multi-turn loop"
         );
 
-        let chat = self
-            .provider
-            .chat(messages, tools)
-            .await
-            .context("provider chat")?;
+        for round in 0..MAX_ROUNDS {
+            let chat = self
+                .provider
+                .chat(messages.clone(), tools.clone())
+                .await
+                .with_context(|| format!("provider chat (round {round})"))?;
 
-        let mut skill_calls = Vec::new();
-        let mut skill_messages = Vec::new();
+            // No tool calls → final answer
+            if chat.tool_calls.is_empty() {
+                let response = chat.content.unwrap_or_default();
+                tracing::info!(
+                    round,
+                    chars = response.chars().count(),
+                    "agent: final response"
+                );
+                return Ok(AgentTurn {
+                    response,
+                    skill_calls: all_skill_calls,
+                });
+            }
 
-        for tc in chat.tool_calls {
-            match self.skills.dispatch(&tc.name, tc.arguments.clone(), ctx).await {
-                Ok(output) => {
-                    tracing::info!(
-                        skill = %tc.name,
-                        msg = %output.user_message,
-                        "skill executed"
-                    );
-                    skill_messages.push(output.user_message.clone());
-                    skill_calls.push(SkillCallRecord {
-                        name: tc.name,
-                        args: tc.arguments,
-                        output,
-                    });
-                }
-                Err(e) => {
-                    tracing::error!(skill = %tc.name, ?e, "skill failed");
-                    skill_messages.push(format!("(skill {} 出錯:{e})", tc.name));
-                }
+            tracing::info!(
+                round,
+                n_tools = chat.tool_calls.len(),
+                names = ?chat.tool_calls.iter().map(|tc| tc.name.as_str()).collect::<Vec<_>>(),
+                "agent: tool calls received"
+            );
+
+            // 把 assistant 的決定 echo 回 messages(OpenAI 協定要求)
+            messages.push(ChatMessage::assistant_with_tool_calls(
+                chat.content.clone(),
+                chat.tool_calls.clone(),
+            ));
+
+            // Execute each tool, append tool result message
+            for tc in &chat.tool_calls {
+                let exec = self
+                    .skills
+                    .dispatch(&tc.name, tc.arguments.clone(), ctx)
+                    .await;
+                let result_text = match exec {
+                    Ok(output) => {
+                        let text = output.user_message.clone();
+                        all_skill_calls.push(SkillCallRecord {
+                            name: tc.name.clone(),
+                            args: tc.arguments.clone(),
+                            output,
+                        });
+                        text
+                    }
+                    Err(e) => {
+                        tracing::error!(skill = %tc.name, ?e, "skill failed");
+                        let text = format!("(error: {e})");
+                        all_skill_calls.push(SkillCallRecord {
+                            name: tc.name.clone(),
+                            args: tc.arguments.clone(),
+                            output: SkillOutput {
+                                user_message: text.clone(),
+                                data: None,
+                            },
+                        });
+                        text
+                    }
+                };
+                messages.push(ChatMessage::tool_result(
+                    tc.id.clone(),
+                    tc.name.clone(),
+                    result_text,
+                ));
             }
         }
 
-        let response = match (chat.content, skill_messages.is_empty()) {
-            // 既有 LLM 自然語言、也有 skill 結果 → 都顯示
-            (Some(content), false) if !content.trim().is_empty() => {
-                format!("{}\n\n{}", content.trim(), skill_messages.join("\n"))
-            }
-            // 只有 LLM 自然語言
-            (Some(content), true) if !content.trim().is_empty() => content,
-            // 只有 skill 結果
-            (_, false) => skill_messages.join("\n"),
-            // 空空如也(罕見,防禦性處理)
-            _ => String::new(),
-        };
-
-        Ok(AgentTurn {
-            response,
-            skill_calls,
-        })
+        // Hit MAX_ROUNDS — 防無限迴圈,但也代表 LLM 行為怪異
+        anyhow::bail!(
+            "agent exceeded max tool-call rounds ({MAX_ROUNDS}) — LLM may be looping"
+        )
     }
 }

--- a/crates/mori-core/src/agent.rs
+++ b/crates/mori-core/src/agent.rs
@@ -1,0 +1,131 @@
+//! Agent 迴圈 — 把 LLM、Skill registry、Memory store 拼成 Mori 的「大腦」。
+//!
+//! Phase 1D 採用「single round of tool use」模式:
+//!
+//! ```text
+//!   user input
+//!      │
+//!      ▼
+//!   provider.chat(messages, tools)
+//!      │
+//!      ├─ 有 content,沒 tool_calls → 直接回傳 content
+//!      │
+//!      ├─ 有 tool_calls(可能也有 content)→
+//!      │      execute(tool_calls)
+//!      │      回傳 = LLM content(若有)+ skills 的 user_messages(疊在後面)
+//!      │
+//!      └─ 都沒有 → 回傳空字串(罕見、防禦性 fallback)
+//! ```
+//!
+//! 不做多輪 tool-call 迴圈(LLM 看到 tool 結果後再講話)— 那需要把
+//! ChatMessage 擴展成支援 assistant.tool_calls + tool.tool_call_id,留到
+//! phase 2+ 真正需要時再做。phase 1D 的 RememberSkill 是「fire and forget」,
+//! 單輪就夠了。
+
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+
+use crate::context::Context;
+use crate::llm::{ChatMessage, LlmProvider};
+use crate::skill::{SkillOutput, SkillRegistry};
+
+/// 一輪 agent 執行的完整結果。
+pub struct AgentTurn {
+    /// 給 UI / 使用者看的最終回應(自然語言)
+    pub response: String,
+    /// 這輪有哪些 skill 被呼叫(供 log / debug / UI 顯示)
+    pub skill_calls: Vec<SkillCallRecord>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SkillCallRecord {
+    pub name: String,
+    pub args: serde_json::Value,
+    pub output: SkillOutput,
+}
+
+pub struct Agent {
+    provider: Arc<dyn LlmProvider>,
+    skills: Arc<SkillRegistry>,
+}
+
+impl Agent {
+    pub fn new(provider: Arc<dyn LlmProvider>, skills: Arc<SkillRegistry>) -> Self {
+        Self { provider, skills }
+    }
+
+    /// 跑一輪:給定 system prompt + 使用者輸入 → 拿到 Mori 的回覆。
+    pub async fn respond(
+        &self,
+        system_prompt: &str,
+        user_input: &str,
+        ctx: &Context,
+    ) -> Result<AgentTurn> {
+        let messages = vec![
+            ChatMessage {
+                role: "system".into(),
+                content: system_prompt.to_string(),
+            },
+            ChatMessage {
+                role: "user".into(),
+                content: user_input.to_string(),
+            },
+        ];
+        let tools = self.skills.tool_definitions();
+        tracing::debug!(
+            tool_count = tools.len(),
+            tool_names = ?tools.iter().map(|t| t.name.as_str()).collect::<Vec<_>>(),
+            "agent: chat with tools"
+        );
+
+        let chat = self
+            .provider
+            .chat(messages, tools)
+            .await
+            .context("provider chat")?;
+
+        let mut skill_calls = Vec::new();
+        let mut skill_messages = Vec::new();
+
+        for tc in chat.tool_calls {
+            match self.skills.dispatch(&tc.name, tc.arguments.clone(), ctx).await {
+                Ok(output) => {
+                    tracing::info!(
+                        skill = %tc.name,
+                        msg = %output.user_message,
+                        "skill executed"
+                    );
+                    skill_messages.push(output.user_message.clone());
+                    skill_calls.push(SkillCallRecord {
+                        name: tc.name,
+                        args: tc.arguments,
+                        output,
+                    });
+                }
+                Err(e) => {
+                    tracing::error!(skill = %tc.name, ?e, "skill failed");
+                    skill_messages.push(format!("(skill {} 出錯:{e})", tc.name));
+                }
+            }
+        }
+
+        let response = match (chat.content, skill_messages.is_empty()) {
+            // 既有 LLM 自然語言、也有 skill 結果 → 都顯示
+            (Some(content), false) if !content.trim().is_empty() => {
+                format!("{}\n\n{}", content.trim(), skill_messages.join("\n"))
+            }
+            // 只有 LLM 自然語言
+            (Some(content), true) if !content.trim().is_empty() => content,
+            // 只有 skill 結果
+            (_, false) => skill_messages.join("\n"),
+            // 空空如也(罕見,防禦性處理)
+            _ => String::new(),
+        };
+
+        Ok(AgentTurn {
+            response,
+            skill_calls,
+        })
+    }
+}

--- a/crates/mori-core/src/lib.rs
+++ b/crates/mori-core/src/lib.rs
@@ -20,4 +20,4 @@ pub mod voice;
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// 當前 phase 名稱
-pub const PHASE: &str = "1D — Skill dispatch + RememberSkill";
+pub const PHASE: &str = "1E — Multi-turn tools + RecallMemorySkill";

--- a/crates/mori-core/src/lib.rs
+++ b/crates/mori-core/src/lib.rs
@@ -9,6 +9,7 @@
 //! Phase 1 只實作每個 trait 的最小可運作骨架。後續 phase 加 module / 加 impl
 //! 即可,trait 定義穩定,核心邏輯一行不動。
 
+pub mod agent;
 pub mod context;
 pub mod llm;
 pub mod memory;
@@ -19,4 +20,4 @@ pub mod voice;
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// 當前 phase 名稱
-pub const PHASE: &str = "1 — Voice MVP scaffold";
+pub const PHASE: &str = "1D — Skill dispatch + RememberSkill";

--- a/crates/mori-core/src/llm/groq.rs
+++ b/crates/mori-core/src/llm/groq.rs
@@ -318,8 +318,12 @@ impl LlmProvider for GroqProvider {
             .mime_str("audio/wav")
             .context("groq transcribe: build part")?;
 
-        // language=zh 強制中文 + prompt 偏好繁中,避免 Whisper 預設輸出簡中。
-        // prompt 也順便包進台灣常見用語,讓辭彙選擇更在地化。
+        // language=zh 強制中文 + prompt 給「使用者直接對 AI 講話」的框架。
+        //
+        // 之前用「逐字稿」這個詞,Whisper 訓練資料裡跟 YouTube 字幕綁定,
+        // 會插入 [字幕] / 贊助商標記 / 時間戳之類的 noise,LLM 看到還會
+        // 以為使用者在貼字幕。改用「使用者對 AI 助手講的話」明確去除字幕聯想。
+        // 仍保留台灣科技用語當 vocab seed,讓 LLM 寫出在地化辭彙。
         let form = multipart::Form::new()
             .part("file", part)
             .text("model", self.transcribe_model.clone())
@@ -327,8 +331,9 @@ impl LlmProvider for GroqProvider {
             .text("language", "zh")
             .text(
                 "prompt",
-                "以下是台灣繁體中文逐字稿,使用繁體中文字。\
-                 常見用語:程式、軟體、檔案、影片、電腦、滑鼠、伺服器、資料庫。",
+                "以下是使用者直接對 AI 助手 Mori 說的話,繁體中文。\
+                 常見用語:程式、軟體、檔案、影片、電腦、滑鼠、伺服器、資料庫、\
+                 記住、提醒、行事曆、會議。",
             );
 
         let resp = self

--- a/crates/mori-core/src/llm/groq.rs
+++ b/crates/mori-core/src/llm/groq.rs
@@ -114,7 +114,7 @@ fn read_json_pointer(path: &std::path::Path, pointer: &str) -> Option<String> {
 #[derive(Serialize)]
 struct ChatRequest<'a> {
     model: &'a str,
-    messages: &'a [WireMessage<'a>],
+    messages: Vec<WireMessage<'a>>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tools: Vec<WireTool<'a>>,
 }
@@ -122,7 +122,31 @@ struct ChatRequest<'a> {
 #[derive(Serialize)]
 struct WireMessage<'a> {
     role: &'a str,
-    content: &'a str,
+    /// `null` 是合法的(assistant 發 tool_call 時可能 content=null)
+    content: Option<&'a str>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tool_calls: Vec<WireToolCallOut<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_call_id: Option<&'a str>,
+    /// `tool` role 訊息要附 tool 名(可選但 OpenAI 標準有)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<&'a str>,
+}
+
+/// 送出時的 tool_call 結構(OpenAI 巢狀 function 格式)
+#[derive(Serialize)]
+struct WireToolCallOut<'a> {
+    id: &'a str,
+    #[serde(rename = "type")]
+    kind: &'static str, // always "function"
+    function: WireFunctionOut<'a>,
+}
+
+#[derive(Serialize)]
+struct WireFunctionOut<'a> {
+    name: &'a str,
+    /// arguments 必須是 JSON-encoded 字串,不是物件
+    arguments: String,
 }
 
 #[derive(Serialize)]
@@ -158,13 +182,14 @@ struct ChoiceMessageWire {
 
 #[derive(Deserialize, Debug)]
 struct ToolCallWire {
+    id: String,
     function: ToolCallFunctionWire,
 }
 
 #[derive(Deserialize, Debug)]
 struct ToolCallFunctionWire {
     name: String,
-    arguments: String, // OpenAI returns args as a JSON string, not object
+    arguments: String, // JSON string
 }
 
 // ─── transcription wire ─────────────────────────────────────────────
@@ -189,11 +214,28 @@ impl LlmProvider for GroqProvider {
         messages: Vec<ChatMessage>,
         tools: Vec<ToolDefinition>,
     ) -> Result<ChatResponse> {
+        // ChatMessage → WireMessage(處理 tool_calls 巢狀格式)
         let wire_messages: Vec<WireMessage> = messages
             .iter()
             .map(|m| WireMessage {
                 role: &m.role,
-                content: &m.content,
+                content: m.content.as_deref(),
+                tool_calls: m
+                    .tool_calls
+                    .iter()
+                    .map(|tc| WireToolCallOut {
+                        id: &tc.id,
+                        kind: "function",
+                        function: WireFunctionOut {
+                            name: &tc.name,
+                            // 把 arguments(內部 Value)序列化成 JSON 字串
+                            arguments: serde_json::to_string(&tc.arguments)
+                                .unwrap_or_else(|_| "{}".to_string()),
+                        },
+                    })
+                    .collect(),
+                tool_call_id: m.tool_call_id.as_deref(),
+                name: m.name.as_deref(),
             })
             .collect();
 
@@ -211,12 +253,12 @@ impl LlmProvider for GroqProvider {
 
         let body = ChatRequest {
             model: &self.model,
-            messages: &wire_messages,
+            messages: wire_messages,
             tools: wire_tools,
         };
 
         let url = format!("{}/chat/completions", self.base_url);
-        tracing::debug!(model = %self.model, "groq chat request");
+        tracing::debug!(model = %self.model, msgs = messages.len(), "groq chat request");
 
         let resp = self
             .client
@@ -250,6 +292,7 @@ impl LlmProvider for GroqProvider {
                 let arguments: serde_json::Value = serde_json::from_str(&tc.function.arguments)
                     .unwrap_or_else(|_| serde_json::json!({}));
                 ToolCall {
+                    id: tc.id,
                     name: tc.function.name,
                     arguments,
                 }

--- a/crates/mori-core/src/llm/mod.rs
+++ b/crates/mori-core/src/llm/mod.rs
@@ -5,6 +5,11 @@
 //! - 任務 → 模型精細搭配
 //! - Fallback chain
 //! - Privacy::LocalOnly 強制本地
+//!
+//! 訊息結構支援 OpenAI tool-calling 多輪協定:
+//! - `system` / `user`:role + content
+//! - `assistant`(發起 tool_call):role + tool_calls(content 可能也有)
+//! - `tool`(回傳結果):role + content + tool_call_id + name
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -13,10 +18,71 @@ use serde_json::Value;
 
 pub mod groq;
 
+/// 一則訊息。
+///
+/// 用 `Option<String>` 給 content 是因為 assistant 在發起 tool_call 時可能
+/// 沒文字內容。`tool_calls` 只在 assistant 發起時非空。`tool_call_id` + `name`
+/// 只在 role="tool" 時用,把回傳結果連回對應的 tool_call。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessage {
     pub role: String,
-    pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_calls: Vec<ToolCall>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+impl ChatMessage {
+    pub fn system(content: impl Into<String>) -> Self {
+        Self {
+            role: "system".into(),
+            content: Some(content.into()),
+            tool_calls: Vec::new(),
+            tool_call_id: None,
+            name: None,
+        }
+    }
+
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            role: "user".into(),
+            content: Some(content.into()),
+            tool_calls: Vec::new(),
+            tool_call_id: None,
+            name: None,
+        }
+    }
+
+    pub fn assistant_with_tool_calls(
+        content: Option<String>,
+        tool_calls: Vec<ToolCall>,
+    ) -> Self {
+        Self {
+            role: "assistant".into(),
+            content,
+            tool_calls,
+            tool_call_id: None,
+            name: None,
+        }
+    }
+
+    pub fn tool_result(
+        call_id: impl Into<String>,
+        name: impl Into<String>,
+        content: impl Into<String>,
+    ) -> Self {
+        Self {
+            role: "tool".into(),
+            content: Some(content.into()),
+            tool_calls: Vec::new(),
+            tool_call_id: Some(call_id.into()),
+            name: Some(name.into()),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -28,13 +94,15 @@ pub struct ToolDefinition {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolCall {
+    /// API 給的唯一 id(回傳 tool 結果要 reference 它)
+    pub id: String,
     pub name: String,
     pub arguments: Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatResponse {
-    /// LLM 自由文字回應(若沒呼叫 tool)
+    /// LLM 自由文字回應(若沒呼叫 tool 或 mid-thought)
     pub content: Option<String>,
     /// LLM 決定呼叫的 tools
     pub tool_calls: Vec<ToolCall>,
@@ -45,7 +113,7 @@ pub trait LlmProvider: Send + Sync {
     /// Provider 識別名(groq / ollama / openai / anthropic / ...)
     fn name(&self) -> &'static str;
 
-    /// 模型 id(server 端的模型代號,例:`openai/gpt-oss-120b`、`qwen3:8b`)
+    /// 模型 id
     fn model(&self) -> &str;
 
     /// 跑一輪 chat completion。

--- a/crates/mori-core/src/memory/markdown.rs
+++ b/crates/mori-core/src/memory/markdown.rs
@@ -68,25 +68,28 @@ impl LocalMarkdownMemoryStore {
         self.root.join(format!("{id}.md"))
     }
 
-    /// 把 core memory 直接攤平成一段純文字,適合塞進 system prompt。
+    /// 把記憶**索引**攤平成一段純文字,塞進 system prompt。
     ///
-    /// Phase 1C 為了讓 LLM「知道你是誰」,我們會在每次 chat 時讀整個索引 +
-    /// 全部 memory 內容當作背景。如果 memory 多了會嫌長,phase 5+ 再做
-    /// 「LLM 自己挑相關 memory」邏輯。
-    pub fn read_all_as_context(&self) -> Result<String> {
+    /// 只送 name + description + id,不送 body。LLM 看到索引若覺得需要某筆
+    /// memory 的細節,呼叫 `recall_memory(id)` skill 主動拉。
+    ///
+    /// 為什麼這樣設計:不擴展把全部 memory 全文塞進 prompt(phase 1D 早期的
+    /// 做法,1000+ 筆會爆 context window)。索引行極短,即使 1000 筆也只有
+    /// ~50KB 仍可放;真正需要的 body 才透過 tool call 拉。對應 docs/memory.md
+    /// 「Phase 1-4: LLM 看索引判斷哪幾個檔相關 → 讀進來」設計。
+    pub fn read_index_as_context(&self) -> Result<String> {
         let entries = blocking_read_index(&self.index_path())?;
         if entries.is_empty() {
             return Ok(String::new());
         }
+
         let mut out = String::new();
-        out.push_str("# 你已知關於使用者的事\n\n");
+        out.push_str("# 長期記憶索引(若需細節,呼叫 recall_memory(id))\n\n");
         for entry in &entries {
-            let path = self.memory_path(&entry.id);
-            if let Ok(memory) = blocking_read_memory(&path) {
-                out.push_str(&format!("## {} ({:?})\n", memory.name, memory.memory_type));
-                out.push_str(&memory.body);
-                out.push_str("\n\n");
-            }
+            out.push_str(&format!(
+                "- id=`{}` 「{}」 — {}\n",
+                entry.id, entry.name, entry.description
+            ));
         }
         Ok(out)
     }

--- a/crates/mori-core/src/skill.rs
+++ b/crates/mori-core/src/skill.rs
@@ -271,6 +271,84 @@ impl Skill for RememberSkill {
     }
 }
 
+// ─── RecallMemorySkill ──────────────────────────────────────────────
+
+/// 從長期記憶讀取單筆 memory 的完整 body。
+///
+/// LLM 在 system prompt 裡只看到記憶**索引**(name + 短描述);若覺得某筆
+/// memory 對當前對話有幫助,呼叫這個 skill 把 body 拉進來。這個 skill 的
+/// 結果會回傳給 LLM(透過 multi-turn tool call),不直接顯示給使用者。
+pub struct RecallMemorySkill {
+    memory: Arc<dyn MemoryStore>,
+}
+
+impl RecallMemorySkill {
+    pub fn new(memory: Arc<dyn MemoryStore>) -> Self {
+        Self { memory }
+    }
+}
+
+#[async_trait]
+impl Skill for RecallMemorySkill {
+    fn name(&self) -> &'static str {
+        "recall_memory"
+    }
+
+    fn description(&self) -> &'static str {
+        "Read the full content of a specific long-term memory by id. \
+         Use this when the memory index (shown in system prompt) lists a \
+         memory whose name/description suggests it's relevant to the user's \
+         current question, but you need the full body to answer accurately. \
+         The id is the filename without .md (e.g. for `2026-05-11_會議.md` \
+         the id is `2026-05-11_會議`)."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Memory id(檔名不含 .md)。從 system prompt 的索引段抓。"
+                }
+            },
+            "required": ["id"]
+        })
+    }
+
+    async fn execute(&self, args: Value, _context: &Context) -> Result<SkillOutput> {
+        let id = args
+            .get("id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("missing id"))?
+            .trim()
+            .to_string();
+
+        let memory = self
+            .memory
+            .read(&id)
+            .await
+            .context("memory store read")?
+            .ok_or_else(|| anyhow!("no memory with id: {id}"))?;
+
+        // user_message 餵回 LLM(multi-turn 機制),不直接顯示給使用者。
+        // 內容直接拼整篇,讓 LLM 看到完整脈絡。
+        let body_dump = format!(
+            "Memory id={} name={:?} type={:?}\n\n{}",
+            memory.id, memory.name, memory.memory_type, memory.body
+        );
+
+        Ok(SkillOutput {
+            user_message: body_dump,
+            data: Some(serde_json::json!({
+                "id": memory.id,
+                "name": memory.name,
+                "body": memory.body,
+            })),
+        })
+    }
+}
+
 /// 把標題 slug 化成檔名安全的 id。
 /// 規則:保留 CJK / 英數字 / 底線,空白→底線,其他標點丟掉。
 ///

--- a/crates/mori-core/src/skill.rs
+++ b/crates/mori-core/src/skill.rs
@@ -1,17 +1,28 @@
 //! Skill = LLM 可呼叫的工具。
 //!
 //! 設計原則:
-//! - 每個 skill 自成一個 module,實作 [`Skill`] trait
-//! - schema 從 Rust struct 自動產生(用 schemars)→ 直接餵給 LLM tool calling
-//! - destructive 操作要 `confirm_required: true`,執行前 UI / TTS 二次確認
-//! - 跨裝置:`target_capability` 表明這個 skill 能在哪跑(Local / Remote / Anywhere)
+//! - 每個 skill 自成一個 struct,實作 [`Skill`] trait
+//! - schema 給 LLM 看(透過 JSON Schema)→ 餵進 OpenAI tool-calling
+//! - destructive 操作 `confirm_required: true`,UI / TTS 二次確認
+//! - 跨裝置:`target_capability` 表明能在哪跑(Local / Remote / Anywhere)
+//!
+//! 使用流程:
+//! 1. [`SkillRegistry::new`] + [`register`](SkillRegistry::register) 註冊 skill
+//! 2. 把 [`SkillRegistry::tool_definitions`] 拿到的 list 交給 LLM
+//! 3. LLM 回 tool_calls → [`SkillRegistry::dispatch`] 拿 skill 跑
 
-use anyhow::Result;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{anyhow, Context as _, Result};
 use async_trait::async_trait;
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::context::Context;
+use crate::llm::ToolDefinition;
+use crate::memory::{Memory, MemoryStore, MemoryType};
 
 /// 這個 skill 可以在哪邊執行?
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -27,54 +38,103 @@ pub enum ExecutionTarget {
 /// 隱私等級。LocalOnly 的 skill 強制只用本地 LLM,絕不送雲端。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Privacy {
-    /// 可送雲端 LLM
     Cloud,
-    /// 必須本地 LLM(例:讀信、操作敏感檔案)
     LocalOnly,
 }
 
 /// Skill 執行結果。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SkillOutput {
-    /// 給使用者看(自然語言)
+    /// 給使用者看的自然語言訊息(會疊在 LLM 回覆之後)
     pub user_message: String,
-    /// 結構化資料(供下游 skill 串接)
+    /// 結構化資料(供下游 skill / UI 串接)
     pub data: Option<Value>,
 }
 
 #[async_trait]
 pub trait Skill: Send + Sync {
-    /// 給 LLM 看的 skill 名稱。應為唯一 snake_case 識別字串。
     fn name(&self) -> &'static str;
-
-    /// 給 LLM 看的描述。盡量寫清楚「什麼時候該叫這個」。
     fn description(&self) -> &'static str;
-
-    /// 參數的 JSON Schema(可從 Rust struct 用 schemars 產生)。
     fn parameters_schema(&self) -> Value;
 
-    /// 是否需要二次確認?(destructive 操作為 true)
     fn confirm_required(&self) -> bool {
         false
     }
-
-    /// 這 skill 能在哪邊執行?
     fn target_capability(&self) -> ExecutionTarget {
         ExecutionTarget::Local
     }
-
-    /// 隱私等級。
     fn privacy(&self) -> Privacy {
         Privacy::Cloud
     }
 
-    /// 執行 skill。
     async fn execute(&self, args: Value, context: &Context) -> Result<SkillOutput>;
 }
 
-/// Phase 1 內建 skill:把 LLM 的回應原樣轉給使用者。
-///
-/// 主要當作端到端 pipeline 的 sanity check 用。
+// ─── Registry ───────────────────────────────────────────────────────
+
+/// Skill 註冊表。Agent 用它把 skill 暴露給 LLM,並 dispatch 回呼。
+pub struct SkillRegistry {
+    skills: HashMap<&'static str, Arc<dyn Skill>>,
+}
+
+impl Default for SkillRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SkillRegistry {
+    pub fn new() -> Self {
+        Self {
+            skills: HashMap::new(),
+        }
+    }
+
+    pub fn register(&mut self, skill: Arc<dyn Skill>) {
+        let name = skill.name();
+        if self.skills.contains_key(name) {
+            tracing::warn!(name, "skill name collision — replacing existing");
+        }
+        self.skills.insert(name, skill);
+    }
+
+    pub fn get(&self, name: &str) -> Option<Arc<dyn Skill>> {
+        self.skills.get(name).cloned()
+    }
+
+    pub fn names(&self) -> Vec<&'static str> {
+        self.skills.keys().copied().collect()
+    }
+
+    /// 把所有 skill 轉成 LLM tool definitions(OpenAI / Groq 相容)
+    pub fn tool_definitions(&self) -> Vec<ToolDefinition> {
+        self.skills
+            .values()
+            .map(|s| ToolDefinition {
+                name: s.name().to_string(),
+                description: s.description().to_string(),
+                parameters: s.parameters_schema(),
+            })
+            .collect()
+    }
+
+    /// 根據 LLM 回的 tool_call 派發給對應 skill
+    pub async fn dispatch(
+        &self,
+        name: &str,
+        args: Value,
+        context: &Context,
+    ) -> Result<SkillOutput> {
+        let skill = self
+            .get(name)
+            .ok_or_else(|| anyhow!("unknown skill: {name}"))?;
+        tracing::info!(skill = name, "dispatching");
+        skill.execute(args, context).await
+    }
+}
+
+// ─── EchoSkill(sanity check 用)──────────────────────────────────
+
 pub struct EchoSkill;
 
 #[async_trait]
@@ -82,24 +142,18 @@ impl Skill for EchoSkill {
     fn name(&self) -> &'static str {
         "echo"
     }
-
     fn description(&self) -> &'static str {
         "Repeat or rephrase the user's input back to them. Useful for confirming what was heard."
     }
-
     fn parameters_schema(&self) -> Value {
         serde_json::json!({
             "type": "object",
             "properties": {
-                "message": {
-                    "type": "string",
-                    "description": "The text to echo back."
-                }
+                "message": { "type": "string", "description": "The text to echo back." }
             },
             "required": ["message"]
         })
     }
-
     async fn execute(&self, args: Value, _context: &Context) -> Result<SkillOutput> {
         let message = args
             .get("message")
@@ -111,4 +165,130 @@ impl Skill for EchoSkill {
             data: None,
         })
     }
+}
+
+// ─── RememberSkill ──────────────────────────────────────────────────
+
+/// 把使用者告訴 Mori 的事寫進長期記憶(`~/.mori/memory/<id>.md`)。
+///
+/// LLM 在以下情況該呼叫:
+/// - 使用者明確說「記住 X」/「以後 X」/「我喜歡 X」/「我老婆是 X」
+/// - 重要日期(生日、紀念日、deadline)
+/// - 進行中的專案、長期偏好、人名地名
+pub struct RememberSkill {
+    memory: Arc<dyn MemoryStore>,
+}
+
+impl RememberSkill {
+    pub fn new(memory: Arc<dyn MemoryStore>) -> Self {
+        Self { memory }
+    }
+}
+
+#[async_trait]
+impl Skill for RememberSkill {
+    fn name(&self) -> &'static str {
+        "remember"
+    }
+
+    fn description(&self) -> &'static str {
+        "Save a fact about the user to Mori's long-term memory. \
+         Call this when the user explicitly asks you to remember something \
+         (e.g. '記住...', '以後...'), or when they share personal info worth \
+         keeping (preferences, important dates like birthdays, names of people \
+         / pets / projects, recurring tasks). \
+         Each call creates one memory file the user can later edit or delete."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "簡短標題,3-15 個字。例如「老婆生日」、「常用編輯器」。"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "完整內容,自然語言寫清楚是什麼事 / 偏好。例如「老婆生日是 11 月 3 日,別忘記」。"
+                },
+                "category": {
+                    "type": "string",
+                    "enum": ["user_identity", "preference", "project", "reference", "other"],
+                    "description": "類別:user_identity=使用者基本資料、preference=偏好習慣、project=進行中專案、reference=查詢資料、other=其他。"
+                }
+            },
+            "required": ["title", "content", "category"]
+        })
+    }
+
+    async fn execute(&self, args: Value, _context: &Context) -> Result<SkillOutput> {
+        let title = args
+            .get("title")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("missing title"))?
+            .trim()
+            .to_string();
+        let content = args
+            .get("content")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("missing content"))?
+            .trim()
+            .to_string();
+        let category_str = args
+            .get("category")
+            .and_then(|v| v.as_str())
+            .unwrap_or("other");
+        let memory_type = match category_str {
+            "user_identity" => MemoryType::UserIdentity,
+            "preference" => MemoryType::Preference,
+            "project" => MemoryType::Project,
+            "reference" => MemoryType::Reference,
+            other => MemoryType::Other(other.to_string()),
+        };
+
+        let id = slugify(&title);
+        let now = Utc::now();
+        let memory = Memory {
+            id: id.clone(),
+            name: title.clone(),
+            description: content.chars().take(60).collect(),
+            memory_type,
+            created: now,
+            last_used: now,
+            body: content,
+        };
+
+        self.memory
+            .write(memory)
+            .await
+            .context("memory store write")?;
+
+        Ok(SkillOutput {
+            user_message: format!("好,我記下了:「{title}」"),
+            data: Some(serde_json::json!({ "id": id })),
+        })
+    }
+}
+
+/// 把標題 slug 化成檔名安全的 id。
+/// 規則:小寫、空格→底線、保留中文/英數字、加 timestamp 避免撞名。
+fn slugify(title: &str) -> String {
+    let mut out = String::new();
+    for ch in title.chars() {
+        if ch.is_alphanumeric()
+            || (ch as u32 >= 0x4E00 && ch as u32 <= 0x9FFF) // CJK 漢字
+            || ch == '_'
+        {
+            out.push(ch);
+        } else if ch.is_whitespace() {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        out.push_str("memory");
+    }
+    // 加 short timestamp 避免重複(同樣標題寫第二次也不蓋掉)
+    let ts = Utc::now().format("%Y%m%d_%H%M%S").to_string();
+    format!("{out}_{ts}")
 }

--- a/crates/mori-core/src/skill.rs
+++ b/crates/mori-core/src/skill.rs
@@ -272,7 +272,12 @@ impl Skill for RememberSkill {
 }
 
 /// 把標題 slug 化成檔名安全的 id。
-/// 規則:小寫、空格→底線、保留中文/英數字、加 timestamp 避免撞名。
+/// 規則:保留 CJK / 英數字 / 底線,空白→底線,其他標點丟掉。
+///
+/// **故意不加 timestamp**:同 title 會 overwrite 既有檔案。這是有意的 —
+/// 讓 LLM 用同 title 寫「整合後的完整 content」就能更新既有記憶。
+/// 整合語意責任在 LLM 端(讀舊 content + 新訊息 → 寫整合版本),
+/// store 端只負責覆寫。詳見 system prompt 裡 remember tool 的使用規則。
 fn slugify(title: &str) -> String {
     let mut out = String::new();
     for ch in title.chars() {
@@ -288,7 +293,5 @@ fn slugify(title: &str) -> String {
     if out.is_empty() {
         out.push_str("memory");
     }
-    // 加 short timestamp 避免重複(同樣標題寫第二次也不蓋掉)
-    let ts = Utc::now().format("%Y%m%d_%H%M%S").to_string();
-    format!("{out}_{ts}")
+    out
 }

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -12,7 +12,7 @@ use mori_core::llm::groq::GroqProvider;
 use mori_core::llm::LlmProvider;
 use mori_core::memory::markdown::LocalMarkdownMemoryStore;
 use mori_core::memory::MemoryStore;
-use mori_core::skill::{RememberSkill, SkillRegistry};
+use mori_core::skill::{RecallMemorySkill, RememberSkill, SkillRegistry};
 use mori_core::{PHASE, VERSION};
 use parking_lot::Mutex;
 use serde::Serialize;
@@ -257,21 +257,20 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
         );
 
         let chat_result: anyhow::Result<String> = async {
-            let memory_context = memory.read_all_as_context().unwrap_or_default();
-            let system_prompt = build_system_prompt(&memory_context);
+            let memory_index = memory.read_index_as_context().unwrap_or_default();
+            let system_prompt = build_system_prompt(&memory_index);
             tracing::debug!(
-                memory_chars = memory_context.chars().count(),
+                index_chars = memory_index.chars().count(),
                 "calling agent with system prompt"
             );
 
-            // 把 provider 包成 Arc<dyn LlmProvider> 給 Agent 用
             let provider: Arc<dyn LlmProvider> = Arc::new(provider);
 
-            // 註冊這次能用的 skill — phase 1D 只有 RememberSkill
+            // 註冊 phase 1E skills:remember(寫入)+ recall_memory(按需讀)
+            let memory_for_skills: Arc<dyn MemoryStore> = memory.clone();
             let mut registry = SkillRegistry::new();
-            registry.register(Arc::new(RememberSkill::new(
-                memory.clone() as Arc<dyn MemoryStore>,
-            )));
+            registry.register(Arc::new(RememberSkill::new(memory_for_skills.clone())));
+            registry.register(Arc::new(RecallMemorySkill::new(memory_for_skills.clone())));
             let registry = Arc::new(registry);
 
             let agent = Agent::new(provider, registry);
@@ -306,10 +305,11 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
     });
 }
 
-/// 建構 Mori 的 system prompt — 角色設定 + 當前時間 + 長期記憶。
-fn build_system_prompt(memory_context: &str) -> String {
+/// 建構 Mori 的 system prompt — 角色 + 時間 + 記憶索引 + tool 規則。
+fn build_system_prompt(memory_index: &str) -> String {
     let now = chrono::Local::now().format("%Y-%m-%d %H:%M (%a)").to_string();
     let mut prompt = String::new();
+
     prompt.push_str(
         "你是 Mori,一個輕巧、貼心的桌面 AI 管家。背景設定:你是來自 world-tree \
          森林的精靈,被使用者帶到桌面當日常陪伴與助手。\n\n",
@@ -317,43 +317,50 @@ fn build_system_prompt(memory_context: &str) -> String {
     prompt.push_str("回覆規則:\n");
     prompt.push_str("- 一律使用繁體中文,語氣自然、簡潔\n");
     prompt.push_str("- 不寫前言或客套(例如「好的」、「沒問題」、「以下是」)— 直接進主題\n");
-    prompt.push_str("- 若使用者問你做不到的事(例如操作系統、開檔案),老實說「目前還沒這個能力」\n");
+    prompt.push_str("- 若使用者問你做不到的事,老實說「目前還沒這個能力」\n");
     prompt.push_str("- 回覆長度配合提問:閒聊就一兩句,問題要解釋才展開\n\n");
-    prompt.push_str("可用工具:\n");
+
+    prompt.push_str("可用工具:\n\n");
+
+    // recall_memory — 比 remember 早講(LLM 看到 user 提問時可能要先 recall 才答)
+    prompt.push_str("**recall_memory(id)**:讀取單筆記憶的完整內容。\n");
     prompt.push_str(
-        "- `remember`:把使用者明確要你記下的事(偏好、重要日期、人名、進行中專案)\
-         寫進長期記憶。當使用者說「記住...」、「以後我都...」、「我喜歡...」、\
-         分享生日 / 紀念日,或介紹重要的人事物時呼叫。一般閒聊或回答問題不要硬叫。\n");
+        "  • system prompt 末尾有「長期記憶索引」段,只列出每筆記憶的 id、\
+         name、短描述。如果使用者問題的關鍵字在索引裡看到相關的 memory,\
+         先呼叫 recall_memory(id=該 id) 把細節拉進來,再答。\n");
+    prompt.push_str(
+        "  • 一輪可叫多次(若多筆記憶相關,各拉一次)。但只在必要時叫 — \
+         索引上看不出相關的問題就不要硬叫。\n\n");
+
+    // remember
+    prompt.push_str("**remember(title, content, category)**:寫入長期記憶。\n");
+    prompt.push_str(
+        "  • 觸發時機:使用者明確說「記住...」「以後...」「我喜歡...」、\
+         分享生日 / 紀念日 / 偏好 / 重要人事物。閒聊或一般問答不要硬叫。\n");
     prompt.push_str(
         "  • Title 規則:**穩定 + 簡潔**。日期事件用「YYYY-MM-DD 主題」\
          (例:「2026-05-11 會議」);人物 / 偏好用主題(例:「老婆生日」、\
          「常用編輯器」)。\n");
     prompt.push_str(
-        "  • **整合而非新增**:如果使用者補充 / 更正你已經記過的事(看「你已知關於\
-         使用者的事」段),呼叫 remember 時**用相同 title**,並且 content 必須是\
-         「舊內容 + 新訊息整合後的完整版本」,不可只寫新訊息(那會丟掉舊資訊)。\n");
+        "  • **整合而非新增**:若使用者補充 / 更正既有記憶(可從索引看到 title \
+         相同或相關),先呼叫 recall_memory 拿舊 content,再呼叫 remember 用\
+         **同 title** + 「舊 content + 新訊息整合後的完整版本」,不可只寫新訊息。\n");
     prompt.push_str(
-        "    範例:\n");
+        "    範例:既有「2026-05-11 會議」(content=「2026-05-11 有會議」),\
+         使用者補充「是頻譜電子的會議」→ 你應該:\n");
     prompt.push_str(
-        "    - 既有記憶 title=「2026-05-11 會議」、content=「2026-05-11 有會議」\n");
+        "      1. recall_memory(id=「2026-05-11_會議」)拿到舊 content\n");
     prompt.push_str(
-        "    - 使用者補充「是頻譜電子的會議」\n");
-    prompt.push_str(
-        "    - 正確呼叫:remember(title=「2026-05-11 會議」, \
+        "      2. remember(title=「2026-05-11 會議」, \
          content=「2026-05-11 與頻譜電子開會」)\n");
     prompt.push_str(
-        "    - 錯誤呼叫:remember(title=「2026-05-11 頻譜電子會議」, ...) \
-         ← 會新增第二筆,造成重複\n");
-    prompt.push_str(
-        "    - 錯誤呼叫:remember(title=「2026-05-11 會議」, content=「頻譜電子」) \
-         ← 會丟掉「有會議」這個既有資訊\n");
-    prompt.push_str(
-        "  • Content 一律寫**完整脈絡**(時間、人物、地點、事件全部),不要只寫片段。\n");
-    prompt.push_str("呼叫 remember 後,用一兩句自然語言確認你記下了什麼。\n\n");
+        "  • Content 一律寫**完整脈絡**(時間、人物、地點、事件),不要片段。\n");
+    prompt.push_str("  • 呼叫後用一兩句自然語言確認記下了什麼。\n\n");
+
     prompt.push_str(&format!("現在時間:{now}\n"));
-    if !memory_context.is_empty() {
+    if !memory_index.is_empty() {
         prompt.push_str("\n");
-        prompt.push_str(memory_context);
+        prompt.push_str(memory_index);
     }
     prompt
 }

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -324,6 +324,31 @@ fn build_system_prompt(memory_context: &str) -> String {
         "- `remember`:把使用者明確要你記下的事(偏好、重要日期、人名、進行中專案)\
          寫進長期記憶。當使用者說「記住...」、「以後我都...」、「我喜歡...」、\
          分享生日 / 紀念日,或介紹重要的人事物時呼叫。一般閒聊或回答問題不要硬叫。\n");
+    prompt.push_str(
+        "  • Title 規則:**穩定 + 簡潔**。日期事件用「YYYY-MM-DD 主題」\
+         (例:「2026-05-11 會議」);人物 / 偏好用主題(例:「老婆生日」、\
+         「常用編輯器」)。\n");
+    prompt.push_str(
+        "  • **整合而非新增**:如果使用者補充 / 更正你已經記過的事(看「你已知關於\
+         使用者的事」段),呼叫 remember 時**用相同 title**,並且 content 必須是\
+         「舊內容 + 新訊息整合後的完整版本」,不可只寫新訊息(那會丟掉舊資訊)。\n");
+    prompt.push_str(
+        "    範例:\n");
+    prompt.push_str(
+        "    - 既有記憶 title=「2026-05-11 會議」、content=「2026-05-11 有會議」\n");
+    prompt.push_str(
+        "    - 使用者補充「是頻譜電子的會議」\n");
+    prompt.push_str(
+        "    - 正確呼叫:remember(title=「2026-05-11 會議」, \
+         content=「2026-05-11 與頻譜電子開會」)\n");
+    prompt.push_str(
+        "    - 錯誤呼叫:remember(title=「2026-05-11 頻譜電子會議」, ...) \
+         ← 會新增第二筆,造成重複\n");
+    prompt.push_str(
+        "    - 錯誤呼叫:remember(title=「2026-05-11 會議」, content=「頻譜電子」) \
+         ← 會丟掉「有會議」這個既有資訊\n");
+    prompt.push_str(
+        "  • Content 一律寫**完整脈絡**(時間、人物、地點、事件全部),不要只寫片段。\n");
     prompt.push_str("呼叫 remember 後,用一兩句自然語言確認你記下了什麼。\n\n");
     prompt.push_str(&format!("現在時間:{now}\n"));
     if !memory_context.is_empty() {

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -6,9 +6,13 @@ mod recording;
 use std::sync::Arc;
 
 use anyhow::Context as _;
+use mori_core::agent::Agent;
+use mori_core::context::Context as MoriContext;
 use mori_core::llm::groq::GroqProvider;
-use mori_core::llm::{ChatMessage, LlmProvider};
+use mori_core::llm::LlmProvider;
 use mori_core::memory::markdown::LocalMarkdownMemoryStore;
+use mori_core::memory::MemoryStore;
+use mori_core::skill::{RememberSkill, SkillRegistry};
 use mori_core::{PHASE, VERSION};
 use parking_lot::Mutex;
 use serde::Serialize;
@@ -257,24 +261,30 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
             let system_prompt = build_system_prompt(&memory_context);
             tracing::debug!(
                 memory_chars = memory_context.chars().count(),
-                "calling LLM with system prompt"
+                "calling agent with system prompt"
             );
 
-            let messages = vec![
-                ChatMessage {
-                    role: "system".into(),
-                    content: system_prompt,
-                },
-                ChatMessage {
-                    role: "user".into(),
-                    content: transcript.clone(),
-                },
-            ];
-            let resp = provider.chat(messages, vec![]).await.context("groq chat")?;
-            let text = resp
-                .content
-                .ok_or_else(|| anyhow::anyhow!("LLM returned no content"))?;
-            Ok(text)
+            // 把 provider 包成 Arc<dyn LlmProvider> 給 Agent 用
+            let provider: Arc<dyn LlmProvider> = Arc::new(provider);
+
+            // 註冊這次能用的 skill — phase 1D 只有 RememberSkill
+            let mut registry = SkillRegistry::new();
+            registry.register(Arc::new(RememberSkill::new(
+                memory.clone() as Arc<dyn MemoryStore>,
+            )));
+            let registry = Arc::new(registry);
+
+            let agent = Agent::new(provider, registry);
+            let ctx = MoriContext::default();
+            let turn = agent.respond(&system_prompt, &transcript, &ctx).await?;
+            if !turn.skill_calls.is_empty() {
+                tracing::info!(
+                    n = turn.skill_calls.len(),
+                    skills = ?turn.skill_calls.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+                    "agent: skills executed"
+                );
+            }
+            Ok(turn.response)
         }
         .await;
 
@@ -309,6 +319,12 @@ fn build_system_prompt(memory_context: &str) -> String {
     prompt.push_str("- 不寫前言或客套(例如「好的」、「沒問題」、「以下是」)— 直接進主題\n");
     prompt.push_str("- 若使用者問你做不到的事(例如操作系統、開檔案),老實說「目前還沒這個能力」\n");
     prompt.push_str("- 回覆長度配合提問:閒聊就一兩句,問題要解釋才展開\n\n");
+    prompt.push_str("可用工具:\n");
+    prompt.push_str(
+        "- `remember`:把使用者明確要你記下的事(偏好、重要日期、人名、進行中專案)\
+         寫進長期記憶。當使用者說「記住...」、「以後我都...」、「我喜歡...」、\
+         分享生日 / 紀念日,或介紹重要的人事物時呼叫。一般閒聊或回答問題不要硬叫。\n");
+    prompt.push_str("呼叫 remember 後,用一兩句自然語言確認你記下了什麼。\n\n");
     prompt.push_str(&format!("現在時間:{now}\n"));
     if !memory_context.is_empty() {
         prompt.push_str("\n");

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -71,8 +71,8 @@ User prefers responses without:
 
 | Phase | 機制 |
 |---|---|
-| 1-4 | LLM 看 `MEMORY.md` 索引 → 判斷哪幾個檔相關 → 讀進來 |
-| 5+ | 加 `sqlite-vec` embedding 加速,大量記憶時用 |
+| 1E | **目前實作**:system prompt 只送索引(`read_index_as_context`),LLM 看到後自行判斷需要哪幾筆 → 呼叫 `recall_memory(id)` skill 拉 body(multi-turn tool call)|
+| 5+ | 加 `sqlite-vec` embedding 加速,大量記憶時 LLM 透過 `search_memory(query)` skill 走語意搜尋 |
 | 7+ | 跨裝置 CRDT 合併 |
 | 9+ | 自動分類 / 自動失效(`stale` 標記) |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,11 +28,18 @@
 - [x] System prompt 整合 Mori persona + core memory + 當前時間
 - [x] 單元測試:write/read roundtrip + search
 
-### Phase 1D — 後續(下個 PR)
-- [ ] `RememberSkill`:LLM tool call,讓 Mori 自己決定要不要寫記憶
-- [ ] `Skill` trait dispatch 真正接通(目前 chat 是直接 hardcode)
+### Phase 1D — Skill dispatch + RememberSkill(2026-05-08)
+- [x] `SkillRegistry`:註冊、列舉、dispatch
+- [x] `Agent::respond`:LLM tool calling 接 SkillRegistry
+- [x] `RememberSkill`:LLM 自己判斷該不該寫記憶 → 直接寫入 markdown store
+- [x] System prompt 加入 tool 使用守則(不要硬叫、寫完要確認)
+- [x] 替代原本 hardcode 的 provider.chat(),全走 Agent 路徑
+
+### Phase 1E — 後續
 - [ ] 系統 tray icon(隱藏視窗時仍可叫出)
-- [ ] 對話歷史(連續對話)— 目前每次都是 stateless
+- [ ] 對話歷史(連續對話 + multi-turn tool call)— 目前是 stateless 單輪
+- [ ] UI 顯示「Mori 剛剛呼叫了 X skill」(`AgentTurn::skill_calls` 已就緒)
+- [ ] ForgetSkill / EditMemorySkill(讓使用者語音改記憶)
 
 ## Phase 2 — 基礎 Skills(2026-06)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,11 +35,20 @@
 - [x] System prompt 加入 tool 使用守則(不要硬叫、寫完要確認)
 - [x] 替代原本 hardcode 的 provider.chat(),全走 Agent 路徑
 
-### Phase 1E — 後續
+### Phase 1E — Multi-turn tools + Index-only context(2026-05-08)
+- [x] `ChatMessage` 擴展支援 OpenAI tool-calling 多輪協定
+      (`assistant.tool_calls` echo + `tool` role with `tool_call_id`)
+- [x] `Agent::respond` 改成多輪迴圈(MAX_ROUNDS=5,LLM 看 tool 結果再答)
+- [x] `RecallMemorySkill`:LLM 按需拉單筆記憶 body
+- [x] `read_index_as_context` 取代 `read_all_as_context`:system prompt 只送
+      索引(name + description + id),body 透過 recall_memory 拉
+- [x] System prompt 重寫:教 LLM 何時用 recall vs remember、整合 vs 新增
+
+### Phase 1F — 後續
 - [ ] 系統 tray icon(隱藏視窗時仍可叫出)
-- [ ] 對話歷史(連續對話 + multi-turn tool call)— 目前是 stateless 單輪
+- [ ] 對話歷史(連續對話)— 目前每輪都重啟,不記得上句
 - [ ] UI 顯示「Mori 剛剛呼叫了 X skill」(`AgentTurn::skill_calls` 已就緒)
-- [ ] ForgetSkill / EditMemorySkill(讓使用者語音改記憶)
+- [ ] ForgetSkill / EditMemorySkill(讓使用者語音改 / 刪記憶)
 
 ## Phase 2 — 基礎 Skills(2026-06)
 


### PR DESCRIPTION
## Summary

Phase 1D + 1E in one PR. Started as just RememberSkill but user push-back during review surfaced two design concerns that were better addressed now than later:

1. **Memory deduplication** — LLM was creating duplicate entries instead of integrating
2. **Memory scaling** — sending all memory body every turn doesn't scale beyond ~50 entries

Both are properly fixed here.

## Phase 1D — Skill dispatch foundation

`Skill` trait was scaffolded since 1A; this PR wires it up.

- `SkillRegistry` — register / get / dispatch / tool_definitions
- `Agent` — initially single-round (no multi-turn); replaced in 1E section below
- `RememberSkill` — `Arc<dyn MemoryStore>`, schema `{title, content, category}`
- `EchoSkill` retained as sanity check

## Phase 1E — Multi-turn + index-only context

Replaces the band-aid "send all memory + 16KB cap" with the design originally documented in `docs/memory.md`:

```
system prompt = persona + tool docs + memory INDEX only (~50 bytes/entry)
LLM sees index → recall_memory(id) when needed → tool message returns body → LLM answers
```

Scales to thousands of memories without blowing the context window.

### `mori-core/llm/mod.rs` — multi-turn ChatMessage

```rust
pub struct ChatMessage {
    pub role: String,
    pub content: Option<String>,           // null when assistant only tool-calls
    pub tool_calls: Vec<ToolCall>,         // assistant's tool requests
    pub tool_call_id: Option<String>,      // tool message: which call
    pub name: Option<String>,              // tool message: which tool
}

pub struct ToolCall {
    pub id: String,                        // server-issued, needed for replies
    pub name: String,
    pub arguments: Value,
}
```

Plus convenience constructors: `system / user / assistant_with_tool_calls / tool_result`.

### `mori-core/llm/groq.rs` — wire types

OpenAI nested-function shape, `arguments` JSON-encoded as string per spec.

### `mori-core/skill.rs` — `RecallMemorySkill`

Reads single memory body by id. Result returned as `user_message` which becomes the tool-result message in multi-turn flow.

### `mori-core/agent.rs` — multi-turn loop

```
loop (MAX_ROUNDS=5):
  resp = provider.chat(messages, tools)
  if resp.tool_calls.empty: return resp.content
  echo assistant message back
  for tc in tool_calls:
    output = registry.dispatch(tc.name, tc.args)
    append tool_result message
```

### `mori-core/memory/markdown.rs`

`read_all_as_context` → `read_index_as_context`. Returns:

```
- id=`2026-05-11_會議` 「2026-05-11 會議」 — 與頻譜電子開會
- id=`user_identity` 「使用者基本資料」 — 亞澤 / 高雄 / .NET 開發者
```

That's it. ~50 bytes per entry regardless of body size.

### System prompt rewrite

- `recall_memory` documented FIRST (LLM sees question, may need recall before answering)
- Integration rules now: recall → see old content → remember with merged content (proper "補充舊記憶" flow)

## Bug fix carried in this PR

User reported during 1D testing: Mori created `5月11日開會` AND `5月11日平普電子會議` (duplicate). Root cause: slugify added timestamp suffix preventing same-title overwrites. Fixed: stable slug + system prompt teaches "整合而非新增".

(「平普」is Whisper hearing 「頻譜」wrong. Documented in commit notes; not a regression.)

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test -p mori-core --lib` — 2/2 memory tests pass
- [x] `npm run build` + `tsc -b` clean

Acer verification (your turn — clean ~/.mori/memory/ first since old duplicates are still there):
- [ ] Pull, `npm run tauri dev`
- [ ] Single fact: "記住我老婆生日 11/3" → check `~/.mori/memory/老婆生日.md` written
- [ ] Update: "我老婆其實是 11/4 生日" → SAME file overwritten (not a new one), content integrated
- [ ] Recall on demand: "我老婆生日什麼時候?" → LLM sees index → calls recall_memory → answers from body
- [ ] Index check: `cat ~/.mori/memory/MEMORY.md` shows one entry per memory

## Out of scope (phase 1F)

- System tray icon
- Conversation history (currently each turn is independent)
- UI badge: "Mori 剛剛呼叫了 X skill"
- ForgetSkill / EditMemorySkill

🤖 Generated with [Claude Code](https://claude.com/claude-code)