### PR TITLE
feat(phase-4B-1): Wayland-compatible global hotkey via xdg-desktop-portal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "zbus",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +477,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -878,6 +927,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +985,27 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fastrand"
@@ -1048,6 +1145,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -2138,9 +2248,11 @@ name = "mori-tauri"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "ashpd",
  "async-trait",
  "chrono",
  "cpal",
+ "futures-util",
  "hound",
  "mori-core",
  "parking_lot",
@@ -2553,6 +2665,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2586,6 +2708,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -4159,6 +4287,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -4472,6 +4601,17 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -5700,6 +5840,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+dependencies = [
+ "async-broadcast",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.2",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.2",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5798,4 +5994,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "url",
+ "winnow 1.0.2",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 1.0.2",
 ]

--- a/crates/mori-tauri/Cargo.toml
+++ b/crates/mori-tauri/Cargo.toml
@@ -30,6 +30,15 @@ cpal = "0.15"
 hound = "3.5"
 # Lock-free shared state for the audio callback path
 parking_lot = "0.12"
+# Async stream utilities — needed to consume ashpd's GlobalShortcuts signal stream.
+futures-util = "0.3"
+
+# Linux-only: xdg-desktop-portal client. Wayland blocks the X11-style
+# global-shortcut path that tauri-plugin-global-shortcut uses, so we go
+# through `org.freedesktop.portal.GlobalShortcuts` instead. ashpd is the
+# canonical Rust wrapper.
+[target.'cfg(target_os = "linux")'.dependencies]
+ashpd = { version = "0.11", default-features = false, features = ["tokio"] }
 
 [features]
 default = ["custom-protocol"]

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -2,6 +2,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod context_provider;
+#[cfg(target_os = "linux")]
+mod portal_hotkey;
 mod recording;
 
 use std::sync::Arc;
@@ -22,8 +24,9 @@ use parking_lot::Mutex;
 use serde::Serialize;
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::TrayIconBuilder;
-use tauri::{AppHandle, Emitter, Manager, WindowEvent};
-use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Shortcut, ShortcutState};
+use tauri::{AppHandle, Emitter, Listener, Manager, WindowEvent};
+#[cfg(not(target_os = "linux"))]
+use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut, ShortcutState};
 
 use recording::Recorder;
 
@@ -730,23 +733,63 @@ fn main() {
                 })
                 .build(app)?;
 
-            // ── 全域熱鍵:F8(Wayland 上常被擋,有 toggle 按鈕當 fallback)──
-            let shortcut = Shortcut::new(None, Code::F8);
-
-            let handle = app.handle().clone();
-            let state_for_handler = state_for_setup.clone();
-
-            app.global_shortcut().on_shortcut(
-                shortcut,
-                move |_app, _shortcut, event| {
-                    if event.state() != ShortcutState::Pressed {
-                        return;
+            // ── 全域熱鍵:Ctrl+Alt+Space ───────────────────────────
+            // Linux 走 xdg-desktop-portal GlobalShortcuts(Wayland 唯一可行
+            // 的路);macOS / Windows 走 tauri-plugin-global-shortcut。
+            // 兩條路最後都呼叫 handle_hotkey_toggle。
+            #[cfg(target_os = "linux")]
+            {
+                let app_for_portal = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    if let Err(e) = portal_hotkey::run(app_for_portal).await {
+                        // Not fatal — UI button still works as fallback.
+                        // Common reasons: xdg-desktop-portal-gnome not installed,
+                        // user denied the permission dialog, or no portal session
+                        // (some headless / display-less envs).
+                        tracing::error!(
+                            ?e,
+                            "portal global shortcut unavailable — use the UI \
+                             toggle button to trigger Mori"
+                        );
                     }
-                    handle_hotkey_toggle(handle.clone(), state_for_handler.clone());
-                },
-            )?;
+                });
 
