### PR TITLE
feat(phase-4C): primary-selection read + ydotool paste-back

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,6 +2248,7 @@ name = "mori-tauri"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "arboard",
  "ashpd",
  "async-trait",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ Mori 不是孤立的 app,是一隻**契約精靈**在多個 repo 各司其職:
 
 ## 目前狀態
 
-**Phase 1 + 2 + 3A + 4B 完成(2026-05-07)** — Mori 終於在 Wayland 上**真的可以當管家用**:
-全域熱鍵通了、UI 不偷焦點、剪貼簿自動抓、休眠 / 醒醒兩態。
+**Phase 1 + 2 + 3A + 4B + 4C 完成(2026-05-08)** — Mori 在 Wayland 上**真的可以當管家用**:
+全域熱鍵通了、UI 不偷焦點、剪貼簿與滑鼠反白都自動抓、休眠 / 醒醒兩態,
+而且**反白文字 + 一句話 → 結果直接貼回**(ZeroType / Typeless 招牌動作)。
 
 按 `Ctrl+Alt+Space`(任何 app focus 都行)→ 講話 → Mori 聽 → 想 → 回。
 跨 session 記得你是誰、跨任務跟著你的工作模式走。
@@ -61,6 +62,7 @@ Mori 不是孤立的 app,是一隻**契約精靈**在多個 repo 各司其職:
 | 📋 摘要 | SummarizeSkill — bullet / paragraph / tldr 三種風格 |
 | 📨 草擬 | ComposeSkill — email / message / essay / social post,不會捏造署名 |
 | 📋 剪貼簿感知 | 每輪自動讀剪貼簿(1KB cap),「翻譯這個」「摘要這段」可直接指代 |
+| 🖱 反白即改寫 | Linux 自動讀滑鼠反白(`wl-paste --primary`,1.5KB cap),「翻譯成英文」「潤一下」處理完 `ydotool` 模擬 Ctrl+V 把結果貼回原視窗 — ZeroType / Typeless 等價流程。Ask 模式(「這在講什麼」)只回 chat,不動編輯區 |
 | 🌳 floating Mori | 桌面常駐小視窗(160×160 透明、不偷焦點),依狀態切表情 + 光暈,可拖、雙擊切顯示主視窗 |
 | 💤 休眠 / 醒醒 | tray 選單 / UI 按鈕 / 語音「晚安」「醒醒」三條路徑都能切。休眠時麥克風 **完全關**(privacy),背景排程仍跑(Phase 5+) |
 | 💭 對話歷史 | working memory 保留 10 對 user-assistant 訊息,可重置 |
@@ -73,7 +75,6 @@ Mori 不是孤立的 app,是一隻**契約精靈**在多個 repo 各司其職:
 
 | 缺什麼 | 為什麼重要 | 在哪個 Phase |
 |---|---|---|
-| ❌ 反白即改寫 | 反白文字 + 講話 → 結果直接貼回反白(ZeroType / Typeless 招牌動作) | Phase 4C(`wl-paste --primary` + `ydotool`) |
 | ❌ App-aware tone | 在 Slack 用閒聊、在 Outlook 用正式 — Mori 知道你在哪 | Phase 4D |
 | ❌ URL routing | YouTube 連結 → 自動摘要 / 文章 → fetch + 摘要 | Phase 3B |
 | ❌ 背景排程 | 「每小時提醒喝水」「每天 9 點晨報」— 真正的常駐 agent | Phase 5 |

--- a/crates/mori-core/src/context.rs
+++ b/crates/mori-core/src/context.rs
@@ -11,7 +11,9 @@ pub struct Context {
     /// 使用者語音(原始音訊位元組,通常 wav/opus)
     pub voice_audio: Option<Vec<u8>>,
 
-    /// 反白選中的文字(跨 app 抓取,Wayland 不支援)
+    /// 反白選中的文字。Linux 走 Wayland primary selection
+    /// (`wl-paste --primary`)或 X11 PRIMARY。macOS / Windows 待實作
+    /// (沒 primary 概念,要走 Accessibility API 或模擬 Cmd/Ctrl+C)。
     pub selected_text: Option<String>,
 
     /// 剪貼簿內容

--- a/crates/mori-core/src/lib.rs
+++ b/crates/mori-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod context;
 pub mod llm;
 pub mod memory;
 pub mod mode;
+pub mod paste;
 pub mod skill;
 pub mod voice;
 

--- a/crates/mori-core/src/lib.rs
+++ b/crates/mori-core/src/lib.rs
@@ -22,4 +22,4 @@ pub mod voice;
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// 當前 phase 名稱
-pub const PHASE: &str = "4B — Active / Background mode + portal hotkey";
+pub const PHASE: &str = "4C — primary selection + ydotool paste-back";

--- a/crates/mori-core/src/paste.rs
+++ b/crates/mori-core/src/paste.rs
@@ -1,0 +1,19 @@
+//! Paste-back primitive for "select + voice + replace" workflows.
+//!
+//! Phase 4C 主軸:使用者反白 → 講話 → Mori 處理 → 結果**回填到原本反白**。
+//! 同 Mode 一樣用 trait 抽象,讓 mori-core 的 skill 不依賴 Tauri / 平台。
+//! mori-tauri 在 Linux 上實作為 `wl-copy <text> && ydotool key Ctrl+V`。
+//!
+//! 沒實作的平台(macOS / Windows)先回 `Err`,UI 顯示「請手動 Cmd/Ctrl+V
+//! 貼上」即可。
+
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait PasteController: Send + Sync {
+    /// 把 `text` 寫進剪貼簿,然後模擬 paste 鍵(Linux 上是 Ctrl+V)送到
+    /// 當下 focused 的視窗。**這個 trait 不負責「保存原視窗 focus」** —
+    /// 呼叫者要保證在呼叫前 focused 的就是要被貼回去的那一個視窗
+    /// (例如 Mori 不偷焦點的設計就是為了維持這點)。
+    async fn paste_back(&self, text: &str) -> anyhow::Result<()>;
+}

--- a/crates/mori-core/src/paste.rs
+++ b/crates/mori-core/src/paste.rs
@@ -9,11 +9,27 @@
 
 use async_trait::async_trait;
 
+/// `paste_back` 的兩段式結果。剪貼簿寫入幾乎不會失敗(整套基本前提);
+/// 反而是模擬 paste 那步比較脆弱(ydotoold 沒跑、input group 沒生效、
+/// 系統沒裝 ydotool 等)。把兩段拆開讓 UI / skill 可以給「**結果已放剪
+/// 貼簿,請手動 Ctrl+V 貼上**」這種 graceful fallback,而不是 hard fail。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PasteResult {
+    /// 剪貼簿寫成功 + paste-key 模擬成功 → 已貼回原視窗。
+    Pasted,
+    /// 剪貼簿寫成功,但 paste-key 模擬失敗。文字仍在剪貼簿裡,user 手動
+    /// Ctrl+V 還是能補上。
+    ClipboardOnly,
+}
+
 #[async_trait]
 pub trait PasteController: Send + Sync {
-    /// 把 `text` 寫進剪貼簿,然後模擬 paste 鍵(Linux 上是 Ctrl+V)送到
-    /// 當下 focused 的視窗。**這個 trait 不負責「保存原視窗 focus」** —
-    /// 呼叫者要保證在呼叫前 focused 的就是要被貼回去的那一個視窗
+    /// 把 `text` 寫進剪貼簿,然後嘗試模擬 paste 鍵(Linux 上是 Ctrl+V)
+    /// 送到當下 focused 的視窗。**這個 trait 不負責「保存原視窗 focus」**
+    /// — 呼叫者要保證在呼叫前 focused 的就是要被貼回去的視窗
     /// (例如 Mori 不偷焦點的設計就是為了維持這點)。
-    async fn paste_back(&self, text: &str) -> anyhow::Result<()>;
+    ///
+    /// `Err` 只用在「**剪貼簿都寫不進去**」這種根本性失敗。Paste-key
+    /// 模擬失敗 → 回 `Ok(ClipboardOnly)`,讓上層決定怎麼跟 user 講。
+    async fn paste_back(&self, text: &str) -> anyhow::Result<PasteResult>;
 }

