### PR TITLE
feat(phase-1F): conversation history + tray icon + forget/edit + skill badges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3759,6 +3759,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "image",
  "jni",
  "libc",
  "log",

--- a/crates/mori-core/src/agent.rs
+++ b/crates/mori-core/src/agent.rs
@@ -22,6 +22,7 @@
 use std::sync::Arc;
 
 use anyhow::{Context as _, Result};
+use serde::Serialize;
 
 use crate::context::Context;
 use crate::llm::{ChatMessage, LlmProvider};
@@ -44,6 +45,53 @@ pub struct SkillCallRecord {
     pub output: SkillOutput,
 }
 
+impl SkillCallRecord {
+    /// 給 UI 看的精簡版(name + 一兩個關鍵 arg + 是否成功)。
+    pub fn summary(&self) -> SkillCallSummary {
+        SkillCallSummary {
+            name: self.name.clone(),
+            args_brief: brief_args(&self.args),
+            success: !self.output.user_message.starts_with("(error"),
+        }
+    }
+}
+
+/// 給前端顯示用的 skill 呼叫簡述。
+#[derive(Debug, Clone, Serialize)]
+pub struct SkillCallSummary {
+    pub name: String,
+    /// 簡短人類可讀的參數描述,例如 "title=「老婆生日」"
+    pub args_brief: String,
+    pub success: bool,
+}
+
+fn brief_args(args: &serde_json::Value) -> String {
+    let Some(obj) = args.as_object() else {
+        return truncate(&args.to_string(), 50);
+    };
+    let parts: Vec<String> = obj
+        .iter()
+        .take(2)
+        .map(|(k, v)| {
+            let val = match v.as_str() {
+                Some(s) => format!("「{}」", truncate(s, 24)),
+                None => truncate(&v.to_string(), 24),
+            };
+            format!("{k}={val}")
+        })
+        .collect();
+    parts.join(", ")
+}
+
+fn truncate(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max_chars - 1).collect();
+        format!("{truncated}…")
+    }
+}
+
 pub struct Agent {
     provider: Arc<dyn LlmProvider>,
     skills: Arc<SkillRegistry>,
@@ -55,16 +103,21 @@ impl Agent {
     }
 
     /// 跑一輪互動。多輪 tool call 迴圈最多 [`MAX_ROUNDS`] 次,超過視為異常。
+    ///
+    /// `history` 是先前對話的 user/assistant 訊息(不含 system,system 由
+    /// 本方法用 `system_prompt` 產生)。每輪交給 caller 自己 append 結果到
+    /// 自己的 history,不在 Agent 內 mutate state。
     pub async fn respond(
         &self,
         system_prompt: &str,
+        history: &[ChatMessage],
         user_input: &str,
         ctx: &Context,
     ) -> Result<AgentTurn> {
-        let mut messages = vec![
-            ChatMessage::system(system_prompt),
-            ChatMessage::user(user_input),
-        ];
+        let mut messages = Vec::with_capacity(history.len() + 2);
+        messages.push(ChatMessage::system(system_prompt));
+        messages.extend_from_slice(history);
+        messages.push(ChatMessage::user(user_input));
         let tools = self.skills.tool_definitions();
         let mut all_skill_calls: Vec<SkillCallRecord> = Vec::new();
 

--- a/crates/mori-core/src/lib.rs
+++ b/crates/mori-core/src/lib.rs
@@ -20,4 +20,4 @@ pub mod voice;
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// 當前 phase 名稱
-pub const PHASE: &str = "1E — Multi-turn tools + RecallMemorySkill";
+pub const PHASE: &str = "1F — Conversation history + Tray + Forget/Edit";

--- a/crates/mori-core/src/skill.rs
+++ b/crates/mori-core/src/skill.rs
@@ -349,6 +349,194 @@ impl Skill for RecallMemorySkill {
     }
 }
 
+// ─── ForgetMemorySkill ──────────────────────────────────────────────
+
+/// 刪除指定 id 的記憶(連同索引行)。LLM 在使用者明確要求「忘掉」、
+/// 「刪除」、「不用記了」之類時呼叫。
+///
+/// 是 destructive 操作 — `confirm_required` 為 true,理想上 UI 該攔下
+/// 二次確認再執行。Phase 1F 暫時沒攔(skill 直接執行)— phase 4+ 會做白名單
+/// + UI confirm flow。
+pub struct ForgetMemorySkill {
+    memory: Arc<dyn MemoryStore>,
+}
+
+impl ForgetMemorySkill {
+    pub fn new(memory: Arc<dyn MemoryStore>) -> Self {
+        Self { memory }
+    }
+}
+
+#[async_trait]
+impl Skill for ForgetMemorySkill {
+    fn name(&self) -> &'static str {
+        "forget_memory"
+    }
+
+    fn description(&self) -> &'static str {
+        "Delete a memory by id. Call this when the user explicitly asks you \
+         to forget / delete / remove a piece of information (e.g. '忘掉...', \
+         '不用記了', '把那個刪掉'). Identify the right memory by checking \
+         the memory index in system prompt. Operation is destructive — only \
+         call when the user's intent to delete is clear."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Memory id(檔名不含 .md)。從 system prompt 索引段抓。"
+                }
+            },
+            "required": ["id"]
+        })
+    }
+
+    fn confirm_required(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, args: Value, _context: &Context) -> Result<SkillOutput> {
+        let id = args
+            .get("id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("missing id"))?
+            .trim()
+            .to_string();
+
+        // 先確認存在,不存在直接回錯,免得「忘了一個本來就沒有的」假成功
+        let existed = self
+            .memory
+            .read(&id)
+            .await
+            .context("memory store read")?
+            .is_some();
+        if !existed {
+            return Ok(SkillOutput {
+                user_message: format!("找不到 id 為 `{id}` 的記憶,沒東西可忘"),
+                data: None,
+            });
+        }
+
+        self.memory
+            .delete(&id)
+            .await
+            .context("memory store delete")?;
+
+        Ok(SkillOutput {
+            user_message: format!("好,把 `{id}` 的記憶忘掉了"),
+            data: Some(serde_json::json!({ "id": id, "deleted": true })),
+        })
+    }
+}
+
+// ─── EditMemorySkill ────────────────────────────────────────────────
+
+/// 編輯既有記憶的內容(保留 name / type,只換 body / description)。
+///
+/// 跟「呼叫 `remember` 用同 title 覆寫」效果類似,但更明確 —
+/// 強制透過 id 指定,LLM 不會誤建新檔。建議用法:
+/// 1. recall_memory(id) 看舊 content
+/// 2. edit_memory(id, new_content) 寫整合後版本
+pub struct EditMemorySkill {
+    memory: Arc<dyn MemoryStore>,
+}
+
+impl EditMemorySkill {
+    pub fn new(memory: Arc<dyn MemoryStore>) -> Self {
+        Self { memory }
+    }
+}
+
+#[async_trait]
+impl Skill for EditMemorySkill {
+    fn name(&self) -> &'static str {
+        "edit_memory"
+    }
+
+    fn description(&self) -> &'static str {
+        "Update an existing memory's body content (keeping its name and type). \
+         Call this when the user is amending or correcting a memory you \
+         already have — typically after recall_memory revealed the old \
+         content. Use the same id from the memory index. \
+         Prefer this over calling `remember` for updates: it makes the intent \
+         explicit and avoids accidentally creating a duplicate from a \
+         slightly-different title."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Memory id(檔名不含 .md)。從索引或先前 recall_memory 結果取得。"
+                },
+                "new_content": {
+                    "type": "string",
+                    "description": "整合後的完整 content。要把舊 content + 新訊息合併,不可只寫新訊息。"
+                },
+                "new_description": {
+                    "type": "string",
+                    "description": "(可選)更新索引行的短描述。不給就保留舊的。"
+                }
+            },
+            "required": ["id", "new_content"]
+        })
+    }
+
+    async fn execute(&self, args: Value, _context: &Context) -> Result<SkillOutput> {
+        let id = args
+            .get("id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("missing id"))?
+            .trim()
+            .to_string();
+        let new_content = args
+            .get("new_content")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("missing new_content"))?
+            .trim()
+            .to_string();
+        let new_description = args
+            .get("new_description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim().to_string());
+
+        let mut existing = self
+            .memory
+            .read(&id)
+            .await
+            .context("memory store read")?
+            .ok_or_else(|| anyhow!("no memory with id: {id} — cannot edit"))?;
+
+        existing.body = new_content.clone();
+        if let Some(desc) = new_description {
+            existing.description = desc;
+        } else {
+            // 沒給新描述,從新 content 抽前 60 字當描述
+            existing.description = new_content.chars().take(60).collect();
+        }
+        existing.last_used = chrono::Utc::now();
+
+        self.memory
+            .write(existing.clone())
+            .await
+            .context("memory store write")?;
+
+        Ok(SkillOutput {
+            user_message: format!("好,把「{}」更新了", existing.name),
+            data: Some(serde_json::json!({
+                "id": existing.id,
+                "name": existing.name,
+                "updated": true,
+            })),
+        })
+    }
+}
+
 /// 把標題 slug 化成檔名安全的 id。
 /// 規則:保留 CJK / 英數字 / 底線,空白→底線,其他標點丟掉。
 ///

