### PR TITLE
feat(phase-5A-1): OllamaProvider + config-driven chat-provider factory

### DIFF
--- a/crates/mori-core/src/llm/groq.rs
+++ b/crates/mori-core/src/llm/groq.rs
@@ -246,7 +246,11 @@ impl GroqProvider {
     }
 
     /// 確保 `~/.mori/` 存在,若 `config.json` 不存在就寫一份 stub
-    /// (含 placeholder,使用者編輯一次後就可用)。
+    /// (含 placeholder + 所有可用 provider 的 default 欄位,使用者編輯
+    /// 一次後就可用)。
+    ///
+    /// **不會覆寫**已存在的 config — 既有 user 的設定保留,新欄位若缺
+    /// 由各 provider 的 default 填補(`OllamaProvider::DEFAULT_*` 等)。
     pub fn bootstrap_mori_config() -> anyhow::Result<std::path::PathBuf> {
         let home = home_dir()
             .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?;
@@ -256,11 +260,20 @@ impl GroqProvider {
         let config = dir.join("config.json");
         if !config.exists() {
             let stub = serde_json::json!({
+                // 哪個 provider 服務 chat / 主 agent loop。
+                // 接受值:"groq"(雲端 Groq Whisper + GPT-OSS 系列)
+                //         "ollama"(本機 Ollama,需先 `ollama serve`)
+                // 之後 phase 5A-2 會加 "claude_cli"(本機 claude CLI)。
+                "default_provider": "groq",
                 "providers": {
                     "groq": {
                         "api_key": "REPLACE_ME_WITH_YOUR_GROQ_API_KEY",
-                        "chat_model": GroqProvider::DEFAULT_CHAT_MODEL,
-                        "transcribe_model": GroqProvider::DEFAULT_TRANSCRIBE_MODEL
+                        "chat_model": super::groq::GroqProvider::DEFAULT_CHAT_MODEL,
+                        "transcribe_model": super::groq::GroqProvider::DEFAULT_TRANSCRIBE_MODEL
+                    },
+                    "ollama": {
+                        "base_url": super::ollama::OllamaProvider::DEFAULT_BASE_URL,
+                        "model":    super::ollama::OllamaProvider::DEFAULT_MODEL
                     }
                 }
             });
@@ -283,7 +296,7 @@ fn is_placeholder(s: &str) -> bool {
     upper.starts_with("REPLACE") || upper.contains("YOUR_GROQ") || upper == "TODO"
 }
 
-fn read_json_pointer(path: &std::path::Path, pointer: &str) -> Option<String> {
+pub(crate) fn read_json_pointer(path: &std::path::Path, pointer: &str) -> Option<String> {
     let text = std::fs::read_to_string(path).ok()?;
     let json: serde_json::Value = serde_json::from_str(&text).ok()?;
     let key = json.pointer(pointer)?.as_str()?;
@@ -293,90 +306,14 @@ fn read_json_pointer(path: &std::path::Path, pointer: &str) -> Option<String> {
     Some(key.to_string())
 }
 
-// ─── chat completion request/response wire types ────────────────────
+// ─── chat completion wire types — shared with other OpenAI-compat
+// providers(Ollama, OpenAI, OpenRouter, ...)— see super::openai_compat.
+use super::openai_compat::{
+    ChatRequest, ChatResponseWire, WireFunction, WireFunctionOut, WireMessage, WireTool,
+    WireToolCallOut,
+};
 
-#[derive(Serialize)]
-struct ChatRequest<'a> {
-    model: &'a str,
-    messages: Vec<WireMessage<'a>>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    tools: Vec<WireTool<'a>>,
-}
-
-#[derive(Serialize)]
-struct WireMessage<'a> {
-    role: &'a str,
-    /// `null` 是合法的(assistant 發 tool_call 時可能 content=null)
-    content: Option<&'a str>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    tool_calls: Vec<WireToolCallOut<'a>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    tool_call_id: Option<&'a str>,
-    /// `tool` role 訊息要附 tool 名(可選但 OpenAI 標準有)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
-}
-
-/// 送出時的 tool_call 結構(OpenAI 巢狀 function 格式)
-#[derive(Serialize)]
-struct WireToolCallOut<'a> {
-    id: &'a str,
-    #[serde(rename = "type")]
-    kind: &'static str, // always "function"
-    function: WireFunctionOut<'a>,
-}
-
-#[derive(Serialize)]
-struct WireFunctionOut<'a> {
-    name: &'a str,
-    /// arguments 必須是 JSON-encoded 字串,不是物件
-    arguments: String,
-}
-
-#[derive(Serialize)]
-struct WireTool<'a> {
-    #[serde(rename = "type")]
-    kind: &'static str,
-    function: WireFunction<'a>,
-}
-
-#[derive(Serialize)]
-struct WireFunction<'a> {
-    name: &'a str,
-    description: &'a str,
-    parameters: &'a serde_json::Value,
-}
-
-#[derive(Deserialize, Debug)]
-struct ChatResponseWire {
-    choices: Vec<ChoiceWire>,
-}
-
-#[derive(Deserialize, Debug)]
-struct ChoiceWire {
-    message: ChoiceMessageWire,
-}
-
-#[derive(Deserialize, Debug)]
-struct ChoiceMessageWire {
-    content: Option<String>,
-    #[serde(default)]
-    tool_calls: Vec<ToolCallWire>,
-}
-
-#[derive(Deserialize, Debug)]
-struct ToolCallWire {
-    id: String,
-    function: ToolCallFunctionWire,
-}
-
-#[derive(Deserialize, Debug)]
-struct ToolCallFunctionWire {
-    name: String,
-    arguments: String, // JSON string
-}
-
-// ─── transcription wire ─────────────────────────────────────────────
+// ─── transcription wire(Groq-specific)──────────────────────────────
 
 #[derive(Deserialize, Debug)]
 struct TranscriptionResponse {

--- a/crates/mori-core/src/llm/mod.rs
+++ b/crates/mori-core/src/llm/mod.rs
@@ -17,6 +17,80 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 pub mod groq;
+pub mod ollama;
+mod openai_compat;
+
+// ─── Provider factory ───────────────────────────────────────────────
+//
+// `build_chat_provider` 讀 `~/.mori/config.json` 的 `default_provider`
+// 欄位,構造對應 LlmProvider 回傳。Groq / Ollama 走不同 default。
+// retry_callback 只對 Groq 有意義(Ollama 本機沒 rate limit)。
+
+use std::sync::Arc;
+
+/// 從 `~/.mori/config.json` 蓋出 chat provider。
+/// 配置:
+/// - `default_provider`: "groq"(預設) | "ollama"
+/// - `providers.groq.{api_key, chat_model}`
+/// - `providers.ollama.{base_url, model}`
+///
+/// retry_callback 只在 Groq 路徑套用(Ollama 本機沒 rate-limit)。
+pub fn build_chat_provider(
+    retry_cb: Option<groq::RetryCallback>,
+) -> anyhow::Result<Arc<dyn LlmProvider>> {
+    let default = mori_config_path()
+        .as_deref()
+        .and_then(|p| groq::read_json_pointer(p, "/default_provider"))
+        .unwrap_or_else(|| "groq".to_string());
+
+    match default.as_str() {
+        "ollama" => {
+            let base_url = mori_config_path()
+                .as_deref()
+                .and_then(|p| groq::read_json_pointer(p, "/providers/ollama/base_url"))
+                .unwrap_or_else(|| ollama::OllamaProvider::DEFAULT_BASE_URL.to_string());
+            let model = mori_config_path()
+                .as_deref()
+                .and_then(|p| groq::read_json_pointer(p, "/providers/ollama/model"))
+                .unwrap_or_else(|| ollama::OllamaProvider::DEFAULT_MODEL.to_string());
+            tracing::info!(provider = "ollama", model = %model, base_url = %base_url, "chat provider selected");
+            Ok(Arc::new(ollama::OllamaProvider::new(base_url, model)))
+        }
+        other => {
+            if other != "groq" {
+                tracing::warn!(
+                    provider = other,
+                    "unknown default_provider — falling back to 'groq'",
+                );
+            }
+            let key = groq::GroqProvider::discover_api_key().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no GROQ_API_KEY configured. Edit ~/.mori/config.json or set $GROQ_API_KEY \
+                     (or set default_provider to 'ollama' if you want to use local LLM only)"
+                )
+            })?;
+            let model = mori_config_path()
+                .as_deref()
+                .and_then(|p| groq::read_json_pointer(p, "/providers/groq/chat_model"))
+                .unwrap_or_else(|| groq::GroqProvider::DEFAULT_CHAT_MODEL.to_string());
+            tracing::info!(provider = "groq", model = %model, "chat provider selected");
+            let p = groq::GroqProvider::new(key, model);
+            let p = if let Some(cb) = retry_cb {
+                p.with_retry_callback(cb)
+            } else {
+                p
+            };
+            Ok(Arc::new(p))
+        }
+    }
+}
+
+fn mori_config_path() -> Option<std::path::PathBuf> {
+    std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .ok()
+        .map(|h| std::path::PathBuf::from(h).join(".mori").join("config.json"))
+}
 
 /// 一則訊息。
 ///

