### PR TITLE
fix(ollama): bump cold-start timeout + pre-warm on startup

### DIFF
--- a/crates/mori-core/src/llm/mod.rs
+++ b/crates/mori-core/src/llm/mod.rs
@@ -85,6 +85,33 @@ pub fn build_chat_provider(
     }
 }
 
+/// 啟動時的 best-effort warm-up:若使用者把 `default_provider` 設成 ollama,
+/// 背景發一個 1-token 的 chat 把模型載進 RAM,使用者第一次按熱鍵時就不用
+/// 等 cold start(qwen3:8b 5.2GB 在 Intel CPU 沒 GPU 加速可能要分鐘級)。
+///
+/// Provider 是 groq 時直接 no-op(網路 LLM 沒 cold start)。
+pub async fn warm_up_default_provider() {
+    let default = mori_config_path()
+        .as_deref()
+        .and_then(|p| groq::read_json_pointer(p, "/default_provider"))
+        .unwrap_or_else(|| "groq".to_string());
+
+    if default != "ollama" {
+        return;
+    }
+
+    let base_url = mori_config_path()
+        .as_deref()
+        .and_then(|p| groq::read_json_pointer(p, "/providers/ollama/base_url"))
+        .unwrap_or_else(|| ollama::OllamaProvider::DEFAULT_BASE_URL.to_string());
+    let model = mori_config_path()
+        .as_deref()
+        .and_then(|p| groq::read_json_pointer(p, "/providers/ollama/model"))
+        .unwrap_or_else(|| ollama::OllamaProvider::DEFAULT_MODEL.to_string());
+
+    ollama::OllamaProvider::warm_up(&base_url, &model).await;
+}
+
 fn mori_config_path() -> Option<std::path::PathBuf> {
     std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))

--- a/crates/mori-core/src/llm/mod.rs
+++ b/crates/mori-core/src/llm/mod.rs
@@ -85,31 +85,68 @@ pub fn build_chat_provider(
     }
 }
 