--- a/crates/mori-tauri/Cargo.toml
+++ b/crates/mori-tauri/Cargo.toml
@@ -12,7 +12,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 mori-core = { workspace = true }
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-global-shortcut = "2"
 serde = { workspace = true }

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -6,17 +6,21 @@ mod recording;
 use std::sync::Arc;
 
 use anyhow::Context as _;
-use mori_core::agent::Agent;
+use mori_core::agent::{Agent, SkillCallSummary};
 use mori_core::context::Context as MoriContext;
 use mori_core::llm::groq::GroqProvider;
-use mori_core::llm::LlmProvider;
+use mori_core::llm::{ChatMessage, LlmProvider};
 use mori_core::memory::markdown::LocalMarkdownMemoryStore;
 use mori_core::memory::MemoryStore;
-use mori_core::skill::{RecallMemorySkill, RememberSkill, SkillRegistry};
+use mori_core::skill::{
+    EditMemorySkill, ForgetMemorySkill, RecallMemorySkill, RememberSkill, SkillRegistry,
+};
 use mori_core::{PHASE, VERSION};
 use parking_lot::Mutex;
 use serde::Serialize;
-use tauri::{AppHandle, Emitter};
+use tauri::menu::{Menu, MenuItem};
+use tauri::tray::TrayIconBuilder;
+use tauri::{AppHandle, Emitter, Manager, WindowEvent};
 use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Shortcut, ShortcutState};
 
 use recording::Recorder;