--- a/crates/mori-core/src/llm/ollama.rs
+++ b/crates/mori-core/src/llm/ollama.rs
@@ -1,0 +1,201 @@
+//! Ollama 本地 LLM provider — OpenAI-compatible HTTP endpoint.
+//!
+//! 預設打 `http://localhost:11434/v1/chat/completions`,wire format 跟
+//! Groq / OpenAI 一樣 → 整套 wire types 借用 [`super::openai_compat`]。
+//!
+//! 跟 Groq 比較,Ollama 路徑簡單很多:
+//! - 沒 API key(本機),所以不送 Authorization header
+//! - 沒 rate-limit / TPD / TPM 概念,失敗就 server 沒在跑或 model 沒
+//!   下載,沒有 retry-after 邏輯,只做一次失敗即報錯
+//! - Tool-calling 支援度 看 model:
+//!     - **支援**:qwen3、llama3.3、mistral、命名為 `*-tools` 的 model
+//!     - **不支援**:很多舊版或基礎 model — server 會回 400 / tool calls 為空
+//!   Mori 的 agent loop 在沒拿到 tool_calls 時會 fall through 到純文字回應,
+//!   不會崩,只是 skill routing 會吃癟。建議 main agent 還是 Groq,Ollama
+//!   留給 skill 內部 chat。
+//!
+//! ## Config(`~/.mori/config.json`)
+//!
+//! ```json
+//! {
+//!   "providers": {
+//!     "ollama": {
+//!       "base_url": "http://localhost:11434",
+//!       "model": "qwen3:8b"
+//!     }
+//!   }
+//! }
+//! ```
+
+use std::time::Duration;
+
+use anyhow::{bail, Context as _, Result};
+use async_trait::async_trait;
+use reqwest::Client;
+
+use super::openai_compat::{
+    ChatRequest, ChatResponseWire, WireFunction, WireFunctionOut, WireMessage, WireTool,
+    WireToolCallOut,
+};
+use super::{ChatMessage, ChatResponse, LlmProvider, ToolCall, ToolDefinition};
+
+pub struct OllamaProvider {
+    client: Client,
+    base_url: String,
+    model: String,
+}
+
+impl OllamaProvider {
+    pub const DEFAULT_BASE_URL: &'static str = "http://localhost:11434";
+    pub const DEFAULT_MODEL: &'static str = "qwen3:8b";
+
+    pub fn new(base_url: impl Into<String>, model: impl Into<String>) -> Self {
+        // 較寬鬆 timeout — 本機 LLM 第一次 load model 可能要 10-30s,後續才秒回。
+        let client = Client::builder()
+            .timeout(Duration::from_secs(120))
+            .build()
+            .expect("reqwest client");
+        let base_url = base_url.into();
+        // 容忍 trailing slash
+        let base_url = base_url.trim_end_matches('/').to_string();
+        Self {
+            client,
+            base_url,
+            model: model.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for OllamaProvider {
+    fn name(&self) -> &'static str {
+        "ollama"
+    }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
+
+    async fn chat(
+        &self,
+        messages: Vec<ChatMessage>,
+        tools: Vec<ToolDefinition>,
+    ) -> Result<ChatResponse> {
+        let wire_messages: Vec<WireMessage> = messages
+            .iter()
+            .map(|m| WireMessage {
+                role: &m.role,
+                content: m.content.as_deref(),
+                tool_calls: m
+                    .tool_calls
+                    .iter()
+                    .map(|tc| WireToolCallOut {
+                        id: &tc.id,
+                        kind: "function",
+                        function: WireFunctionOut {
+                            name: &tc.name,
+                            arguments: tc.arguments.to_string(),
+                        },
+                    })
+                    .collect(),
+                tool_call_id: m.tool_call_id.as_deref(),
+                name: m.name.as_deref(),
+            })
+            .collect();
+
+        let wire_tools: Vec<WireTool> = tools
+            .iter()
+            .map(|t| WireTool {
+                kind: "function",
+                function: WireFunction {
+                    name: &t.name,
+                    description: &t.description,
+                    parameters: &t.parameters,
+                },
+            })
+            .collect();
+
+        let body = ChatRequest {
+            model: &self.model,
+            messages: wire_messages,
+            tools: wire_tools,
+        };
+
+        let url = format!("{}/v1/chat/completions", self.base_url);
+        tracing::debug!(model = %self.model, msgs = messages.len(), "ollama chat request");
+
+        let resp = self
+            .client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .context(
+                "ollama chat: send (is the daemon running? `systemctl --user status ollama` \
+                 or `ollama serve`)",
+            )?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let err_body = resp.text().await.unwrap_or_default();
+            bail!(
+                "ollama chat: HTTP {}: {} (model `{}` 沒下載?跑 `ollama pull {}`)",
+                status,
+                err_body,
+                self.model,
+                self.model,
+            );
+        }
+
+        let text = resp.text().await.context("ollama chat: read body")?;
+        let wire: ChatResponseWire = serde_json::from_str(&text)
+            .context("ollama chat: parse response (server returned non-OpenAI shape?)")?;
+
+        let first = wire
+            .choices
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("ollama chat: empty choices"))?;
+
+        let tool_calls = first
+            .message
+            .tool_calls
+            .into_iter()
+            .map(|tc| {
+                let arguments: serde_json::Value =
+                    serde_json::from_str(&tc.function.arguments).unwrap_or_else(|_| {
+                        serde_json::json!({ "_raw": tc.function.arguments })
+                    });
+                ToolCall {
+                    id: tc.id,
+                    name: tc.function.name,
+                    arguments,
+                }
+            })
+            .collect();
+
+        Ok(ChatResponse {
+            content: first.message.content,
+            tool_calls,
+        })
+    }
+
+    // transcribe → 預設 trait impl 回 "not supported" — Ollama 沒 STT。
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_url_no_trailing_slash() {
+        let p = OllamaProvider::new("http://localhost:11434/", "qwen3:8b");
+        assert_eq!(p.base_url, "http://localhost:11434");
+    }
+
+    #[test]
+    fn name_is_ollama() {
+        let p = OllamaProvider::new(OllamaProvider::DEFAULT_BASE_URL, "qwen3:8b");
+        assert_eq!(p.name(), "ollama");
+    }
+}