--- a/crates/mori-core/src/skill/mod.rs
+++ b/crates/mori-core/src/skill/mod.rs
@@ -157,6 +157,9 @@ mod translate;
 // Phase 4B-2: 模式控制(Active / Background)
 mod set_mode;
 
+// Phase 4C: 反白 → 講話 → 結果貼回
+mod paste_selection;
+
 pub use echo::EchoSkill;
 pub use edit::EditMemorySkill;
 pub use forget::ForgetMemorySkill;
@@ -169,6 +172,7 @@ pub use summarize::SummarizeSkill;
 pub use translate::TranslateSkill;
 
 pub use set_mode::SetModeSkill;
+pub use paste_selection::PasteSelectionBackSkill;
 
 // ─── 共用 helpers(memory-related skills 用)────────────────────────
 

--- a/crates/mori-core/src/skill/paste_selection.rs
+++ b/crates/mori-core/src/skill/paste_selection.rs
@@ -1,0 +1,104 @@
+//! PasteSelectionBackSkill — 回填處理結果到使用者原本反白的位置。
+//!
+//! 流程:
+//! 1. 使用者反白文字(Wayland primary selection / X11 PRIMARY)
+//! 2. 講話下指令(「翻成英文」「潤一下」「改更短」)
+//! 3. LLM 看到 `selected_text` in context,先呼叫 translate / polish /
+//!    summarize 拿結果
+//! 4. **這個 skill** 把結果寫剪貼簿 + 模擬 Ctrl+V → 取代原反白
+//!
+//! 關鍵:LLM 要在處理結果出來「之後」才呼叫,且只在使用者意圖是
+//! **修改**(verb)而不是**問問題**(question)時呼叫。
+//!
+//! 使用情境分類:
+//!   ✅ 「翻譯這段」→ paste(翻譯結果)
+//!   ✅ 「潤一下」 → paste(潤稿結果)
+//!   ❌ 「這在講什麼」→ 不 paste,結果在 popover 顯示
+
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::context::Context;
+use crate::paste::PasteController;
+use super::{Skill, SkillOutput};
+
+pub struct PasteSelectionBackSkill {
+    controller: Arc<dyn PasteController>,
+}
+
+impl PasteSelectionBackSkill {
+    pub fn new(controller: Arc<dyn PasteController>) -> Self {
+        Self { controller }
+    }
+}
+
+#[async_trait]
+impl Skill for PasteSelectionBackSkill {
+    fn name(&self) -> &'static str {
+        "paste_selection_back"
+    }
+
+    fn description(&self) -> &'static str {
+        "Replace the user's currently-selected text with `text`. Call this \
+         AFTER you've finished processing the user's selected_text — for \
+         example after `translate` / `polish` / `summarize` returned a \
+         result and the user clearly wanted the selection MODIFIED \
+         (verbs: 翻譯, 潤稿, 摘要, 改寫, 改短, 改成 X 語氣). DON'T call \
+         it when the user just asked a question about the selection \
+         (e.g. '這在講什麼', 'what does this mean') — for those, just \
+         answer in chat. Internally writes `text` to the clipboard then \
+         simulates the platform paste shortcut (Ctrl+V on Linux/Windows, \
+         Cmd+V on macOS), so the result lands in whatever app the user \
+         was selecting in. Mori's window is non-focus-stealing so the \
+         original app keeps focus and receives the paste."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "處理過的最終文字 — 會直接取代使用者原本反白的範圍。"
+                }
+            },
+            "required": ["text"]
+        })
+    }
+
+    fn confirm_required(&self) -> bool {
+        // 雖然會改使用者編輯區內容,但因為這是「使用者明確要求改寫」的
+        // 直接結果,不該攔下二次確認 — 那會打斷流暢度。如果之後發現
+        // 誤觸發太多,再升級成 confirm_required = true。
+        false
+    }
+
+    async fn execute(&self, args: Value, _context: &Context) -> Result<SkillOutput> {
+        let text = args
+            .get("text")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("missing text"))?
+            .to_string();
+
+        if text.is_empty() {
+            return Ok(SkillOutput {
+                user_message: "(沒東西可貼,跳過)".to_string(),
+                data: None,
+            });
+        }
+
+        self.controller.paste_back(&text).await?;
+
+        let preview: String = text.chars().take(40).collect();
+        let suffix = if text.chars().count() > 40 { "…" } else { "" };
+        Ok(SkillOutput {
+            user_message: format!("已貼回反白範圍:「{preview}{suffix}」"),
+            data: Some(serde_json::json!({
+                "pasted_chars": text.chars().count(),
+            })),
+        })
+    }
+}

--- a/crates/mori-core/src/skill/paste_selection.rs
+++ b/crates/mori-core/src/skill/paste_selection.rs
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::context::Context;
-use crate::paste::PasteController;
+use crate::paste::{PasteController, PasteResult};
 use super::{Skill, SkillOutput};
 
 pub struct PasteSelectionBackSkill {
@@ -90,14 +90,30 @@ impl Skill for PasteSelectionBackSkill {
             });
         }
 
-        self.controller.paste_back(&text).await?;
+        let result = self.controller.paste_back(&text).await?;
 
         let preview: String = text.chars().take(40).collect();
         let suffix = if text.chars().count() > 40 { "…" } else { "" };
+        let (user_message, pasted) = match result {
+            PasteResult::Pasted => (
+                format!("已貼回反白範圍:「{preview}{suffix}」"),
+                true,
+            ),
+            PasteResult::ClipboardOnly => (
+                format!(
+                    "結果已放剪貼簿(「{preview}{suffix}」),但模擬 Ctrl+V 失敗 — \
+                     ydotoold 可能沒在跑,請手動 Ctrl+V 貼上。\
+                     之後跑 setup-wayland-input.sh + 重開機一次能修。"
+                ),
+                false,
+            ),
+        };
+
         Ok(SkillOutput {
-            user_message: format!("已貼回反白範圍:「{preview}{suffix}」"),
+            user_message,
             data: Some(serde_json::json!({
                 "pasted_chars": text.chars().count(),
+                "pasted": pasted,
             })),
         })
     }