-/// 啟動時的 best-effort warm-up:若使用者把 `default_provider` 設成 ollama,
-/// 背景發一個 1-token 的 chat 把模型載進 RAM,使用者第一次按熱鍵時就不用
-/// 等 cold start(qwen3:8b 5.2GB 在 Intel CPU 沒 GPU 加速可能要分鐘級)。
-///
-/// Provider 是 groq 時直接 no-op(網路 LLM 沒 cold start)。
-pub async fn warm_up_default_provider() {
+/// 目前生效的 chat provider 設定快照。給 UI / IPC / warm-up 用,
+/// 避免各處重複讀 config + 各自落 fallback。
+#[derive(Debug, Clone)]
+pub struct ProviderSnapshot {
+    pub name: String,
+    pub model: String,
+    /// Ollama 才有;Groq/雲端 provider 為 None。
+    pub base_url: Option<String>,
+}
+
+pub fn active_chat_provider_snapshot() -> ProviderSnapshot {
     let default = mori_config_path()
         .as_deref()
         .and_then(|p| groq::read_json_pointer(p, "/default_provider"))
         .unwrap_or_else(|| "groq".to_string());
 
-    if default != "ollama" {
+    match default.as_str() {
+        "ollama" => {
+            let base_url = mori_config_path()
+                .as_deref()
+                .and_then(|p| groq::read_json_pointer(p, "/providers/ollama/base_url"))
+                .unwrap_or_else(|| ollama::OllamaProvider::DEFAULT_BASE_URL.to_string());
+            let model = mori_config_path()
+                .as_deref()
+                .and_then(|p| groq::read_json_pointer(p, "/providers/ollama/model"))
+                .unwrap_or_else(|| ollama::OllamaProvider::DEFAULT_MODEL.to_string());
+            ProviderSnapshot {
+                name: "ollama".into(),
+                model,
+                base_url: Some(base_url),
+            }
+        }
+        _ => {
+            let model = mori_config_path()
+                .as_deref()
+                .and_then(|p| groq::read_json_pointer(p, "/providers/groq/chat_model"))
+                .unwrap_or_else(|| groq::GroqProvider::DEFAULT_CHAT_MODEL.to_string());
+            ProviderSnapshot {
+                name: "groq".into(),
+                model,
+                base_url: None,
+            }
+        }
+    }
+}
+
+/// 啟動時的 best-effort warm-up:若使用者把 `default_provider` 設成 ollama,
+/// 背景發一個 1-token 的 chat 把模型載進 RAM,使用者第一次按熱鍵時就不用
+/// 等 cold start(qwen3:8b 5.2GB 在 Intel CPU 沒 GPU 加速可能要分鐘級)。
+///
+/// Provider 是 groq 時直接 no-op(網路 LLM 沒 cold start)。
+/// 失敗無聲忽略 — UI 想知道狀態的話走 mori-tauri 那邊發事件版本。
+pub async fn warm_up_default_provider() {
+    let snap = active_chat_provider_snapshot();
+    if snap.name != "ollama" {
         return;
     }
-
-    let base_url = mori_config_path()
-        .as_deref()
-        .and_then(|p| groq::read_json_pointer(p, "/providers/ollama/base_url"))
-        .unwrap_or_else(|| ollama::OllamaProvider::DEFAULT_BASE_URL.to_string());
-    let model = mori_config_path()
-        .as_deref()
-        .and_then(|p| groq::read_json_pointer(p, "/providers/ollama/model"))
-        .unwrap_or_else(|| ollama::OllamaProvider::DEFAULT_MODEL.to_string());
-
-    ollama::OllamaProvider::warm_up(&base_url, &model).await;
+    if let Some(base_url) = snap.base_url {
+        if let Err(e) = ollama::OllamaProvider::warm_up(&base_url, &snap.model).await {
+            tracing::debug!(?e, "ollama warm-up failed (non-fatal)");
+        }
+    }
 }
 
 fn mori_config_path() -> Option<std::path::PathBuf> {

--- a/crates/mori-core/src/llm/ollama.rs
+++ b/crates/mori-core/src/llm/ollama.rs
@@ -68,11 +68,13 @@ impl OllamaProvider {
         }
     }
 
-    /// 啟動時呼叫一次的 best-effort warm-up。發一個 1-token 的 chat
-    /// 讓 Ollama 把 model 載進 RAM,使用者第一次按熱鍵時就不用等
-    /// cold start。失敗(daemon 沒跑、model 沒下載、port 不對)默默
-    /// 吞掉 — 真正用到時 user 會看到正常 error path。
-    pub async fn warm_up(base_url: &str, model: &str) {
+    /// 啟動時呼叫一次的 warm-up。發一個 1-token 的 chat 讓 Ollama 把
+    /// model 載進 RAM,使用者第一次按熱鍵時就不用等 cold start。
+    ///
+    /// 等到 server 回應(2xx)才 return Ok,讓呼叫端能在「真的載完」
+    /// 時通知 UI。失敗(daemon 沒跑、model 沒下載、port 不對、HTTP
+    /// 非 2xx)回 Err — 呼叫端決定是無聲忽略還是發 UI 事件。
+    pub async fn warm_up(base_url: &str, model: &str) -> Result<()> {
         let url = format!(
             "{}/v1/chat/completions",
             base_url.trim_end_matches('/')
@@ -82,20 +84,23 @@ impl OllamaProvider {
             "messages": [{ "role": "user", "content": "ok" }],
             "max_tokens": 1,
         });
-        let client = match Client::builder()
+        let client = Client::builder()
             .timeout(Duration::from_secs(300))
             .build()
-        {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-        match client.post(&url).json(&body).send().await {
-            Ok(_) => tracing::info!(
-                model,
-                "ollama warm-up dispatched (model is loading into RAM)"
-            ),
-            Err(e) => tracing::debug!(?e, "ollama warm-up failed (daemon down? non-fatal)"),
+            .context("ollama warm-up: build client")?;
+        let resp = client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .context("ollama warm-up: send (daemon not running?)")?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            bail!("ollama warm-up: HTTP {}: {}", status, body);
         }
+        tracing::info!(model, "ollama warm-up complete (model resident in RAM)");
+        Ok(())
     }
 }
 

--- a/crates/mori-core/src/llm/ollama.rs
+++ b/crates/mori-core/src/llm/ollama.rs
@@ -50,9 +50,12 @@ impl OllamaProvider {
     pub const DEFAULT_MODEL: &'static str = "qwen3:8b";
 
     pub fn new(base_url: impl Into<String>, model: impl Into<String>) -> Self {
-        // 較寬鬆 timeout — 本機 LLM 第一次 load model 可能要 10-30s,後續才秒回。
+        // 寬鬆 timeout — 第一次請求要 cold-load 模型到 RAM,5-8GB 模型在
+        // Intel CPU(沒 GPU 加速)上可能 60s+;qwen3 又預設啟 thinking
+        // mode,prefill 大 system prompt(我們現在 ~3-4K tokens)再搭一輪
+        // tool calling 動輒分鐘級。300s 是上限不是常態,熱起來後通常 5-15s。
         let client = Client::builder()
-            .timeout(Duration::from_secs(120))
+            .timeout(Duration::from_secs(300))
             .build()
             .expect("reqwest client");
         let base_url = base_url.into();
@@ -62,6 +65,36 @@ impl OllamaProvider {
             client,
             base_url,
             model: model.into(),
+        }
+    }
+
+    /// 啟動時呼叫一次的 best-effort warm-up。發一個 1-token 的 chat
+    /// 讓 Ollama 把 model 載進 RAM,使用者第一次按熱鍵時就不用等
+    /// cold start。失敗(daemon 沒跑、model 沒下載、port 不對)默默
+    /// 吞掉 — 真正用到時 user 會看到正常 error path。
+    pub async fn warm_up(base_url: &str, model: &str) {
+        let url = format!(
+            "{}/v1/chat/completions",
+            base_url.trim_end_matches('/')
+        );
+        let body = serde_json::json!({
+            "model": model,
+            "messages": [{ "role": "user", "content": "ok" }],
+            "max_tokens": 1,
+        });
+        let client = match Client::builder()
+            .timeout(Duration::from_secs(300))
+            .build()
+        {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+        match client.post(&url).json(&body).send().await {
+            Ok(_) => tracing::info!(
+                model,
+                "ollama warm-up dispatched (model is loading into RAM)"
+            ),
+            Err(e) => tracing::debug!(?e, "ollama warm-up failed (daemon down? non-fatal)"),
         }
     }
 }

--- a/crates/mori-core/src/llm/ollama.rs
+++ b/crates/mori-core/src/llm/ollama.rs
@@ -68,21 +68,25 @@ impl OllamaProvider {
         }
     }
 
-    /// 啟動時呼叫一次的 warm-up。發一個 1-token 的 chat 讓 Ollama 把
-    /// model 載進 RAM,使用者第一次按熱鍵時就不用等 cold start。
+    /// 啟動時呼叫一次的 warm-up。走 Ollama 原生 `/api/generate` + 空 prompt
+    /// 讓 server 只 load model 不跑推理 — 比經 OpenAI-compat 發 1-token chat
+    /// 健壯太多:
+    /// - 不會被 qwen3 thinking mode 燒 CPU 燒到 timeout(實測 8b 模型 thinking
+    ///   mode 處理一個 "ok" 也可以跑 2 分鐘以上)
+    /// - 設 `keep_alive: "30m"` 把模型保活延長到 30 分鐘,user 中午吃飯回來
+    ///   也不必再等冷啟動(預設只 5 分鐘)
+    /// - 取消 `stream` 拿單一 JSON 回應,簡單判斷成敗
     ///
     /// 等到 server 回應(2xx)才 return Ok,讓呼叫端能在「真的載完」
     /// 時通知 UI。失敗(daemon 沒跑、model 沒下載、port 不對、HTTP
     /// 非 2xx)回 Err — 呼叫端決定是無聲忽略還是發 UI 事件。
     pub async fn warm_up(base_url: &str, model: &str) -> Result<()> {
-        let url = format!(
-            "{}/v1/chat/completions",
-            base_url.trim_end_matches('/')
-        );
+        let url = format!("{}/api/generate", base_url.trim_end_matches('/'));
         let body = serde_json::json!({
             "model": model,
-            "messages": [{ "role": "user", "content": "ok" }],
-            "max_tokens": 1,
+            "prompt": "",
+            "stream": false,
+            "keep_alive": "30m",
         });
         let client = Client::builder()
             .timeout(Duration::from_secs(300))
@@ -99,7 +103,7 @@ impl OllamaProvider {
             let body = resp.text().await.unwrap_or_default();
             bail!("ollama warm-up: HTTP {}: {}", status, body);
         }
-        tracing::info!(model, "ollama warm-up complete (model resident in RAM)");
+        tracing::info!(model, "ollama warm-up complete (model resident in RAM, keep_alive=30m)");
         Ok(())
     }
 }

--- a/crates/mori-tauri/build.rs
+++ b/crates/mori-tauri/build.rs
@@ -1,3 +1,50 @@
+use std::process::Command;
+
 fn main() {
-    tauri_build::build()
+    tauri_build::build();
+
+    // 把 git SHA、dirty flag、build 時間編進 binary,讓 UI 能秀出來,
+    // user 一眼就能分辨「我現在跑的是哪個 build」。
+    let sha = Command::new("git")
+        .args(["rev-parse", "--short=8", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".into());
+    println!("cargo:rustc-env=MORI_GIT_SHA={}", sha);
+
+    let dirty = Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false);
+    println!(
+        "cargo:rustc-env=MORI_GIT_DIRTY={}",
+        if dirty { "1" } else { "" }
+    );
+
+    // UTC,不靠 chrono(避免拉 build-dep)。`date` 在 Linux/macOS 都有。
+    // Windows build 走這條會拿到 "unknown" — Mori 是 Linux-first 不擋。
+    let time = Command::new("date")
+        .args(["-u", "+%Y-%m-%d %H:%MZ"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".into());
+    println!("cargo:rustc-env=MORI_BUILD_TIME={}", time);
+
+    // 確保 git checkout / commit 後重 build 也會更新 SHA。HEAD ref
+    // 變動 + index 變動都讓 build.rs rerun。
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/index");
+    if let Ok(head) = std::fs::read_to_string("../../.git/HEAD") {
+        if let Some(rest) = head.strip_prefix("ref: ") {
+            println!("cargo:rerun-if-changed=../../.git/{}", rest.trim());
+        }
+    }
 }

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -1011,6 +1011,14 @@ fn main() {
                 }
             });
 
+            // ── Ollama warm-up(僅當 default_provider=ollama)─────
+            // qwen3:8b 5.2GB 在 Intel CPU 沒 GPU 加速首次載入可能要分鐘級。
+            // 啟動就背景發一個 1-token chat 觸發 model load,使用者第一次按
+            // 熱鍵時模型已熱。Groq 路徑直接 no-op。
+            tauri::async_runtime::spawn(async {
+                mori_core::llm::warm_up_default_provider().await;
+            });
+
             // ── 全域熱鍵:Ctrl+Alt+Space ───────────────────────────
             // Linux 走 xdg-desktop-portal GlobalShortcuts(Wayland 唯一可行
             // 的路);macOS / Windows 走 tauri-plugin-global-shortcut。

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -142,6 +142,32 @@ fn mori_phase() -> String {
     PHASE.to_string()
 }
 
+/// build SHA / dirty / 時間 / phase / version。值由 build.rs 在 compile
+/// time 經 cargo:rustc-env 注入,所以重 build 才會更新。前端用這個秀
+/// 在 status panel 上,user 一眼就能分辨「我跑的是哪個 build」。
+#[tauri::command]
+fn build_info() -> serde_json::Value {
+    serde_json::json!({
+        "sha": env!("MORI_GIT_SHA"),
+        "dirty": !env!("MORI_GIT_DIRTY").is_empty(),
+        "build_time": env!("MORI_BUILD_TIME"),
+        "phase": PHASE,
+        "version": VERSION,
+    })
+}
+
+/// 目前生效的 chat provider + model。讀 ~/.mori/config.json,跟
+/// build_chat_provider() 走同一條 fallback 路徑。前端拿來秀 status
+/// row,user 不用 grep config 就知道是 groq 還是 ollama。
+#[tauri::command]
+fn chat_provider_info() -> serde_json::Value {
+    let snap = mori_core::llm::active_chat_provider_snapshot();
+    serde_json::json!({
+        "name": snap.name,
+        "model": snap.model,
+    })
+}
+
 #[tauri::command]
 fn current_phase(state: tauri::State<Arc<AppState>>) -> Phase {
     state.phase.lock().clone()
@@ -896,6 +922,8 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             mori_version,
             mori_phase,
+            build_info,
+            chat_provider_info,
             current_phase,
             has_groq_key,
             toggle,
@@ -1015,8 +1043,33 @@ fn main() {
             // qwen3:8b 5.2GB 在 Intel CPU 沒 GPU 加速首次載入可能要分鐘級。
             // 啟動就背景發一個 1-token chat 觸發 model load,使用者第一次按
             // 熱鍵時模型已熱。Groq 路徑直接 no-op。
-            tauri::async_runtime::spawn(async {
-                mori_core::llm::warm_up_default_provider().await;
+            //
+            // 同時 emit `ollama-warmup` 事件讓 UI 顯示 loading → ready/failed,
+            // user 看得到 warm-up 真的在動,不是只記到 log。
+            let app_for_warmup = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                let snap = mori_core::llm::active_chat_provider_snapshot();
+                if snap.name != "ollama" {
+                    return;
+                }
+                let Some(base_url) = snap.base_url else {
+                    return;
+                };
+                let _ = app_for_warmup.emit("ollama-warmup", "loading");
+                match mori_core::llm::ollama::OllamaProvider::warm_up(
+                    &base_url,
+                    &snap.model,
+                )
+                .await
+                {
+                    Ok(_) => {
+                        let _ = app_for_warmup.emit("ollama-warmup", "ready");
+                    }
+                    Err(e) => {
+                        tracing::warn!(?e, "ollama warm-up failed");
+                        let _ = app_for_warmup.emit("ollama-warmup", "failed");
+                    }
+                }
             });
 
             // ── 全域熱鍵:Ctrl+Alt+Space ───────────────────────────

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -86,6 +86,11 @@ pub struct AppState {
     /// Phase 對應「使用者的這一輪對話進行到哪」,Mode 是「Mori 整體的工作狀態」,
     /// 兩者正交。Phase 變回 Idle 不會動 Mode。
     pub mode: Mutex<Mode>,
+    /// Ollama warm-up 狀態(僅當 default_provider=ollama 時有值):
+    /// "loading" | "ready" | "failed",其他 provider 為 None。
+    /// 存在 state 是因為 warm-up 可能在 React 還沒掛上 listener 前就完成,
+    /// 用 IPC 把當下狀態回給前端就不會錯過 transition。
+    pub ollama_warmup: Mutex<Option<&'static str>>,
 }
 
 impl AppState {
@@ -156,15 +161,21 @@ fn build_info() -> serde_json::Value {
     })
 }
 
-/// 目前生效的 chat provider + model。讀 ~/.mori/config.json,跟
-/// build_chat_provider() 走同一條 fallback 路徑。前端拿來秀 status
-/// row,user 不用 grep config 就知道是 groq 還是 ollama。
+/// 目前生效的 chat provider + model + Ollama warm-up 狀態。讀
+/// ~/.mori/config.json,跟 build_chat_provider() 走同一條 fallback。
+/// 前端拿來秀 status row,user 不用 grep config 就知道是 groq 還是 ollama。
+///
+/// `warmup` 從 AppState 取目前快照(loading/ready/failed/null),
+/// 解決 React listener 來不及訂閱就錯過 emit 的 race。後續 transition
+/// 仍走 `ollama-warmup` event。
 #[tauri::command]
-fn chat_provider_info() -> serde_json::Value {
+fn chat_provider_info(state: tauri::State<Arc<AppState>>) -> serde_json::Value {
     let snap = mori_core::llm::active_chat_provider_snapshot();
+    let warmup = *state.ollama_warmup.lock();
     serde_json::json!({
         "name": snap.name,
         "model": snap.model,
+        "warmup": warmup,
     })
 }
 
@@ -897,6 +908,7 @@ fn main() {
         memory,
         conversation: Mutex::new(Vec::new()),
         mode: Mutex::new(Mode::Active),
+        ollama_warmup: Mutex::new(None),
     });
 
     if let Some(key) = GroqProvider::discover_api_key() {
@@ -1044,9 +1056,13 @@ fn main() {
             // 啟動就背景發一個 1-token chat 觸發 model load,使用者第一次按
             // 熱鍵時模型已熱。Groq 路徑直接 no-op。
             //
-            // 同時 emit `ollama-warmup` 事件讓 UI 顯示 loading → ready/failed,
-            // user 看得到 warm-up 真的在動,不是只記到 log。
+            // 兩個地方記狀態:
+            // 1. AppState.ollama_warmup — 給後到的 React 訂閱者用
+            //   (model 已熱時 warm-up 1 秒就完成,React 還沒 listen 到時
+            //    event 已經 emit 過了)。
+            // 2. emit `ollama-warmup` event — 給已經訂閱的訂閱者收 transition。
             let app_for_warmup = app.handle().clone();
+            let state_for_warmup = state_for_setup.clone();
             tauri::async_runtime::spawn(async move {
                 let snap = mori_core::llm::active_chat_provider_snapshot();
                 if snap.name != "ollama" {
@@ -1055,6 +1071,7 @@ fn main() {
                 let Some(base_url) = snap.base_url else {
                     return;
                 };
+                *state_for_warmup.ollama_warmup.lock() = Some("loading");
                 let _ = app_for_warmup.emit("ollama-warmup", "loading");
                 match mori_core::llm::ollama::OllamaProvider::warm_up(
                     &base_url,
@@ -1063,10 +1080,12 @@ fn main() {
                 .await
                 {
                     Ok(_) => {
+                        *state_for_warmup.ollama_warmup.lock() = Some("ready");
                         let _ = app_for_warmup.emit("ollama-warmup", "ready");
                     }
                     Err(e) => {
                         tracing::warn!(?e, "ollama warm-up failed");
+                        *state_for_warmup.ollama_warmup.lock() = Some("failed");
                         let _ = app_for_warmup.emit("ollama-warmup", "failed");
                     }
                 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,8 +31,12 @@ type BuildInfo = {
   version: string;
 };
 
-type ChatProviderInfo = { name: string; model: string };
 type WarmupState = "loading" | "ready" | "failed";
+type ChatProviderInfo = {
+  name: string;
+  model: string;
+  warmup: WarmupState | null;
+};
 
 function App() {
   const [coreVersion, setCoreVersion] = useState<string>("");
@@ -61,7 +65,12 @@ function App() {
     invoke<Mode>("current_mode").then(setMode).catch(() => {});
     invoke<BuildInfo>("build_info").then(setBuildInfo).catch(() => setBuildInfo(null));
     invoke<ChatProviderInfo>("chat_provider_info")
-      .then(setChatProvider)
+      .then((info) => {
+        setChatProvider(info);
+        // 後到 race:warm-up 可能在 React mount 前就完成,event 已經 emit 過。
+        // 直接從 IPC 拿到的 snapshot 補一次,後續再靠 event 收 transition。
+        if (info.warmup) setWarmup(info.warmup);
+      })
       .catch(() => setChatProvider(null));
     refreshConvLength();
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,17 @@ type Phase =
 
 type Mode = "active" | "background";
 
+type BuildInfo = {
+  sha: string;
+  dirty: boolean;
+  build_time: string;
+  phase: string;
+  version: string;
+};
+
+type ChatProviderInfo = { name: string; model: string };
+type WarmupState = "loading" | "ready" | "failed";
+
 function App() {
   const [coreVersion, setCoreVersion] = useState<string>("");
   const [phaseLabel, setPhaseLabel] = useState<string>("");
@@ -32,6 +43,9 @@ function App() {
   const [audioLevel, setAudioLevel] = useState<number>(0);
   const [convLength, setConvLength] = useState<number>(0);
   const [mode, setMode] = useState<Mode>("active");
+  const [buildInfo, setBuildInfo] = useState<BuildInfo | null>(null);
+  const [chatProvider, setChatProvider] = useState<ChatProviderInfo | null>(null);
+  const [warmup, setWarmup] = useState<WarmupState | null>(null);
 
   const refreshConvLength = () => {
     invoke<number>("conversation_length")
@@ -45,6 +59,10 @@ function App() {
     invoke<boolean>("has_groq_key").then(setHasKey).catch(() => setHasKey(false));
     invoke<Phase>("current_phase").then(setPhase).catch(() => {});
     invoke<Mode>("current_mode").then(setMode).catch(() => {});
+    invoke<BuildInfo>("build_info").then(setBuildInfo).catch(() => setBuildInfo(null));
+    invoke<ChatProviderInfo>("chat_provider_info")
+      .then(setChatProvider)
+      .catch(() => setChatProvider(null));
     refreshConvLength();
 
     const unlistenPhase = listen<Phase>("phase-changed", (event) => {
@@ -89,12 +107,18 @@ function App() {
     const unlistenMode = listen<Mode>("mode-changed", (event) => {
       setMode(event.payload);
     });
+    // Phase 5A-1 hot-fix:啟動時若 default_provider=ollama,Tauri 會跑 warm-up
+    // 並 emit 這個事件,UI 顯示「載入中 → 就緒/失敗」讓 user 看到 warm-up 真的有在動
+    const unlistenWarmup = listen<WarmupState>("ollama-warmup", (event) => {
+      setWarmup(event.payload);
+    });
     return () => {
       unlistenPhase.then((f) => f());
       unlistenLevel.then((f) => f());
       unlistenRetry.then((f) => f());
       unlistenContext.then((f) => f());
       unlistenMode.then((f) => f());
+      unlistenWarmup.then((f) => f());
     };
   }, []);
 
@@ -360,15 +384,71 @@ function App() {
           <span className="value">{phaseLabel || "..."}</span>
         </div>
         <div className="status-row">
+          <span className="label">build</span>
+          <span
+            className="value"
+            title={
+              buildInfo
+                ? `built ${buildInfo.build_time}${buildInfo.dirty ? " · 含未提交變更" : ""}`
+                : undefined
+            }
+          >
+            {buildInfo
+              ? `${buildInfo.sha}${buildInfo.dirty ? "*" : ""} · ${buildInfo.build_time}`
+              : "..."}
+          </span>
+        </div>
+        <div className="status-row">
           <span className="label">mode</span>
           <span className={`value ${mode === "background" ? "warn" : "ok"}`}>
             {mode === "background" ? "💤 休眠" : "🟢 清醒"}
           </span>
         </div>
         <div className="status-row">
-          <span className="label">groq</span>
-          <span className={`value ${hasKey ? "ok" : "warn"}`}>
-            {hasKey === null ? "..." : hasKey ? "ready" : "no key"}
+          <span className="label">chat</span>
+          <span
+            className={`value ${
+              chatProvider?.name === "groq"
+                ? hasKey
+                  ? "ok"
+                  : "warn"
+                : warmup === "ready"
+                ? "ok"
+                : warmup === "failed"
+                ? "warn"
+                : ""
+            }`}
+            title={
+              chatProvider?.name === "groq"
+                ? hasKey
+                  ? "Groq API key 已就緒"
+                  : "沒設 GROQ_API_KEY"
+                : warmup === "ready"
+                ? "Ollama 模型已載入,首次 chat 應該秒回"
+                : warmup === "loading"
+                ? "Ollama 正在把模型載進 RAM,完成後才不會 cold-start timeout"
+                : warmup === "failed"
+                ? "Ollama warm-up 失敗 — daemon 沒跑?model 沒下載?"
+                : undefined
+            }
+          >
+            {chatProvider
+              ? `${chatProvider.name} · ${chatProvider.model}${
+                  chatProvider.name === "ollama"
+                    ? warmup === "loading"
+                      ? " · 🔄 載入中"
+                      : warmup === "ready"
+                      ? " · ✅ 就緒"
+                      : warmup === "failed"
+                      ? " · ⚠️ 失敗"
+                      : ""
+                    : hasKey === null
+                    ? ""
+                    : hasKey
+                    ? " · ready"
+                    : " · no key"
+                }`
+              : "..."}
           </span>
         </div>
         <div className="status-row">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,8 @@ function App() {
   const [buildInfo, setBuildInfo] = useState<BuildInfo | null>(null);
   const [chatProvider, setChatProvider] = useState<ChatProviderInfo | null>(null);
   const [warmup, setWarmup] = useState<WarmupState | null>(null);
+  const [warmupStartedAt, setWarmupStartedAt] = useState<number | null>(null);
+  const [warmupElapsed, setWarmupElapsed] = useState<number>(0);
 
   const refreshConvLength = () => {
     invoke<number>("conversation_length")
@@ -69,7 +71,11 @@ function App() {
         setChatProvider(info);
         // 後到 race:warm-up 可能在 React mount 前就完成,event 已經 emit 過。
         // 直接從 IPC 拿到的 snapshot 補一次,後續再靠 event 收 transition。
-        if (info.warmup) setWarmup(info.warmup);
+        if (info.warmup) {
+          setWarmup(info.warmup);
+          // mount 時就在 loading → 開始計時(approximate;不知道實際 start)
+          if (info.warmup === "loading") setWarmupStartedAt(Date.now());
+        }
       })
       .catch(() => setChatProvider(null));
     refreshConvLength();
@@ -120,6 +126,12 @@ function App() {
     // 並 emit 這個事件,UI 顯示「載入中 → 就緒/失敗」讓 user 看到 warm-up 真的有在動
     const unlistenWarmup = listen<WarmupState>("ollama-warmup", (event) => {
       setWarmup(event.payload);
+      // 進 loading 時開始計時;結束時(ready/failed)凍結 elapsed 但保留顯示
+      if (event.payload === "loading") {
+        setWarmupStartedAt(Date.now());
+      } else {
+        setWarmupStartedAt(null);
+      }
     });
     return () => {
       unlistenPhase.then((f) => f());
@@ -141,6 +153,18 @@ function App() {
     const id = setInterval(tick, 250);
     return () => clearInterval(id);
   }, [phase]);
+
+  // Warm-up elapsed timer — user 看得到 loading 已經幾秒,判斷是真在動還是 stuck
+  useEffect(() => {
+    if (warmupStartedAt === null) {
+      setWarmupElapsed(0);
+      return;
+    }
+    const tick = () => setWarmupElapsed(Math.floor((Date.now() - warmupStartedAt) / 1000));
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [warmupStartedAt]);
 
   // Esc 取消錄音(只在主視窗 focused 時生效;global cancel 之後可走 portal)。
   useEffect(() => {
@@ -445,7 +469,7 @@ function App() {
               ? `${chatProvider.name} · ${chatProvider.model}${
                   chatProvider.name === "ollama"
                     ? warmup === "loading"
-                      ? " · 🔄 載入中"
+                      ? ` · 🔄 載入中 ${warmupElapsed}s`
                       : warmup === "ready"
                       ? " · ✅ 就緒"
                       : warmup === "failed"


### PR DESCRIPTION
## Summary
- Bump `OllamaProvider` reqwest client timeout 120s → 300s. The 120s default fired on cold start because qwen3:8b (5.2GB) on Intel CPU + qwen3 default thinking-mode prefill of our ~3-4K-token system prompt takes longer than 120s on first call.
- New `mori_core::llm::warm_up_default_provider()`. Tauri spawns it as a background task during `setup()`. If `default_provider == "ollama"` it fires a 1-token chat against the configured base_url/model so the model is resident in RAM before the user's first hotkey press. Groq path is a no-op; warm-up failures (daemon down, model missing) log at debug only — the real chat call still surfaces a normal error to the user.

## Why
On Acer (Intel 155H, no GPU offload), 5A-1 timed out at exactly 120s with `operation timed out` against `localhost:11434/v1/chat/completions`. Fix the client timeout AND eliminate the cold start being the user-visible first-call delay.

## Test plan
- [ ] `cargo test -p mori-core --lib llm::` (16 tests, was passing, should still pass)
- [ ] On Acer with `default_provider=ollama`: launch Mori → check logs for `ollama warm-up dispatched` shortly after startup → wait until Ollama settles → press hotkey, talk → first chat should now respond in seconds, not time out
- [ ] On Acer with `default_provider=groq` (or unset): launch Mori → confirm warm-up is a no-op (no Ollama log lines)
- [ ] Force a misconfig: set `providers.ollama.base_url` to a wrong port → startup should still succeed; warm-up logs at debug only

🤖 Generated with [Claude Code](https://claude.com/claude-code)