--- a/crates/mori-core/src/llm/openai_compat.rs
+++ b/crates/mori-core/src/llm/openai_compat.rs
@@ -1,0 +1,99 @@
+//! OpenAI-compatible wire types for chat completion + tool calling.
+//!
+//! Shared between every provider that speaks the de-facto-standard
+//! `/v1/chat/completions` schema:
+//! - Groq (`api.groq.com/openai/v1/...`)
+//! - Ollama (`localhost:11434/v1/...`)
+//! - OpenAI 自身, OpenRouter, vLLM, etc.
+//!
+//! Providers with totally different shapes(Anthropic native, Claude CLI
+//! subprocess)don't use these types — they implement [`LlmProvider`]
+//! against their own protocol.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+// ─── Outgoing(client → server)──────────────────────────────────────
+
+#[derive(Serialize)]
+pub(crate) struct ChatRequest<'a> {
+    pub model: &'a str,
+    pub messages: Vec<WireMessage<'a>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<WireTool<'a>>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct WireMessage<'a> {
+    pub role: &'a str,
+    /// `null` 合法(assistant 發起 tool_call 時 content 可能 null)
+    pub content: Option<&'a str>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tool_calls: Vec<WireToolCallOut<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<&'a str>,
+    /// `tool` role 訊息要附 tool 名(OpenAI 標準)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<&'a str>,
+}
+
+/// 送出時的 tool_call 結構(OpenAI 巢狀 function 格式)
+#[derive(Serialize)]
+pub(crate) struct WireToolCallOut<'a> {
+    pub id: &'a str,
+    #[serde(rename = "type")]
+    pub kind: &'static str, // always "function"
+    pub function: WireFunctionOut<'a>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct WireFunctionOut<'a> {
+    pub name: &'a str,
+    /// arguments 必須是 JSON-encoded 字串,不是物件
+    pub arguments: String,
+}
+
+#[derive(Serialize)]
+pub(crate) struct WireTool<'a> {
+    #[serde(rename = "type")]
+    pub kind: &'static str,
+    pub function: WireFunction<'a>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct WireFunction<'a> {
+    pub name: &'a str,
+    pub description: &'a str,
+    pub parameters: &'a Value,
+}
+
+// ─── Incoming(server → client)──────────────────────────────────────
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct ChatResponseWire {
+    pub choices: Vec<ChoiceWire>,
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct ChoiceWire {
+    pub message: ChoiceMessageWire,
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct ChoiceMessageWire {
+    pub content: Option<String>,
+    #[serde(default)]
+    pub tool_calls: Vec<ToolCallWire>,
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct ToolCallWire {
+    pub id: String,
+    pub function: ToolCallFunctionWire,
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct ToolCallFunctionWire {
+    pub name: String,
+    pub arguments: String, // JSON string
+}

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -235,23 +235,21 @@ fn submit_text(app: AppHandle, state: tauri::State<Arc<AppState>>, text: String)
         }
     }
 
-    let api_key = state.groq_api_key.lock().clone();
-    let key = match api_key {
-        Some(k) => k,
-        None => {
+    // Phase 5A-1: chat provider 走 config-driven factory
+    // (default_provider="groq" / "ollama"),retry callback 只對 Groq 有意義
+    // 也透傳進 factory(內部會 ignore 給 Ollama)。
+    let provider = match mori_core::llm::build_chat_provider(Some(retry_callback_for(app.clone()))) {
+        Ok(p) => p,
+        Err(e) => {
             state.set_phase(
                 &app,
                 Phase::Error {
-                    message: "no GROQ_API_KEY configured. Edit ~/.mori/config.json or set $GROQ_API_KEY".into(),
+                    message: format!("{e:#}"),
                 },
             );
             return;
         }
     };
-    let provider: Arc<dyn LlmProvider> = Arc::new(
-        GroqProvider::new(key, GroqProvider::DEFAULT_CHAT_MODEL.to_string())
-            .with_retry_callback(retry_callback_for(app.clone())),
-    );
 
     let state_clone = state.inner().clone();
     tauri::async_runtime::spawn(async move {
@@ -380,8 +378,10 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
     let app_for_provider = app.clone();
 
     tauri::async_runtime::spawn(async move {
-        // Stage 1: Whisper
-        let transcribe_result: anyhow::Result<(String, GroqProvider)> = async {
+        // Stage 1: Whisper transcribe — **永遠走 Groq**,因為目前只有
+        // GroqProvider 實作 transcribe()。Local STT(whisper-rs)會在 phase
+        // 5C 接入,屆時這邊也走 factory pattern。
+        let transcribe_result: anyhow::Result<String> = async {
             let audio = recorder.stop().context("stop recorder")?;
             let duration = audio.duration_secs();
             let rms = if audio.samples.is_empty() {
@@ -419,16 +419,16 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
                 "no GROQ_API_KEY configured. \
                  Edit ~/.mori/config.json or set $GROQ_API_KEY",
             )?;
-            let provider =
+            let stt =
                 GroqProvider::new(key, GroqProvider::DEFAULT_CHAT_MODEL.to_string())
                     .with_retry_callback(retry_callback_for(app_for_provider.clone()));
-            let transcript = provider.transcribe(wav).await.context("groq transcribe")?;
+            let transcript = stt.transcribe(wav).await.context("groq transcribe")?;
             tracing::info!(chars = transcript.chars().count(), "transcribed");
-            Ok((transcript, provider))
+            Ok(transcript)
         }
         .await;
 
-        let (transcript, provider) = match transcribe_result {
+        let transcript = match transcribe_result {
             Ok(t) => t,
             Err(e) => {
                 tracing::error!(?e, "transcribe failed");
@@ -442,8 +442,22 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
             }
         };
 
-        // Stage 2: 走共用 chat pipeline(submit_text 也呼叫同一份)
-        let provider_arc: Arc<dyn LlmProvider> = Arc::new(provider);
+        // Stage 2: chat provider 走 config-driven factory(可能 Groq、可能
+        // Ollama,phase 5A-2 後也可能 Claude CLI)。STT 跟 chat 解耦了,語音
+        // 一定走 Groq Whisper,但接 chat 那輪可以 free-pick。
+        let provider_arc =
+            match mori_core::llm::build_chat_provider(Some(retry_callback_for(app.clone()))) {
+                Ok(p) => p,
+                Err(e) => {
+                    state.set_phase(
+                        &app,
+                        Phase::Error {
+                            message: format!("{e:#}"),
+                        },
+                    );
+                    return;
+                }
+            };
         run_chat_pipeline(app, state, transcript, provider_arc).await;
     });
 }


### PR DESCRIPTION
## Summary

Builds the multi-provider scaffold so Mori's chat path can be served by **Groq (cloud) or Ollama (local)** without code changes — same `LlmProvider` trait, all existing skills work with either. Direct response to TPD limits being the daily blocker: when Groq's daily token budget is exhausted, the user can flip one config field and Mori keeps working off-line.

## What landed

### `OllamaProvider` (`crates/mori-core/src/llm/ollama.rs`)
- HTTP to `${base_url}/v1/chat/completions`, defaults `http://localhost:11434` + `qwen3:8b` (tool-calling capable on recent models).
- 120s client timeout — first model load can be 10-30s, subsequent calls are fast.
- No retry/backoff (local; no rate limits).
- `transcribe()` falls through to the default `LlmProvider` impl that says "not supported" — Ollama has no STT, so STT stays on Groq for now.
- 2 unit tests for URL trimming + name.

### Wire-type extraction → `crates/mori-core/src/llm/openai_compat.rs`
Pulled the `/v1/chat/completions` request/response wire structs (`ChatRequest`, `WireMessage`, `ChatResponseWire`, etc.) out of `groq.rs` into a shared module. Both Groq and Ollama use the same de-facto-standard OpenAI shape, no need to duplicate. Future OpenRouter / OpenAI / vLLM providers slot into the same module. Providers with their own protocol (Anthropic native, Claude CLI subprocess in 5A-2) implement against their own.

### Config-driven factory `mori_core::llm::build_chat_provider()`
Reads `~/.mori/config.json` `default_provider` field, returns the right `Arc<dyn LlmProvider>`. Retry callback only attached to Groq (Ollama doesn't need one). Unknown provider name → warn + fall back to Groq.

### Bootstrap stub config
Now writes both `providers.groq` and `providers.ollama` sections plus `default_provider: \"groq\"`. Existing user configs aren't touched; missing fields fall back to each provider's hardcoded defaults via `serde(default)`-like JSON pointer reads.

### main.rs — both call sites
Both `submit_text` and `stop_and_transcribe` now build their chat provider through the factory. STT path inside `stop_and_transcribe` stays Groq-direct (only `GroqProvider` implements `transcribe()`); the chat provider is constructed separately after transcription, so a user with `default_provider: \"ollama\"` still gets Groq Whisper for the speech-to-text step but local Ollama for the actual thinking. Phase 5C will add `LocalWhisperProvider` to make STT pluggable too.

## Tests

- `cargo test -p mori-core` 16/16 passing (Groq's 14 retry-parser tests + Ollama's 2 new ones).
- Default behaviour unchanged: `default_provider=\"groq\"`, all skills go through Groq as before. Existing voice flow + Phase 4C reflection-edit + paste-back all unaffected.

## How to try Ollama

```bash
# On Acer, one-time
ollama serve              # if daemon not already running
ollama pull qwen3:8b      # tool-calling-capable, ~5GB

# Edit ~/.mori/config.json
\"default_provider\": \"ollama\"

# Restart Mori; log shows
\"chat provider selected provider=ollama model=qwen3:8b\"
```

STT keeps going through Groq (1 Whisper call per voice round); chat / agent / skill loops all run locally. Speed is ~2-3x slower than Groq's LPU on Acer's Intel 155H CPU, but completely unaffected by Groq TPD.

## Phase 5A roadmap

- **5A-1** (this PR): scaffold + OllamaProvider
- **5A-2**: `ClaudeCliProvider` — subprocess to `claude -p`, chat-only (no tool-calling). Suitable for skill-internal calls (translate / polish / summarize / compose). User has Claude CLI installed already, so zero extra setup.
- **5A-3**: per-skill provider override + auto-fallback on rate limit (Groq 429/TPD → next configured provider).

🤖 Generated with [Claude Code](https://claude.com/claude-code)