--- a/crates/mori-core/src/skill/translate.rs
+++ b/crates/mori-core/src/skill/translate.rs
@@ -39,10 +39,15 @@ impl Skill for TranslateSkill {
                 "source_text": { "type": "string", "description": "要翻譯的原文" },
                 "target_lang": {
                     "type": "string",
-                    "description": "目標語言。常用:zh-TW(繁中)、zh-CN(簡中)、en、ja、ko"
+                    "description": "目標語言。常用:zh-TW(繁中)、zh-CN(簡中)、en、ja、ko。\
+                                   **省略時預設 zh-TW**(我們主要使用者是繁中講者)。"
                 }
             },
-            "required": ["source_text", "target_lang"]
+            // `target_lang` 故意不放 required — Groq 的 tool validator 會
+            // 擋掉「LLM 漏帶 required」的整個 call(HTTP 400 tool_use_failed),
+            // 即使使用者講「翻譯成中文」LLM 仍偶爾會省略此欄。允許省略 +
+            // 預設 zh-TW 比 hard fail 友善很多。
+            "required": ["source_text"]
         })
     }
 
@@ -53,12 +58,13 @@ impl Skill for TranslateSkill {
             .ok_or_else(|| anyhow!("missing source_text"))?
             .trim()
             .to_string();
+        // target_lang 缺省 → 預設 zh-TW(對齊 schema description 的承諾)
         let target_lang = args
             .get("target_lang")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| anyhow!("missing target_lang"))?
-            .trim()
-            .to_string();
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "zh-TW".to_string());
 
         let messages = vec![
             ChatMessage::system(

--- a/crates/mori-tauri/Cargo.toml
+++ b/crates/mori-tauri/Cargo.toml
@@ -33,12 +33,18 @@ parking_lot = "0.12"
 # Async stream utilities — needed to consume ashpd's GlobalShortcuts signal stream.
 futures-util = "0.3"
 
-# Linux-only: xdg-desktop-portal client. Wayland blocks the X11-style
-# global-shortcut path that tauri-plugin-global-shortcut uses, so we go
-# through `org.freedesktop.portal.GlobalShortcuts` instead. ashpd is the
-# canonical Rust wrapper.
+# Linux-only deps:
+# - ashpd: xdg-desktop-portal client for the global-shortcut hotkey
+#   (Wayland blocks the X11-style keyboard grab tauri-plugin uses).
+# - arboard: read X11 PRIMARY selection directly. We were shelling out
+#   to `wl-paste --primary`, which on GNOME Wayland triggers an
+#   "unknown wl-clipboard wants clipboard access" portal prompt every
+#   single round — flow killer. arboard goes through XWayland's X11
+#   selection API (we force GDK_BACKEND=x11), no portal involvement,
+#   no prompt.
 [target.'cfg(target_os = "linux")'.dependencies]
 ashpd = { version = "0.11", default-features = false, features = ["tokio"] }
+arboard = "3"
 
 [features]
 default = ["custom-protocol"]

--- a/crates/mori-tauri/capabilities/default.json
+++ b/crates/mori-tauri/capabilities/default.json
@@ -22,6 +22,7 @@
     "core:tray:default",
     "clipboard-manager:default",
     "clipboard-manager:allow-read-text",
+    "clipboard-manager:allow-write-text",
     "global-shortcut:default"
   ]
 }

--- a/crates/mori-tauri/src/context_provider.rs
+++ b/crates/mori-tauri/src/context_provider.rs
@@ -1,8 +1,8 @@
 //! Tauri 平台的 ContextProvider 實作。
 //!
-//! Phase 3A:只先抓**剪貼簿文字**。其他欄位(selected_text、cursor_position、
-//! active_window 等)留 phase 3B/4 各平台再實作 — 那些跨 app 在 Wayland 上
-//! 受沙箱限制較多,需走 xdg-desktop-portal,工程量較大。
+//! Phase 3A:剪貼簿文字。
+//! Phase 4C:Linux primary selection(`wl-paste --primary` shell out)— 給
+//!          反白即改寫流程用。
 
 use async_trait::async_trait;
 use mori_core::context::{Context, ContextProvider};
@@ -32,9 +32,17 @@ impl ContextProvider for TauriContextProvider {
                 }
             }
             Err(e) => {
-                // 非 fatal,但提到 warn — 之前 capabilities 漏 allow-read-text
-                // 時整個 context 一直空白,debug log 看不到根本不知道。
                 tracing::warn!(?e, "clipboard read_text failed (image content / missing permission / Wayland quirk)");
+            }
+        }
+
+        // Phase 4C:讀 primary selection(滑鼠反白)。Linux only;其他
+        // 平台這條路徑回 None,fall through 不影響功能。
+        #[cfg(target_os = "linux")]
+        {
+            if let Some(sel) = crate::selection::read_primary_selection() {
+                tracing::info!(chars = sel.chars().count(), "captured primary selection");
+                ctx.selected_text = Some(sel);
             }
         }
 

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -717,17 +717,26 @@ fn build_system_prompt(memory_index: &str, ctx: &MoriContext) -> String {
     if let Some(sel) = &ctx.selected_text {
         prompt.push_str("\n# 當下反白文字\n\n");
         prompt.push_str(
-            "**這段是使用者在別的 app 裡剛反白的文字。**\n\n\
-             **硬規則**(如果這段存在,以下優先於剪貼簿規則):\n\
-             - 動詞型指令(翻譯 / 潤稿 / 摘要 / 改寫 / 英文化 / 改短 / \
-             改成 X 語氣 ...)的 source_text **一律**用這段反白,**不要**\
-             用剪貼簿(就算剪貼簿看起來內容更多更相關,也不要)。剪貼簿只\
-             是「沒反白時的 fallback」。\n\
-             - 處理完成後**必須**呼叫 `paste_selection_back(text=結果)`,\
-             把結果貼回使用者反白的位置。**不調用 = 任務沒完成**,\
-             使用者會以為 Mori 什麼都沒做。\n\
-             - 例外:使用者只是**問問題**(「這在講什麼」「為什麼這樣寫」\
-             「what does this mean」)→ 在 chat 回答即可,不要 paste。\n\n",
+            "**使用者在別的 app 裡剛反白了下面這段文字。**\n\n\
+             ## 嚴格時序(這段存在時的流程,不可繞過)\n\n\
+             **動詞型指令**(翻譯 / 潤稿 / 摘要 / 改寫 / 英文化 / 改短 / \
+             改成 X 語氣 / ...)→ 走這個**兩輪固定流程**:\n\n\
+             1. **Round 0**:呼叫 translate / polish / summarize / compose,\
+             `source_text` **一律**填這段反白(**不要**用對話歷史、**不要**\
+             用剪貼簿、**不要**用 Mori 上輪的回答 — 即使它們看起來更相關)。\n\
+             2. **Round 1**:看到 step 1 的結果後,**立刻**呼叫 \
+             `paste_selection_back(text=step1 的結果)`,**完整把結果原樣傳入**。\n\
+             3. 結束 turn,用一句話回覆使用者「已貼回」就好。\n\n\
+             **禁止**:\n\
+             - **禁止**對同一段文字連續呼叫兩次 action skill(polish 完不要再 polish,\
+             translate 完不要再 translate)。step 1 的結果就是最終答案,直接 paste-back。\n\
+             - **禁止**漏掉 step 2(paste_selection_back)。漏 = 整件事 = 沒做。\
+             使用者語音說「潤一下」期待看到反白被取代,沒貼回他完全感覺不到 Mori 動了什麼。\n\
+             - **禁止**把 source_text 改用對話歷史或 Mori 上輪的回應。哪怕你覺得歷史比較相關,\
+             也只用反白。\n\n\
+             **問句型指令**(「這在講什麼」、「為什麼這樣寫」、「what does this mean」\
+             — 沒有改寫意圖,只是問)→ 直接在 chat 回答,**不**呼叫 paste_selection_back,\
+             **不**動使用者編輯區。\n\n",
         );
         prompt.push_str("```\n");
         prompt.push_str(sel);

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -681,17 +681,19 @@ fn build_system_prompt(memory_index: &str, ctx: &MoriContext) -> String {
     // Paste-back skill(phase 4C):反白即改寫的回填動作
     prompt.push_str("**paste_selection_back(text)**:把處理過的文字貼回使用者反白範圍。\n");
     prompt.push_str(
-        "  • **觸發前提**:當下 context 有「反白文字」段(`# 當下反白文字`),\
-         且使用者意圖是**修改**這段反白(動詞:翻譯 / 潤稿 / 摘要 / 改寫 / \
-         改短 / 改成 X 語氣)。\n");
+        "  • **硬規則**:只要 system prompt 有 `# 當下反白文字` 段 + 使用者用\
+         動詞(翻譯 / 潤稿 / 摘要 / 改寫 / 改短 / 改成 X 語氣 / 英文化…),\
+         **流程是固定的**:\n");
     prompt.push_str(
-        "  • **流程**:先 translate / polish / summarize 把反白文字當 \
-         source_text 處理,**拿到結果之後**再呼叫 paste_selection_back \
-         (text=結果),把答案貼回使用者編輯區的反白範圍。\n");
+        "      1. translate / polish / summarize / compose 處理反白文字,\
+         source_text **一律**填那段反白(忽略剪貼簿)。\n");
+    prompt.push_str(
+        "      2. 拿到結果**立刻**呼叫 `paste_selection_back(text=結果)` —\
+         **這步不可省略**,沒 paste 等於整件事沒完成,使用者會以為 Mori 沒做事。\n");
     prompt.push_str(
         "  • **不要叫的情境**:使用者只是**問問題**(「這在講什麼」、\
-         「what does this mean」、「這段為什麼這樣寫」)— 那種是回 chat,\
-         **不要**動使用者的編輯區。\n");
+         「what does this mean」、「這段為什麼這樣寫」)→ 直接 chat 回答,\
+         **不**呼叫這個 skill,**不**動使用者編輯區。\n");
     prompt.push_str(
         "  • Linux only — 其他平台沒這個 skill,不會出現在 tool 清單。\n\n");
 