-            tracing::info!("registered global shortcut: F8 + tray icon");
+                let handle = app.handle().clone();
+                let state_for_handler = state_for_setup.clone();
+                app.listen(portal_hotkey::PORTAL_HOTKEY_EVENT, move |_event| {
+                    handle_hotkey_toggle(handle.clone(), state_for_handler.clone());
+                });
+
+                tracing::info!(
+                    "spawned portal hotkey task (Ctrl+Alt+Space) + tray icon"
+                );
+            }
+
+            #[cfg(not(target_os = "linux"))]
+            {
+                let shortcut = Shortcut::new(
+                    Some(Modifiers::CONTROL | Modifiers::ALT),
+                    Code::Space,
+                );
+
+                let handle = app.handle().clone();
+                let state_for_handler = state_for_setup.clone();
+
+                app.global_shortcut().on_shortcut(
+                    shortcut,
+                    move |_app, _shortcut, event| {
+                        if event.state() != ShortcutState::Pressed {
+                            return;
+                        }
+                        handle_hotkey_toggle(handle.clone(), state_for_handler.clone());
+                    },
+                )?;
+
+                tracing::info!(
+                    "registered global shortcut: Ctrl+Alt+Space + tray icon"
+                );
+            }
+
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/crates/mori-tauri/src/portal_hotkey.rs
+++ b/crates/mori-tauri/src/portal_hotkey.rs
@@ -11,8 +11,17 @@
 
 use anyhow::{Context as _, Result};
 use ashpd::desktop::global_shortcuts::{GlobalShortcuts, NewShortcut};
+use ashpd::{register_host_app, AppID};
 use futures_util::StreamExt;
 use tauri::{AppHandle, Emitter};
+
+/// App ID we register with the portal Registry. Must match
+/// `tauri.conf.json` `identifier` so per-app portal permissions are
+/// stored under one key. GNOME requires a registered app id before any
+/// portal call that needs to attribute permissions to a specific app
+/// (without it, GlobalShortcuts.CreateSession returns
+/// `org.freedesktop.portal.Error.NotAllowed: An app id is required`).
+const APP_ID: &str = "ai.yazelin.mori";
 
 /// Stable id we register with the portal — the `Activated` signal
 /// echoes this back so we can tell which shortcut fired (we'll have