@@ -34,10 +38,11 @@ pub enum Phase {
     Transcribing,
     /// transcript 拿到了,正在問 LLM
     Responding { transcript: String },
-    /// 完整一輪結束 — 同時帶 transcript 跟 LLM 回應
+    /// 完整一輪結束 — 同時帶 transcript、LLM 回應、用到的 skills
     Done {
         transcript: String,
         response: String,
+        skill_calls: Vec<SkillCallSummary>,
     },
     /// 錯誤(任何階段都可以掉到這)
     Error { message: String },
@@ -49,6 +54,9 @@ impl Default for Phase {
     }
 }
 
+/// 對話歷史最多保留幾「對」(user + assistant 各算一則,所以實際 message 數是 2x)。
+const MAX_HISTORY_PAIRS: usize = 10;
+
 pub struct AppState {
     pub phase: Mutex<Phase>,
     pub recorder: Mutex<Option<Recorder>>,
@@ -58,6 +66,9 @@ pub struct AppState {
     /// 長期記憶 store。Phase 1C 是 LocalMarkdownMemoryStore;
     /// phase 7+ 換成 SyncedMemoryStore 不重寫上層程式碼。
     pub memory: Arc<LocalMarkdownMemoryStore>,
+    /// Working memory:本次 session 的對話歷史(user / assistant 訊息對)。
+    /// 重啟 app 就清空。長期記憶寫進 memory 那邊。
+    pub conversation: Mutex<Vec<ChatMessage>>,
 }
 
 impl AppState {
@@ -96,6 +107,22 @@ fn has_groq_key(state: tauri::State<Arc<AppState>>) -> bool {
 #[tauri::command]
 fn toggle(app: AppHandle, state: tauri::State<Arc<AppState>>) {
     handle_hotkey_toggle(app, state.inner().clone());
+}
+
+/// 清空當前對話歷史(working memory),長期記憶不動。
+/// UI「重新開始對話」按鈕呼叫。
+#[tauri::command]
+fn reset_conversation(state: tauri::State<Arc<AppState>>) {
+    let mut conv = state.conversation.lock();
+    let n = conv.len();
+    conv.clear();
+    tracing::info!(cleared = n, "conversation reset");
+}
+
+/// 取得當前對話歷史長度(訊息數),供 UI 顯示用。
+#[tauri::command]
+fn conversation_length(state: tauri::State<Arc<AppState>>) -> usize {
+    state.conversation.lock().len()
 }
 
 // ─── 熱鍵 / toggle 處理 ─────────────────────────────────────────────
@@ -256,26 +283,34 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
             },
         );
 
-        let chat_result: anyhow::Result<String> = async {
+        // 把當前 history snapshot 出來給 agent 用(避免拿著 lock 跑 await)
+        let history_snapshot = state.conversation.lock().clone();
+
+        let chat_result: anyhow::Result<(String, Vec<SkillCallSummary>)> = async {
             let memory_index = memory.read_index_as_context().unwrap_or_default();
             let system_prompt = build_system_prompt(&memory_index);
             tracing::debug!(
                 index_chars = memory_index.chars().count(),
-                "calling agent with system prompt"
+                history_msgs = history_snapshot.len(),
+                "calling agent"
             );
 
             let provider: Arc<dyn LlmProvider> = Arc::new(provider);
 
-            // 註冊 phase 1E skills:remember(寫入)+ recall_memory(按需讀)
+            // 註冊 phase 1F skills:remember / recall / forget / edit
             let memory_for_skills: Arc<dyn MemoryStore> = memory.clone();
             let mut registry = SkillRegistry::new();
             registry.register(Arc::new(RememberSkill::new(memory_for_skills.clone())));
             registry.register(Arc::new(RecallMemorySkill::new(memory_for_skills.clone())));
+            registry.register(Arc::new(ForgetMemorySkill::new(memory_for_skills.clone())));
+            registry.register(Arc::new(EditMemorySkill::new(memory_for_skills.clone())));
             let registry = Arc::new(registry);
 
             let agent = Agent::new(provider, registry);
             let ctx = MoriContext::default();
-            let turn = agent.respond(&system_prompt, &transcript, &ctx).await?;
+            let turn = agent
+                .respond(&system_prompt, &history_snapshot, &transcript, &ctx)
+                .await?;
             if !turn.skill_calls.is_empty() {
                 tracing::info!(
                     n = turn.skill_calls.len(),
@@ -283,14 +318,38 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
                     "agent: skills executed"
                 );
             }
-            Ok(turn.response)
+            let summaries: Vec<SkillCallSummary> =
+                turn.skill_calls.iter().map(|c| c.summary()).collect();
+            Ok((turn.response, summaries))
         }
         .await;
 
         match chat_result {
-            Ok(response) => {
+            Ok((response, skill_calls)) => {
                 tracing::info!(chars = response.chars().count(), "Mori responded");
-                state.set_phase(&app, Phase::Done { transcript, response });
+
+                // Append 到 conversation history,trim 到 cap
+                {
+                    let mut conv = state.conversation.lock();
+                    conv.push(ChatMessage::user(transcript.clone()));
+                    conv.push(ChatMessage::assistant_with_tool_calls(
+                        Some(response.clone()),
+                        Vec::new(),
+                    ));
+                    let max_msgs = MAX_HISTORY_PAIRS * 2;
+                    while conv.len() > max_msgs {
+                        conv.remove(0);
+                    }
+                }
+
+                state.set_phase(
+                    &app,
+                    Phase::Done {
+                        transcript,
+                        response,
+                        skill_calls,
+                    },
+                );
             }
             Err(e) => {
                 tracing::error!(?e, "chat failed");
@@ -357,6 +416,24 @@ fn build_system_prompt(memory_index: &str) -> String {
         "  • Content 一律寫**完整脈絡**(時間、人物、地點、事件),不要片段。\n");
     prompt.push_str("  • 呼叫後用一兩句自然語言確認記下了什麼。\n\n");
 
+    // edit_memory
+    prompt.push_str(
+        "**edit_memory(id, new_content, [new_description])**:\
+         更新既有記憶的內容。\n");
+    prompt.push_str(
+        "  • 對既有記憶補充 / 更正用這個比 remember 更明確 — \
+         不會因 title 微差建出重複檔。\n");
+    prompt.push_str(
+        "  • 標準流程:recall_memory(看舊內容)→ edit_memory(寫整合後新內容)。\n");
+    prompt.push_str("  • new_content 一樣要是「舊 + 新」整合版,不可只寫新訊息。\n\n");
+
+    // forget_memory
+    prompt.push_str("**forget_memory(id)**:刪除一筆記憶。\n");
+    prompt.push_str(
+        "  • 觸發時機:使用者**明確要求**忘掉(「忘掉那個」、「不用記了」、\
+         「把 X 刪掉」)。意圖不明確就不要主動刪。\n");
+    prompt.push_str("  • Destructive 操作,刪了沒救。確認 id 對。\n\n");
+
     prompt.push_str(&format!("現在時間:{now}\n"));
     if !memory_index.is_empty() {
         prompt.push_str("\n");
@@ -400,6 +477,7 @@ fn main() {
         recorder: Mutex::new(None),
         groq_api_key: Mutex::new(None),
         memory,
+        conversation: Mutex::new(Vec::new()),
     });
 
     if let Some(key) = GroqProvider::discover_api_key() {
@@ -427,10 +505,63 @@ fn main() {
             mori_phase,
             current_phase,
             has_groq_key,
-            toggle
+            toggle,
+            reset_conversation,
+            conversation_length,
         ])
+        .on_window_event(|window, event| {
+            // 關視窗時不殺 app — 隱藏到系統匣繼續跑(像 Slack / Discord)
+            if let WindowEvent::CloseRequested { api, .. } = event {
+                tracing::info!("close requested → hiding to tray");
+                let _ = window.hide();
+                api.prevent_close();
+            }
+        })
         .setup(move |app| {
-            // 全域熱鍵:F8(單鍵,衝突最少;Wayland 上單鍵攔截行為跟 combo 可能不同)
+            // ── 系統匣(tray)+ 選單 ──
+            let menu = Menu::with_items(
+                app,
+                &[
+                    &MenuItem::with_id(app, "show", "顯示 Mori", true, None::<&str>)?,
+                    &MenuItem::with_id(app, "hide", "隱藏", true, None::<&str>)?,
+                    &MenuItem::with_id(app, "reset", "重新開始對話", true, None::<&str>)?,
+                    &MenuItem::with_id(app, "quit", "離開", true, None::<&str>)?,
+                ],
+            )?;
+
+            let state_for_tray = state_for_setup.clone();
+            let _tray = TrayIconBuilder::new()
+                .icon(app.default_window_icon().unwrap().clone())
+                .tooltip("Mori")
+                .menu(&menu)
+                .show_menu_on_left_click(true)
+                .on_menu_event(move |app, event| match event.id().as_ref() {
+                    "show" => {
+                        if let Some(w) = app.get_webview_window("main") {
+                            let _ = w.show();
+                            let _ = w.set_focus();
+                        }
+                    }
+                    "hide" => {
+                        if let Some(w) = app.get_webview_window("main") {
+                            let _ = w.hide();
+                        }
+                    }
+                    "reset" => {
+                        let mut conv = state_for_tray.conversation.lock();
+                        let n = conv.len();
+                        conv.clear();
+                        tracing::info!(cleared = n, "conversation reset (tray)");
+                    }
+                    "quit" => {
+                        tracing::info!("quit from tray");
+                        app.exit(0);
+                    }
+                    _ => {}
+                })
+                .build(app)?;
+
+            // ── 全域熱鍵:F8(Wayland 上常被擋,有 toggle 按鈕當 fallback)──
             let shortcut = Shortcut::new(None, Code::F8);
 
             let handle = app.handle().clone();
@@ -446,7 +577,7 @@ fn main() {
                 },
             )?;
 
-            tracing::info!("registered global shortcut: F8");
+            tracing::info!("registered global shortcut: F8 + tray icon");
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,11 +44,18 @@
       索引(name + description + id),body 透過 recall_memory 拉
 - [x] System prompt 重寫:教 LLM 何時用 recall vs remember、整合 vs 新增
 
-### Phase 1F — 後續
-- [ ] 系統 tray icon(隱藏視窗時仍可叫出)
-- [ ] 對話歷史(連續對話)— 目前每輪都重啟,不記得上句
-- [ ] UI 顯示「Mori 剛剛呼叫了 X skill」(`AgentTurn::skill_calls` 已就緒)
-- [ ] ForgetSkill / EditMemorySkill(讓使用者語音改 / 刪記憶)
+### Phase 1F — Conversation history + Tray + Forget/Edit(2026-05-08)
+- [x] **對話歷史**:`AppState.conversation: Vec<ChatMessage>`,
+      Agent::respond 取 `&[ChatMessage]` history,trim 到 MAX_HISTORY_PAIRS=10
+- [x] `reset_conversation` IPC + UI 按鈕 + 系統匣選單
+- [x] **系統 tray icon**:顯示 / 隱藏 / 重新對話 / 離開 選單,
+      關視窗 → 隱藏不殺 app(像 Slack)
+- [x] **ForgetMemorySkill / EditMemorySkill**:LLM 能語音刪 / 改記憶
+- [x] **Skill 呼叫透明化**:`Phase::Done` 帶 `skill_calls`,UI 在 Mori 回覆下
+      列 🔧 badge,失敗顯示 ⚠️
+- [x] System prompt 加 forget / edit 規則(destructive 要謹慎、明確 id)
+
+**Phase 1 完整收工:Mori 已是端到端可用的 voice AI 管家。**
 
 ## Phase 2 — 基礎 Skills(2026-06)
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,23 @@ import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 
+type SkillCallSummary = {
+  name: string;
+  args_brief: string;
+  success: boolean;
+};
+
 type Phase =
   | { kind: "idle" }
   | { kind: "recording"; started_at_ms: number }
   | { kind: "transcribing" }
   | { kind: "responding"; transcript: string }
-  | { kind: "done"; transcript: string; response: string }
+  | {
+      kind: "done";
+      transcript: string;
+      response: string;
+      skill_calls: SkillCallSummary[];
+    }
   | { kind: "error"; message: string };
 
 function App() {
@@ -17,15 +28,25 @@ function App() {
   const [phase, setPhase] = useState<Phase>({ kind: "idle" });
   const [recElapsed, setRecElapsed] = useState<number>(0);
   const [audioLevel, setAudioLevel] = useState<number>(0);
+  const [convLength, setConvLength] = useState<number>(0);
+
+  const refreshConvLength = () => {
+    invoke<number>("conversation_length")
+      .then(setConvLength)
+      .catch(() => setConvLength(0));
+  };
 
   useEffect(() => {
     invoke<string>("mori_version").then(setCoreVersion).catch(() => setCoreVersion("(unavailable)"));
     invoke<string>("mori_phase").then(setPhaseLabel).catch(() => setPhaseLabel("(unavailable)"));
     invoke<boolean>("has_groq_key").then(setHasKey).catch(() => setHasKey(false));
     invoke<Phase>("current_phase").then(setPhase).catch(() => {});
+    refreshConvLength();
 
     const unlistenPhase = listen<Phase>("phase-changed", (event) => {
       setPhase(event.payload);
+      // 每次 phase 變化(尤其轉到 done 時)順便刷一下對話長度
+      refreshConvLength();
     });
     const unlistenLevel = listen<number>("audio-level", (event) => {
       setAudioLevel(event.payload);
@@ -49,6 +70,15 @@ function App() {
 
   const onToggle = () => {
     invoke("toggle").catch((e) => console.error("toggle failed", e));
+  };
+
+  const onReset = () => {
+    invoke("reset_conversation")
+      .then(() => {
+        setConvLength(0);
+        setPhase({ kind: "idle" });
+      })
+      .catch((e) => console.error("reset failed", e));
   };
 
   return (
@@ -103,6 +133,20 @@ function App() {
             <div className="speech-block mori">
               <span className="speech-label">Mori</span>
               <p className="speech-text">{phase.response || "(無回應)"}</p>
+              {phase.skill_calls && phase.skill_calls.length > 0 && (
+                <div className="skill-badges">
+                  {phase.skill_calls.map((sc, i) => (
+                    <span
+                      key={i}
+                      className={`skill-badge ${sc.success ? "" : "failed"}`}
+                      title={sc.args_brief}
+                    >
+                      {sc.success ? "🔧" : "⚠️"} {sc.name}
+                      {sc.args_brief ? ` (${sc.args_brief})` : ""}
+                    </span>
+                  ))}
+                </div>
+              )}
             </div>
             <p className="hero-hint">按 F8 / 按鈕錄下一段</p>
           </>
@@ -119,7 +163,15 @@ function App() {
 
       <section className="actions">
         <button onClick={onToggle} className="toggle-btn">
-          手動觸發(等同熱鍵)
+          手動觸發(等同 F8)
+        </button>
+        <button
+          onClick={onReset}
+          className="toggle-btn reset-btn"
+          disabled={convLength === 0}
+          title="清掉本次對話歷史(長期記憶不動)"
+        >
+          重新開始對話
         </button>
       </section>
 
@@ -137,6 +189,10 @@ function App() {
           <span className={`value ${hasKey ? "ok" : "warn"}`}>
             {hasKey === null ? "..." : hasKey ? "ready" : "no key"}
           </span>
+        </div>
+        <div className="status-row">
+          <span className="label">history</span>
+          <span className="value">{convLength} msgs</span>
         </div>
       </section>
     </main>

--- a/src/styles.css
+++ b/src/styles.css
@@ -224,6 +224,40 @@ header h1 {
   font-family: var(--font-sans);
 }
 
+/* Mori 這輪呼叫過的 skills */
+.skill-badges {
+  margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.skill-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-dim);
+}
+
+.skill-badge.failed {
+  border-color: var(--error);
+  color: var(--error);
+}
+
+/* Reset button — 跟 toggle-btn 同基底,稍微淡一點 */
+.reset-btn {
+  margin-left: 8px;
+}
+
+.reset-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .error-msg {
   margin: 8px 0 0;
   padding: 12px;


### PR DESCRIPTION
## Summary

Phase 1F closes out phase 1. Four user-facing improvements + the architectural foundation for each:

| 功能 | 你會看到的 |
|---|---|
| 對話歷史 | Mori 記得這個 session 上一句講什麼,可以「再說一次」、「他是誰」這類接續對話 |
| 系統匣 | 關視窗不殺 app,從 macOS 選單列 / Windows 系統匣叫回來 |
| Skill 透明 | Mori 回覆下方顯示 🔧 badge,看到它剛剛呼叫了什麼 skill |
| Forget / Edit | 「忘掉那個」、「修改一下我老婆生日」 — Mori 自己改記憶 |

## What's new

### Conversation history

```
AppState.conversation: Mutex<Vec<ChatMessage>>
            ↓
each turn: append (user, assistant) pair
trim to MAX_HISTORY_PAIRS = 10 (20 messages)
            ↓
restart Mori → wiped (long-term memory in ~/.mori/memory/ untouched)
```

`Agent::respond` now takes `&[ChatMessage] history`. Agent stays stateless; caller owns history.

New IPC: `reset_conversation`, `conversation_length`. UI: 「重新開始對話」按鈕(disabled when empty) + status footer 顯示「history: N msgs」.

### System tray icon

Tauri 2 tray-icon feature enabled. Menu:
- 顯示 Mori
- 隱藏
- 重新開始對話
- 離開

Window close → hide instead of quit (Slack/Discord pattern). Quit via tray menu only.

### ForgetMemorySkill + EditMemorySkill

Both new skills registered alongside existing remember / recall_memory:

- **forget_memory(id)** — destructive (`confirm_required: true`), reads first to avoid fake-success on missing id
- **edit_memory(id, new_content, [new_description])** — preferred over `remember(same title)` for updates because it forces id-based selection (no slug-typo duplicates)

System prompt updated to teach LLM the new tools + recommend `recall → edit` flow for amendments.

### Skill badges

`Phase::Done` extended:
```rust
Done {
    transcript: String,
    response: String,
    skill_calls: Vec<SkillCallSummary>,
}
```

UI renders under Mori's reply:

```
🔧 remember (title=「老婆生日」)   ← success
⚠️ recall_memory (id=「xxx」)      ← failed (red border)
```

`SkillCallSummary` is a small serde-friendly subset of internal `SkillCallRecord` (name + 60-char args brief + success bool).

## Out of scope (phase 2+)

- TTS — still phase 6+
- Persistent session log on disk — `docs/memory.md` Working Memory path
- Confirm dialog before forget_memory executes (destructive UX)

## Test plan

Local /home/ct verified:
- [x] `cargo check --workspace` clean (added tauri features for tray)
- [x] `cargo test -p mori-core --lib` — 2/2 still pass
- [x] `npm run build` + `tsc -b` clean

Acer verification (your turn):
- [ ] Pull, `npm run tauri dev`
- [ ] **Conversation**: 「我老婆叫小明」→「她生日什麼時候?」 should reference prior turn
- [ ] **Reset**: click reset button → 「她生日什麼時候?」now should NOT know who 「她」是
- [ ] **Tray**: close window → still in tray → click tray to bring back
- [ ] **Forget**: 「忘掉 X」→ check `~/.mori/memory/` 該檔案消失 + UI 顯示 🔧 forget_memory badge
- [ ] **Edit**: 「把 X 改成 Y」→ same file, body updated + 🔧 edit_memory badge
- [ ] **Failed skill**: try invalid id → ⚠️ red badge appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)