@@ -715,12 +717,17 @@ fn build_system_prompt(memory_index: &str, ctx: &MoriContext) -> String {
     if let Some(sel) = &ctx.selected_text {
         prompt.push_str("\n# 當下反白文字\n\n");
         prompt.push_str(
-            "(使用者**目前**在另一個 app 裡反白選中了下面這段文字。當他說\n\
-             「這個 / 這段 / 剛選的」配上**動詞**(翻譯 / 潤稿 / 摘要 / 改\n\
-             寫)時,**這份反白優先於剪貼簿**作為 source_text。\n\
-             處理完之後若意圖是**修改**反白本身,記得呼叫\n\
-             `paste_selection_back(text=結果)` 把結果貼回去 — 不要只在\n\
-             chat 回答,使用者期待看到編輯區直接被改掉。)\n\n",
+            "**這段是使用者在別的 app 裡剛反白的文字。**\n\n\
+             **硬規則**(如果這段存在,以下優先於剪貼簿規則):\n\
+             - 動詞型指令(翻譯 / 潤稿 / 摘要 / 改寫 / 英文化 / 改短 / \
+             改成 X 語氣 ...)的 source_text **一律**用這段反白,**不要**\
+             用剪貼簿(就算剪貼簿看起來內容更多更相關,也不要)。剪貼簿只\
+             是「沒反白時的 fallback」。\n\
+             - 處理完成後**必須**呼叫 `paste_selection_back(text=結果)`,\
+             把結果貼回使用者反白的位置。**不調用 = 任務沒完成**,\
+             使用者會以為 Mori 什麼都沒做。\n\
+             - 例外:使用者只是**問問題**(「這在講什麼」「為什麼這樣寫」\
+             「what does this mean」)→ 在 chat 回答即可,不要 paste。\n\n",
         );
         prompt.push_str("```\n");
         prompt.push_str(sel);

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -519,7 +519,7 @@ async fn run_chat_pipeline(
         #[cfg(target_os = "linux")]
         {
             let paste_controller: Arc<dyn PasteController> =
-                Arc::new(crate::selection::LinuxPasteController);
+                Arc::new(crate::selection::LinuxPasteController::new(app.clone()));
             registry.register(Arc::new(PasteSelectionBackSkill::new(paste_controller)));
         }
         let registry = Arc::new(registry);

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -806,10 +806,15 @@ fn main() {
 
     tracing::info!("Mori starting — phase {}", PHASE);
     #[cfg(target_os = "linux")]
-    tracing::info!(
-        gdk_backend = %std::env::var("GDK_BACKEND").unwrap_or_default(),
-        "GDK backend (forced x11 unless overridden)",
-    );
+    {
+        tracing::info!(
+            gdk_backend = %std::env::var("GDK_BACKEND").unwrap_or_default(),
+            "GDK backend (forced x11 unless overridden)",
+        );
+        // 反白即改寫(phase 4C)依賴 wl-clipboard + ydotool。startup 早點警告
+        // 比讓 user 試了一次「為什麼沒貼回」再 grep 程式碼好。
+        crate::selection::warn_if_setup_missing();
+    }
 
     // 確保 ~/.mori/config.json 存在(第一次跑就會寫一份 stub)
     let config_path = match GroqProvider::bootstrap_mori_config() {

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -5,6 +5,8 @@ mod context_provider;
 #[cfg(target_os = "linux")]
 mod portal_hotkey;
 mod recording;
+#[cfg(target_os = "linux")]
+mod selection;
 
 use std::sync::Arc;
 
@@ -17,6 +19,10 @@ use mori_core::llm::{ChatMessage, LlmProvider};
 use mori_core::memory::markdown::LocalMarkdownMemoryStore;
 use mori_core::memory::MemoryStore;
 use mori_core::mode::{Mode, ModeController};
+#[cfg(target_os = "linux")]
+use mori_core::paste::PasteController;
+#[cfg(target_os = "linux")]
+use mori_core::skill::PasteSelectionBackSkill;
 use mori_core::skill::{
     ComposeSkill, EditMemorySkill, ForgetMemorySkill, PolishSkill, RecallMemorySkill,
     RememberSkill, SetModeSkill, SkillRegistry, SummarizeSkill, TranslateSkill,
@@ -507,6 +513,15 @@ async fn run_chat_pipeline(
             app: app.clone(),
         });
         registry.register(Arc::new(SetModeSkill::new(mode_controller)));
+        // Paste-back skill(phase 4C):反白 → 講話 → 結果取代反白
+        // Linux only — 其他平台還沒實作 PasteController(macOS / Windows
+        // 各有各的 paste-key 模擬路徑,等之後跨平台 phase 補)。
+        #[cfg(target_os = "linux")]
+        {
+            let paste_controller: Arc<dyn PasteController> =
+                Arc::new(crate::selection::LinuxPasteController);
+            registry.register(Arc::new(PasteSelectionBackSkill::new(paste_controller)));
+        }
         let registry = Arc::new(registry);
 
         let agent = Agent::new(provider, registry);
@@ -663,6 +678,23 @@ fn build_system_prompt(memory_index: &str, ctx: &MoriContext) -> String {
          上面這些 text skills 是當使用者**明確要求一個動作**(翻譯 / 潤稿 / \
          摘要 / 撰寫)時才呼叫。\n\n");
 
+    // Paste-back skill(phase 4C):反白即改寫的回填動作
+    prompt.push_str("**paste_selection_back(text)**:把處理過的文字貼回使用者反白範圍。\n");
+    prompt.push_str(
+        "  • **觸發前提**:當下 context 有「反白文字」段(`# 當下反白文字`),\
+         且使用者意圖是**修改**這段反白(動詞:翻譯 / 潤稿 / 摘要 / 改寫 / \
+         改短 / 改成 X 語氣)。\n");
+    prompt.push_str(
+        "  • **流程**:先 translate / polish / summarize 把反白文字當 \
+         source_text 處理,**拿到結果之後**再呼叫 paste_selection_back \
+         (text=結果),把答案貼回使用者編輯區的反白範圍。\n");
+    prompt.push_str(
+        "  • **不要叫的情境**:使用者只是**問問題**(「這在講什麼」、\
+         「what does this mean」、「這段為什麼這樣寫」)— 那種是回 chat,\
+         **不要**動使用者的編輯區。\n");
+    prompt.push_str(
+        "  • Linux only — 其他平台沒這個 skill,不會出現在 tool 清單。\n\n");
+
     // Mode skill(phase 4B-2)
     prompt.push_str("**set_mode(mode)**:切換 Active / Background。\n");
     prompt.push_str(
@@ -676,6 +708,24 @@ fn build_system_prompt(memory_index: &str, ctx: &MoriContext) -> String {
          例如休眠回「好,我先閉眼,叫我就回來」)。\n\n");
 
     prompt.push_str(&format!("現在時間:{now}\n"));
+
+    // Phase 4C:當下反白文字(優先順序高於剪貼簿)。使用者反白後講話,
+    // 「這個 / 這段」幾乎都是指反白,不是剪貼簿。也是觸發
+    // paste_selection_back 的前提。
+    if let Some(sel) = &ctx.selected_text {
+        prompt.push_str("\n# 當下反白文字\n\n");
+        prompt.push_str(
+            "(使用者**目前**在另一個 app 裡反白選中了下面這段文字。當他說\n\
+             「這個 / 這段 / 剛選的」配上**動詞**(翻譯 / 潤稿 / 摘要 / 改\n\
+             寫)時,**這份反白優先於剪貼簿**作為 source_text。\n\
+             處理完之後若意圖是**修改**反白本身,記得呼叫\n\
+             `paste_selection_back(text=結果)` 把結果貼回去 — 不要只在\n\
+             chat 回答,使用者期待看到編輯區直接被改掉。)\n\n",
+        );
+        prompt.push_str("```\n");
+        prompt.push_str(sel);
+        prompt.push_str("\n```\n");
+    }
 
     // Phase 3A:當下 context(剪貼簿)。LLM 看到後可在使用者用代名詞時引用。
     if let Some(clip) = &ctx.clipboard {

--- a/crates/mori-tauri/src/selection.rs
+++ b/crates/mori-tauri/src/selection.rs
@@ -1,0 +1,123 @@
+//! Linux primary selection + paste-back via shell-out.
+//!
+//! Mori reads what the user has highlighted in another app via Wayland's
+//! primary-selection protocol (or X11 PRIMARY under XWayland) using
+//! `wl-paste --primary`. To replace the highlighted range, we write the
+//! result to the clipboard via `wl-copy` and then synthesize a Ctrl+V
+//! keypress with `ydotool` so the focused (still the original) app
+//! receives a paste.
+//!
+//! Why ydotool, not wtype: GNOME mutter doesn't implement
+//! `zwp_virtual_keyboard_v1`, so wtype silently does nothing. ydotool
+//! works at the kernel uinput layer, compositor-agnostic.
+//!
+//! Setup is one-time: `sudo bash setup-wayland-input.sh` from
+//! yazelin/ubuntu-26.04-setup installs `wl-clipboard` + `ydotool`,
+//! adds the user to the `input` group, enables the ydotoold systemd
+//! user unit. Reboot once for input-group membership to take effect on
+//! the systemd manager.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use anyhow::{anyhow, Context as _, Result};
+use async_trait::async_trait;
+use mori_core::paste::PasteController;
+
+/// 最大允許的反白字數 — 太長就視為使用者選了整篇，不適合直接送 Whisper /
+/// LLM tool args。1500 是經驗值(中文 ~2000 token,加上提示 + 結果輸出
+/// 大概 5-6K total,留有餘地給 Groq gpt-oss-120b TPM)。
+const MAX_SELECTION_CHARS: usize = 1500;
+
+/// 讀 Wayland primary selection(滑鼠反白文字)。
+/// 失敗時回 None — 反白為空、wl-paste 不在 PATH、Wayland session 沒有
+/// primary 等情況都當「沒抓到」處理,**不要** fatal。
+pub fn read_primary_selection() -> Option<String> {
+    let output = Command::new("wl-paste")
+        .args(["--primary", "--no-newline"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        // 反白為空時 wl-paste 會 exit code != 0,完全正常,不要 warn。
+        return None;
+    }
+
+    let text = String::from_utf8(output.stdout).ok()?;
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Cap 過長的選取(整篇文章不該整個塞 LLM context)。
+    let truncated = if trimmed.chars().count() > MAX_SELECTION_CHARS {
+        let head: String = trimmed.chars().take(MAX_SELECTION_CHARS).collect();
+        tracing::info!(
+            total = trimmed.chars().count(),
+            kept = MAX_SELECTION_CHARS,
+            "primary selection truncated for context",
+        );
+        head
+    } else {
+        trimmed.to_string()
+    };
+
+    Some(truncated)
+}
+
+/// PasteController 的 Linux 實作:`wl-copy <text> && ydotool key Ctrl+V`。
+pub struct LinuxPasteController;
+
+#[async_trait]
+impl PasteController for LinuxPasteController {
+    async fn paste_back(&self, text: &str) -> Result<()> {
+        // 1) 把結果寫到 Wayland 系統剪貼簿(透過 wl-copy)。我們用阻塞
+        //    版本 — wl-copy 預設會 fork 一個 daemon 把資料留在剪貼簿,
+        //    main process 立刻 return,所以 spawn → write stdin → drop
+        //    OK。
+        let mut child = Command::new("wl-copy")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .context("spawn wl-copy (is wl-clipboard installed? run setup-wayland-input.sh)")?;
+
+        {
+            let stdin = child
+                .stdin
+                .as_mut()
+                .ok_or_else(|| anyhow!("wl-copy stdin"))?;
+            stdin.write_all(text.as_bytes()).context("write to wl-copy stdin")?;
+        }
+        let status = child.wait().context("wl-copy wait")?;
+        if !status.success() {
+            anyhow::bail!("wl-copy exited non-zero ({status})");
+        }
+
+        // 2) 給合成器一拍呼吸時間 — 太快送 ydotool 偶爾會在 wl-copy 的
+        //    daemon 還沒設好 selection 之前就觸發 paste,目標 app 抓到的
+        //    是「上一個」剪貼簿值。50ms 通常夠。
+        tokio::time::sleep(Duration::from_millis(80)).await;
+
+        // 3) ydotool 用 Linux input-event keycode 送 Ctrl+V。
+        //    29 = LEFT_CTRL, 47 = V。`:1` 表示按下,`:0` 表示放開。
+        //    順序:Ctrl down → V down → V up → Ctrl up,完整 paste。
+        let status = Command::new("ydotool")
+            .args(["key", "29:1", "47:1", "47:0", "29:0"])
+            .status()
+            .context(
+                "ydotool key send (is ydotoold daemon running? \
+                 systemctl --user status ydotool)",
+            )?;
+        if !status.success() {
+            anyhow::bail!("ydotool exited non-zero ({status})");
+        }
+
+        tracing::info!(
+            chars = text.chars().count(),
+            "paste-back: wl-copy + ydotool Ctrl+V dispatched",
+        );
+        Ok(())
+    }
+}

--- a/crates/mori-tauri/src/selection.rs
+++ b/crates/mori-tauri/src/selection.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Context as _, Result};
 use async_trait::async_trait;
-use mori_core::paste::PasteController;
+use mori_core::paste::{PasteController, PasteResult};
 
 /// 最大允許的反白字數 — 太長就視為使用者選了整篇，不適合直接送 Whisper /
 /// LLM tool args。1500 是經驗值(中文 ~2000 token,加上提示 + 結果輸出
@@ -71,18 +71,19 @@ pub struct LinuxPasteController;
 
 #[async_trait]
 impl PasteController for LinuxPasteController {
-    async fn paste_back(&self, text: &str) -> Result<()> {
-        // 1) 把結果寫到 Wayland 系統剪貼簿(透過 wl-copy)。我們用阻塞
-        //    版本 — wl-copy 預設會 fork 一個 daemon 把資料留在剪貼簿,
-        //    main process 立刻 return,所以 spawn → write stdin → drop
-        //    OK。
+    async fn paste_back(&self, text: &str) -> Result<PasteResult> {
+        // ── Step 1:寫入 Wayland 剪貼簿 ────────────────────────────
+        // 這步如果壞了等於 paste-back 整套沒希望(連 user 手動 Ctrl+V
+        // 都救不了)。Bail out 為 hard error。
         let mut child = Command::new("wl-copy")
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
             .spawn()
-            .context("spawn wl-copy (is wl-clipboard installed? run setup-wayland-input.sh)")?;
-
+            .context(
+                "spawn wl-copy (is wl-clipboard installed? \
+                 run setup-wayland-input.sh)",
+            )?;
         {
             let stdin = child
                 .stdin
@@ -95,29 +96,66 @@ impl PasteController for LinuxPasteController {
             anyhow::bail!("wl-copy exited non-zero ({status})");
         }
 
-        // 2) 給合成器一拍呼吸時間 — 太快送 ydotool 偶爾會在 wl-copy 的
-        //    daemon 還沒設好 selection 之前就觸發 paste,目標 app 抓到的
-        //    是「上一個」剪貼簿值。50ms 通常夠。
+        // ── Step 2:讓合成器消化一下 selection 變更 ───────────────
+        // 太快送 ydotool 偶爾會在 wl-copy 的 daemon 還沒設好 selection
+        // 之前就觸發 paste,目標 app 抓到「上一個」剪貼簿值。80ms 夠。
         tokio::time::sleep(Duration::from_millis(80)).await;
 
-        // 3) ydotool 用 Linux input-event keycode 送 Ctrl+V。
-        //    29 = LEFT_CTRL, 47 = V。`:1` 表示按下,`:0` 表示放開。
-        //    順序:Ctrl down → V down → V up → Ctrl up,完整 paste。
-        let status = Command::new("ydotool")
+        // ── Step 3:ydotool 模擬 Ctrl+V ────────────────────────────
+        // 這步比較脆弱(ydotoold 沒跑、user 沒進 input group、ydotool
+        // 沒裝)。失敗時**不要 bail** — 文字已經在剪貼簿,user 手動
+        // Ctrl+V 還能補上,所以回 `ClipboardOnly` 讓上層友善降級。
+        let ydotool_outcome = Command::new("ydotool")
             .args(["key", "29:1", "47:1", "47:0", "29:0"])
-            .status()
-            .context(
-                "ydotool key send (is ydotoold daemon running? \
-                 systemctl --user status ydotool)",
-            )?;
-        if !status.success() {
-            anyhow::bail!("ydotool exited non-zero ({status})");
-        }
+            .status();
 
-        tracing::info!(
-            chars = text.chars().count(),
-            "paste-back: wl-copy + ydotool Ctrl+V dispatched",
-        );
-        Ok(())
+        match ydotool_outcome {
+            Ok(s) if s.success() => {
+                tracing::info!(
+                    chars = text.chars().count(),
+                    "paste-back: wl-copy + ydotool Ctrl+V dispatched",
+                );
+                Ok(PasteResult::Pasted)
+            }
+            Ok(s) => {
+                tracing::warn!(
+                    status = ?s,
+                    "ydotool exited non-zero — text in clipboard but paste-key not sent. \
+                     Check `systemctl --user status ydotool` and that user is in `input` group.",
+                );
+                Ok(PasteResult::ClipboardOnly)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    ?e,
+                    "ydotool failed to spawn — text in clipboard but paste-key not sent. \
+                     Run setup-wayland-input.sh and reboot once for input-group membership.",
+                );
+                Ok(PasteResult::ClipboardOnly)
+            }
+        }
+    }
+}
+
+/// 啟動時的健康檢查 — 看 wl-clipboard / ydotool 在不在 PATH,缺什麼
+/// 早警告。**不要** fail app — 反白即改寫只是 phase 4C 的功能,沒它
+/// Mori 還是能跑(語音、剪貼簿、記憶都不受影響)。只是讓 user 早點
+/// 知道為何 paste-back 待會會 fallback 到 ClipboardOnly。
+pub fn warn_if_setup_missing() {
+    for tool in ["wl-paste", "wl-copy", "ydotool"] {
+        let ok = Command::new("which")
+            .arg(tool)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !ok {
+            tracing::warn!(
+                tool,
+                "selection / paste-back tool missing — phase 4C 功能會降級。\
+                 跑 yazelin/ubuntu-26.04-setup 的 setup-wayland-input.sh 裝齊。",
+            );
+        }
     }
 }

--- a/crates/mori-tauri/src/selection.rs
+++ b/crates/mori-tauri/src/selection.rs
@@ -17,13 +17,14 @@
 //! user unit. Reboot once for input-group membership to take effect on
 //! the systemd manager.
 
-use std::io::Write;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
-use anyhow::{anyhow, Context as _, Result};
+use anyhow::{Context as _, Result};
 use async_trait::async_trait;
 use mori_core::paste::{PasteController, PasteResult};
+use tauri::AppHandle;
+use tauri_plugin_clipboard_manager::ClipboardExt;
 
 /// 最大允許的反白字數 — 太長就視為使用者選了整篇，不適合直接送 Whisper /
 /// LLM tool args。1500 是經驗值(中文 ~2000 token,加上提示 + 結果輸出
@@ -66,39 +67,38 @@ pub fn read_primary_selection() -> Option<String> {
     Some(truncated)
 }
 
-/// PasteController 的 Linux 實作:`wl-copy <text> && ydotool key Ctrl+V`。
-pub struct LinuxPasteController;
+/// PasteController 的 Linux 實作:**Tauri 剪貼簿插件**寫剪貼簿(用
+/// Mori 自己 process 走 portal,不會跳「未知 wl-clipboard 要求權限」對話
+/// 框)+ ydotool 模擬 Ctrl+V。
+///
+/// 之前用 `wl-copy` shell-out 會在 GNOME 50 的 xdg-desktop-portal
+/// 跳「未知 wl-clipboard」權限對話框,使用者每次都要手動點允許 — 改
+/// 走 Tauri plugin 之後 Mori 是已註冊的 host app(via portal_hotkey
+/// 的 register_host_app),GNOME 就視為 trusted。
+pub struct LinuxPasteController {
+    app: AppHandle,
+}
+
+impl LinuxPasteController {
+    pub fn new(app: AppHandle) -> Self {
+        Self { app }
+    }
+}
 
 #[async_trait]
 impl PasteController for LinuxPasteController {
     async fn paste_back(&self, text: &str) -> Result<PasteResult> {
-        // ── Step 1:寫入 Wayland 剪貼簿 ────────────────────────────
+        // ── Step 1:寫入 Wayland 剪貼簿(走 Tauri plugin,不 shell-out)──
         // 這步如果壞了等於 paste-back 整套沒希望(連 user 手動 Ctrl+V
         // 都救不了)。Bail out 為 hard error。
-        let mut child = Command::new("wl-copy")
-            .stdin(Stdio::piped())
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .spawn()
-            .context(
-                "spawn wl-copy (is wl-clipboard installed? \
-                 run setup-wayland-input.sh)",
-            )?;
-        {
-            let stdin = child
-                .stdin
-                .as_mut()
-                .ok_or_else(|| anyhow!("wl-copy stdin"))?;
-            stdin.write_all(text.as_bytes()).context("write to wl-copy stdin")?;
-        }
-        let status = child.wait().context("wl-copy wait")?;
-        if !status.success() {
-            anyhow::bail!("wl-copy exited non-zero ({status})");
-        }
+        self.app
+            .clipboard()
+            .write_text(text.to_string())
+            .context("Tauri clipboard write_text (capability allow-write-text granted?)")?;
 
         // ── Step 2:讓合成器消化一下 selection 變更 ───────────────
-        // 太快送 ydotool 偶爾會在 wl-copy 的 daemon 還沒設好 selection
-        // 之前就觸發 paste,目標 app 抓到「上一個」剪貼簿值。80ms 夠。
+        // 太快送 ydotool 偶爾會在 selection 還沒設好之前就觸發 paste,
+        // 目標 app 抓到「上一個」剪貼簿值。80ms 夠。
         tokio::time::sleep(Duration::from_millis(80)).await;
 
         // ── Step 3:ydotool 模擬 Ctrl+V ────────────────────────────
@@ -142,7 +142,9 @@ impl PasteController for LinuxPasteController {
 /// Mori 還是能跑(語音、剪貼簿、記憶都不受影響)。只是讓 user 早點
 /// 知道為何 paste-back 待會會 fallback 到 ClipboardOnly。
 pub fn warn_if_setup_missing() {
-    for tool in ["wl-paste", "wl-copy", "ydotool"] {
+    // wl-copy 不再需要 — 我們改走 Tauri 剪貼簿插件寫剪貼簿,只剩 wl-paste
+    // (讀 primary selection)和 ydotool(Ctrl+V 模擬)是 shell-out 路徑。
+    for tool in ["wl-paste", "ydotool"] {
         let ok = Command::new("which")
             .arg(tool)
             .stdout(Stdio::null())

--- a/crates/mori-tauri/src/selection.rs
+++ b/crates/mori-tauri/src/selection.rs
@@ -21,6 +21,7 @@ use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use anyhow::{Context as _, Result};
+use arboard::{Clipboard, GetExtLinux, LinuxClipboardKind};
 use async_trait::async_trait;
 use mori_core::paste::{PasteController, PasteResult};
 use tauri::AppHandle;
@@ -31,27 +32,38 @@ use tauri_plugin_clipboard_manager::ClipboardExt;
 /// 大概 5-6K total,留有餘地給 Groq gpt-oss-120b TPM)。
 const MAX_SELECTION_CHARS: usize = 1500;
 
-/// 讀 Wayland primary selection(滑鼠反白文字)。
-/// 失敗時回 None — 反白為空、wl-paste 不在 PATH、Wayland session 沒有
-/// primary 等情況都當「沒抓到」處理,**不要** fatal。
+/// 讀 X11 PRIMARY selection(滑鼠反白文字)。
+///
+/// 走 `arboard` 的 X11 backend — 我們強制 `GDK_BACKEND=x11` 讓 Mori 跑
+/// 在 XWayland 相容層,XWayland 自動把 Wayland primary selection 同步到
+/// X11 PRIMARY,所以從 X11 client 視角讀就拿到使用者的反白。**完全不
+/// 走 Wayland portal**,GNOME 不會跳「未知 wl-clipboard 要求剪貼簿存
+/// 取」對話框。
+///
+/// 失敗 / 反白為空 → 回 None。**不**做 fatal。
 pub fn read_primary_selection() -> Option<String> {
-    let output = Command::new("wl-paste")
-        .args(["--primary", "--no-newline"])
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        // 反白為空時 wl-paste 會 exit code != 0,完全正常,不要 warn。
-        return None;
-    }
-
-    let text = String::from_utf8(output.stdout).ok()?;
+    let mut clipboard = match Clipboard::new() {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::debug!(?e, "arboard Clipboard::new failed (no display?)");
+            return None;
+        }
+    };
+    let text = match clipboard.get().clipboard(LinuxClipboardKind::Primary).text() {
+        Ok(t) => t,
+        Err(e) => {
+            // 反白為空 / 不是文字(圖片) / 沒 selection owner 都會 Err,
+            // 全部當「沒抓到」即可,不要 warn 洗 log。
+            tracing::trace!(?e, "primary selection unavailable");
+            return None;
+        }
+    };
     let trimmed = text.trim();
     if trimmed.is_empty() {
         return None;
     }
 
-    // Cap 過長的選取(整篇文章不該整個塞 LLM context)。
+    // Cap 過長選取(整篇文章不該整個塞 LLM context)。
     let truncated = if trimmed.chars().count() > MAX_SELECTION_CHARS {
         let head: String = trimmed.chars().take(MAX_SELECTION_CHARS).collect();
         tracing::info!(
@@ -142,9 +154,10 @@ impl PasteController for LinuxPasteController {
 /// Mori 還是能跑(語音、剪貼簿、記憶都不受影響)。只是讓 user 早點
 /// 知道為何 paste-back 待會會 fallback 到 ClipboardOnly。
 pub fn warn_if_setup_missing() {
-    // wl-copy 不再需要 — 我們改走 Tauri 剪貼簿插件寫剪貼簿,只剩 wl-paste
-    // (讀 primary selection)和 ydotool(Ctrl+V 模擬)是 shell-out 路徑。
-    for tool in ["wl-paste", "ydotool"] {
+    // 寫剪貼簿走 Tauri plugin(arboard),讀 primary 也走 arboard,
+    // 兩者都是 in-process X11/XWayland API。剩下的 shell-out 只有 ydotool
+    // (Ctrl+V 模擬,沒有更乾淨的替代)。
+    for tool in ["ydotool"] {
         let ok = Command::new("which")
             .arg(tool)
             .stdout(Stdio::null())

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,8 +75,11 @@ function App() {
         );
       }, ms);
     });
-    // Phase 3A:Mori 在每輪開始抓 context(目前只有剪貼簿)
-    const unlistenContext = listen<{ clipboard?: string | null }>(
+    // Phase 3A + 4C:Mori 在每輪開始抓 context(剪貼簿、反白文字)
+    const unlistenContext = listen<{
+      clipboard?: string | null;
+      selected_text?: string | null;
+    }>(
       "context-captured",
       (event) => {
         setLastContext(event.payload);
@@ -129,9 +132,10 @@ function App() {
     reason: string;
     op: string;
   } | null>(null);
-  // Phase 3A:當 Mori 抓到剪貼簿等 context 時顯示
+  // Phase 3A + 4C:當 Mori 抓到剪貼簿 / 反白文字 時顯示
   const [lastContext, setLastContext] = useState<{
     clipboard?: string | null;
+    selected_text?: string | null;
   } | null>(null);
 
   const onToggle = () => {
@@ -381,6 +385,19 @@ function App() {
           >
             {lastContext?.clipboard
               ? `📋 ${lastContext.clipboard.length} 字`
+              : "—"}
+          </span>
+        </div>
+        <div className="status-row">
+          <span className="label">selection</span>
+          <span
+            className={`value ${
+              lastContext?.selected_text ? "ok" : ""
+            }`}
+            title={lastContext?.selected_text ?? "上一輪沒抓到反白文字"}
+          >
+            {lastContext?.selected_text
+              ? `🖱 ${lastContext.selected_text.length} 字`
               : "—"}
           </span>
         </div>


### PR DESCRIPTION
## Summary

Mori finally has the **「反白 → 講話 → 結果取代反白」** flow that ZeroType / Typeless make their headline. Linux / GNOME Wayland (under XWayland) verified end-to-end on Acer.

## What landed

### Read — primary selection capture
- `ContextProvider::capture()` now also reads X11 PRIMARY (mouse-highlighted text) on Linux, capped at 1500 chars so a whole article doesn't wreck Groq's TPM budget.
- Routed through **`arboard`** (in-process X11 selection API). Avoids the "未知 wl-clipboard 要求剪貼簿存取" GNOME portal prompt that subprocess `wl-paste` would have triggered every single round. Mori is forced to `GDK_BACKEND=x11` already (for always-on-top), so XWayland transparently bridges Wayland's primary selection into X11 PRIMARY for us.

### Write — paste-back
- New `mori-core::paste::PasteController` trait + `PasteSelectionBackSkill`. Skill is registered Linux-only (cfg-gated); macOS / Windows can implement when their PasteController arrives.
- `LinuxPasteController`:
    - Step 1: **Tauri's clipboard plugin** (`app.clipboard().write_text()`) sets the system clipboard. Same trick as the read — in-process, Mori is a registered portal app, no GNOME prompt.
    - Step 2: 80 ms compositor-settle sleep (else ydotool fires before clipboard daemon registers the new owner; target app pastes the previous content).
    - Step 3: `ydotool key 29:1 47:1 47:0 29:0` synthesizes Ctrl+V into the still-focused window.
- Returns `PasteResult { Pasted | ClipboardOnly }`. If wl-copy fails, hard error. If ydotool fails (ydotoold not running, user not in `input` group), graceful: text is in clipboard, message tells user to manually Ctrl+V.

### Prompt — strict 2-round contract
The system prompt for `paste_selection_back` was iterated several times during live testing:
- Initial soft hint ("記得呼叫") → LLM ignored it
- Hardened "必須" → LLM still polished prior chat answer instead of selection
- **Final form**: explicit two-round contract with **forbidden patterns** listed:
    - Round 0: action skill, `source_text` MUST be the selection
    - Round 1: `paste_selection_back(text=step-0 result)` verbatim
    - DON'T call same action skill twice in a row
    - DON'T substitute conversation history / clipboard / prior reply for source_text
    - DON'T skip paste_selection_back when selection is the source

Question-mode (「這在講什麼」/ "what does this mean") explicitly carved out as the only path that doesn't paste back.

### Bonus fixes that landed on this branch

- `translate.target_lang` removed from JSON-schema `required` and defaulted to `zh-TW` in code. Caught live: LLM emitted `translate(source_text=...)` without `target_lang` despite user clearly saying 「翻譯成中文」, Groq's strict tool validator killed the whole turn with HTTP 400 `tool_use_failed`. The 99% Mori user is Chinese-speaking; defaulting beats a hard fail.
- `warn_if_setup_missing()` startup health check shrunk to just `ydotool` (only out-of-process tool left after the arboard / Tauri-plugin migration).
- UI status footer adds a `selection` row alongside `clipboard`.
- Capabilities gain `clipboard-manager:allow-write-text`.
- README "能做的事" gains the 反白即改寫 row; "還沒做" drops it.

## Test plan

Verified live on Acer (Ubuntu 26.04 GNOME 50 Wayland → XWayland via GDK_BACKEND=x11):
- [x] Highlight text in any app + 「翻成英文」/「翻譯成中文」 → selection replaced with translation, no portal prompts
- [x] Highlight + 「這在講什麼」 → Mori answers in chat, editor untouched
- [x] `target_lang` omitted by LLM → defaults to zh-TW, no HTTP 400
- [x] Status footer shows `selection: 🖱 N 字` after each round
- [x] No "未知 wl-clipboard" portal dialog (the original bug that made paste-back unusable)
- [ ] Polish reliability: prompt iterated to a strict 2-round contract; real-world tuning may continue based on use. Translate path is proven; polish path is the same mechanism + same skill so should follow once LLM consistently obeys the contract.

## Follow-ups

- **Phase 4D — App-aware tone**: detect focused window class, slot into system prompt so Mori writes formally in Outlook, casually in Slack. Deferred.
- **Phase 5A — Multi-provider routing**: the natural next phase. Groq TPD limits are the daily blocker; adding `OllamaProvider` (local) + CLI fallbacks gives Mori a working path even when Groq is exhausted. Will pick up next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)