@@ -37,6 +46,17 @@ const PREFERRED_TRIGGER: &str = "CTRL+ALT+space";
 /// "manual trigger" button — there's no global shortcut, but Mori still
 /// works.
 pub async fn run(app: AppHandle) -> Result<()> {
+    // Tell xdg-desktop-portal who we are. For non-flatpak apps this is
+    // necessary so the portal can scope permissions to our app id;
+    // flatpak'd apps inherit it from the sandbox manifest and ashpd
+    // skips this call automatically.
+    let app_id: AppID = APP_ID
+        .parse()
+        .context("APP_ID is not a valid reverse-DNS identifier")?;
+    register_host_app(app_id)
+        .await
+        .context("register host app id with xdg-desktop-portal Registry")?;
+
     let proxy = GlobalShortcuts::new()
         .await
         .context("connect to xdg-desktop-portal GlobalShortcuts (is xdg-desktop-portal-gnome installed?)")?;

--- a/crates/mori-tauri/src/portal_hotkey.rs
+++ b/crates/mori-tauri/src/portal_hotkey.rs
@@ -1,0 +1,93 @@
+//! Wayland-compatible global shortcut, via xdg-desktop-portal.
+//!
+//! `tauri-plugin-global-shortcut` registers via the X11 keyboard-grab API,
+//! which Wayland deliberately blocks. The official path on Wayland is the
+//! `org.freedesktop.portal.GlobalShortcuts` DBus interface — the first
+//! time we bind a shortcut, the compositor pops a permission dialog
+//! ("Mori 想註冊 Ctrl+Alt+Space"). After the user grants it, key presses
+//! arrive as DBus `Activated` signals; nobody has to grab the keyboard.
+//!
+//! Linux only. macOS / Windows use tauri-plugin-global-shortcut.
+
+use anyhow::{Context as _, Result};
+use ashpd::desktop::global_shortcuts::{GlobalShortcuts, NewShortcut};
+use futures_util::StreamExt;
+use tauri::{AppHandle, Emitter};
+
+/// Stable id we register with the portal — the `Activated` signal
+/// echoes this back so we can tell which shortcut fired (we'll have
+/// more than one in later phases, e.g. an "ask about selection"
+/// modifier variant).
+pub const TOGGLE_SHORTCUT_ID: &str = "toggle";
+
+/// Tauri event emitted when the toggle shortcut fires. The main loop
+/// listens for this and runs `handle_hotkey_toggle`.
+pub const PORTAL_HOTKEY_EVENT: &str = "portal-hotkey-fired";
+
+/// Hint to the portal — XDG "shortcuts" spec format. The user can
+/// override via the GNOME settings dialog if they want a different
+/// chord; we just say "this is what we'd prefer".
+const PREFERRED_TRIGGER: &str = "CTRL+ALT+space";
+
+/// Run forever, dispatching portal Activated signals into Tauri events.
+///
+/// Spawn this in a tokio task at app start. If the portal call fails
+/// (no GNOME, sandboxed env without xdg-portal, user denied), this
+/// returns an error and the caller should log + fall back to the UI
+/// "manual trigger" button — there's no global shortcut, but Mori still
+/// works.
+pub async fn run(app: AppHandle) -> Result<()> {
+    let proxy = GlobalShortcuts::new()
+        .await
+        .context("connect to xdg-desktop-portal GlobalShortcuts (is xdg-desktop-portal-gnome installed?)")?;
+
+    let session = proxy
+        .create_session()
+        .await
+        .context("create GlobalShortcuts session")?;
+
+    let shortcuts = vec![NewShortcut::new(TOGGLE_SHORTCUT_ID, "Mori — 開始 / 停止錄音")
+        .preferred_trigger(Some(PREFERRED_TRIGGER))];
+
+    // First-ever call pops the GNOME permission dialog. After grant, the
+    // binding persists per-user — subsequent runs are silent.
+    let bind = proxy
+        .bind_shortcuts(&session, &shortcuts, None)
+        .await
+        .context("bind shortcuts (first run shows permission dialog — user must grant)")?;
+    let bound = bind
+        .response()
+        .context("portal returned error / user denied")?;
+
+    if bound.shortcuts().is_empty() {
+        anyhow::bail!("portal accepted bind but returned no shortcuts");
+    }
+    for sc in bound.shortcuts() {
+        tracing::info!(
+            id = sc.id(),
+            description = sc.description(),
+            trigger = sc.trigger_description(),
+            "portal global shortcut bound",
+        );
+    }
+
+    let mut activated = proxy
+        .receive_activated()
+        .await
+        .context("subscribe to Activated signal")?;
+
+    while let Some(event) = activated.next().await {
+        tracing::debug!(
+            id = event.shortcut_id(),
+            ts_ms = event.timestamp().as_millis() as u64,
+            "portal hotkey activated",
+        );
+        if event.shortcut_id() == TOGGLE_SHORTCUT_ID {
+            if let Err(e) = app.emit(PORTAL_HOTKEY_EVENT, ()) {
+                tracing::warn!(?e, "failed to emit portal-hotkey-fired event");
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/mori-tauri/src/portal_hotkey.rs
+++ b/crates/mori-tauri/src/portal_hotkey.rs
@@ -46,6 +46,14 @@ const PREFERRED_TRIGGER: &str = "CTRL+ALT+space";
 /// "manual trigger" button — there's no global shortcut, but Mori still
 /// works.
 pub async fn run(app: AppHandle) -> Result<()> {
+    // GNOME's portal-gnome looks up a `.desktop` file for our app id
+    // before letting us register. Non-flatpak dev binaries don't
+    // get one for free — write a minimal one into the user-level
+    // applications dir pointing at our current binary.
+    if let Err(e) = ensure_desktop_file() {
+        tracing::warn!(?e, "could not write user desktop entry; portal may reject registration");
+    }
+
     // Tell xdg-desktop-portal who we are. For non-flatpak apps this is
     // necessary so the portal can scope permissions to our app id;
     // flatpak'd apps inherit it from the sandbox manifest and ashpd
@@ -107,6 +115,53 @@ pub async fn run(app: AppHandle) -> Result<()> {
                 tracing::warn!(?e, "failed to emit portal-hotkey-fired event");
             }
         }
+    }
+
+    Ok(())
+}
+
+/// Make sure `~/.local/share/applications/<APP_ID>.desktop` exists and
+/// points at the current binary. Idempotent — overwrites every run so a
+/// moved / rebuilt binary stays addressable. Without this file
+/// xdg-desktop-portal-gnome rejects host-app registration with
+/// `Could not register app ID: App info not found`.
+fn ensure_desktop_file() -> Result<()> {
+    let home = std::env::var("HOME").context("HOME not set")?;
+    let dir = std::path::PathBuf::from(home).join(".local/share/applications");
+    std::fs::create_dir_all(&dir).with_context(|| format!("mkdir {}", dir.display()))?;
+
+    let exe = std::env::current_exe().context("get current_exe")?;
+    let exe_str = exe.to_str().context("current_exe path is not valid UTF-8")?;
+
+    let path = dir.join(format!("{APP_ID}.desktop"));
+    let content = format!(
+        "[Desktop Entry]\n\
+         Type=Application\n\
+         Name=Mori\n\
+         Comment=森林精靈 Mori 的桌面身體\n\
+         Exec={exe_str}\n\
+         Icon=mori\n\
+         Categories=Utility;AudioVideo;\n\
+         StartupWMClass=Mori\n\
+         X-GNOME-UsesNotifications=true\n\
+         NoDisplay=false\n",
+    );
+
+    let needs_write = match std::fs::read_to_string(&path) {
+        Ok(existing) => existing != content,
+        Err(_) => true,
+    };
+
+    if needs_write {
+        std::fs::write(&path, &content)
+            .with_context(|| format!("write {}", path.display()))?;
+        tracing::info!(path = %path.display(), exec = exe_str, "wrote desktop entry for portal");
+
+        // Best-effort cache refresh — newer GNOME picks up the file
+        // immediately, but older portals cache and need a kick.
+        let _ = std::process::Command::new("update-desktop-database")
+            .arg(&dir)
+            .status();
     }
 
     Ok(())


### PR DESCRIPTION
## Why

`tauri-plugin-global-shortcut` on Linux uses the X11 keyboard-grab API, which Wayland deliberately blocks for security. Mori's F8 hotkey was silently broken on every Wayland desktop — the README documented "use the UI button as fallback" but that defeats the entire point of a voice assistant ("press to talk" doesn't work if "press" requires alt-tabbing first).

The official Wayland path is xdg-desktop-portal's `org.freedesktop.portal.GlobalShortcuts` interface: app calls `BindShortcuts` via DBus, the compositor pops a one-time permission dialog, and from then on key presses arrive as `Activated` DBus signals — no keyboard grab required, focus stays where it was.

## Changes

- New module `crates/mori-tauri/src/portal_hotkey.rs` (Linux-only via cfg) wrapping `ashpd::desktop::global_shortcuts`. Spawned as a tokio task at app start; emits Tauri event `portal-hotkey-fired` when the bound shortcut fires.
- Setup: on Linux, spawn the portal task + `app.listen()` for the event + call existing `handle_hotkey_toggle`. On macOS / Windows, keep `tauri-plugin-global-shortcut`.
- Hotkey changed from F8 → **`Ctrl+Alt+Space`** across all platforms (per design discussion: single sane default, no IDE-debugger conflict, matches the `Cmd+Space` cultural pattern of Raycast / Spotlight / "talk to AI").
- Two GNOME-portal-specific gotchas, found and fixed live on Acer (Ubuntu 26.04, GNOME Shell 50):
    - **`An app id is required`** — non-flatpak host apps must call `register_host_app(AppID)` before opening a portal session. Use the same id as `tauri.conf.json` `identifier` (`ai.yazelin.mori`) so per-app permissions accrue under one key.
    - **`App info not found for 'ai.yazelin.mori'`** — the portal's Registry refuses to register an app id that has no associated `.desktop` file. We write `~/.local/share/applications/ai.yazelin.mori.desktop` on every run, with `Exec=` pointing at `current_exe()` so it stays valid across rebuilds and binary moves. Also kicks `update-desktop-database` for older portals that cache the lookup.

## Failure mode

Non-fatal: if any of {portal not present, user denies permission dialog, no `.desktop` write permission} fail, we log an error and continue. The UI "manual trigger" button remains a fallback. macOS / Windows are unaffected.

## Test plan

- [x] `cargo check` passes on Linux
- [x] Live verified on Acer (Ubuntu 26.04, GNOME 50, Wayland): permission dialog appears once, "Add" → shortcut bound. Pressing Ctrl+Alt+Space anywhere triggers Mori recording without focus stealing.
- [ ] Verify on macOS / Windows (tauri-plugin-global-shortcut path) once cross-platform testing rig is set up

## Follow-ups (separate PRs)

- Phase 4B-2: `Active` / `Background` mode + tray menu
- Phase 4B-3: floating Mori widget window
- README: update phase status + replace F8 references with Ctrl+Alt+Space + Wayland note

🤖 Generated with [Claude Code](https://claude.com/claude-code)