### PR TITLE
feat(phase-5A-3a): per-skill provider routing

### DIFF
--- a/crates/mori-core/src/llm/claude_cli.rs
+++ b/crates/mori-core/src/llm/claude_cli.rs
@@ -105,6 +105,10 @@ impl LlmProvider for ClaudeCliProvider {
         self.model.as_deref().unwrap_or("(claude-cli default)")
     }
 
+    fn supports_tool_calling(&self) -> bool {
+        false
+    }
+
     async fn chat(
         &self,
         messages: Vec<ChatMessage>,

--- a/crates/mori-core/src/llm/groq.rs
+++ b/crates/mori-core/src/llm/groq.rs
@@ -266,6 +266,28 @@ impl GroqProvider {
                 //         "claude-cli"(本機 claude CLI subprocess,**chat-only**,
                 //                       不能當主 agent provider — 沒 tool calling)
                 "default_provider": "groq",
+                // 5A-3:per-skill provider routing(可選)。沒設這塊就全部
+                // 用 default_provider — 跟 5A-2 之前一樣。
+                //
+                // 用法:agent 指主 agent loop 走的 provider(必須能 tool calling
+                // — 不要用 claude-cli);skills.<name> 指該 skill 內部 chat
+                // 走的 provider,沒列到的 skill 退回 agent。
+                //
+                // 範例:agent 走 Groq tool dispatch、translate/polish/summarize
+                // 走 user 自己的 Claude Pro/Max quota,compose 走本機 ollama:
+                //   "routing": {
+                //     "agent": "groq",
+                //     "skills": {
+                //       "translate": "claude-cli",
+                //       "polish":    "claude-cli",
+                //       "summarize": "claude-cli",
+                //       "compose":   "ollama"
+                //     }
+                //   }
+                "routing": {
+                    "agent": null,
+                    "skills": {}
+                },
                 "providers": {
                     "groq": {
                         "api_key": "REPLACE_ME_WITH_YOUR_GROQ_API_KEY",

--- a/crates/mori-core/src/llm/mod.rs
+++ b/crates/mori-core/src/llm/mod.rs
@@ -27,24 +27,19 @@ mod openai_compat;
 // 欄位,構造對應 LlmProvider 回傳。Groq / Ollama 走不同 default。
 // retry_callback 只對 Groq 有意義(Ollama 本機沒 rate limit)。
 
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-/// 從 `~/.mori/config.json` 蓋出 chat provider。
-/// 配置:
-/// - `default_provider`: "groq"(預設) | "ollama"
-/// - `providers.groq.{api_key, chat_model}`
-/// - `providers.ollama.{base_url, model}`
+/// 由名字蓋一個 LlmProvider。`name` 是 config 裡的 provider key
+/// ("groq" / "ollama" / "claude-cli")。retry_cb 只在 Groq 用上,其他 ignore。
 ///
-/// retry_callback 只在 Groq 路徑套用(Ollama 本機沒 rate-limit)。
-pub fn build_chat_provider(
+/// 不知道的 name 會回 Err,讓呼叫端能看到錯字 — 不像 `build_chat_provider`
+/// 把未知值 silently fallback 到 groq。Routing 路徑要嚴一點。
+pub fn build_named_provider(
+    name: &str,
     retry_cb: Option<groq::RetryCallback>,
 ) -> anyhow::Result<Arc<dyn LlmProvider>> {
-    let default = mori_config_path()
-        .as_deref()
-        .and_then(|p| groq::read_json_pointer(p, "/default_provider"))
-        .unwrap_or_else(|| "groq".to_string());
-
-    match default.as_str() {
+    match name {
         "ollama" => {
             let base_url = mori_config_path()
                 .as_deref()
@@ -54,7 +49,6 @@ pub fn build_chat_provider(
                 .as_deref()
                 .and_then(|p| groq::read_json_pointer(p, "/providers/ollama/model"))
                 .unwrap_or_else(|| ollama::OllamaProvider::DEFAULT_MODEL.to_string());
-            tracing::info!(provider = "ollama", model = %model, base_url = %base_url, "chat provider selected");
             Ok(Arc::new(ollama::OllamaProvider::new(base_url, model)))
         }
         "claude-cli" => {
@@ -65,34 +59,18 @@ pub fn build_chat_provider(
             let model = mori_config_path()
                 .as_deref()
                 .and_then(|p| groq::read_json_pointer(p, "/providers/claude-cli/model"));
-            tracing::info!(
-                provider = "claude-cli",
-                model = ?model,
-                binary = %binary,
-                "chat provider selected — note: chat-only, no tool calling. \
-                 Use only for skill-internal chat, not main agent dispatch."
-            );
             Ok(Arc::new(claude_cli::ClaudeCliProvider::new(binary, model)))
         }
-        other => {
-            if other != "groq" {
-                tracing::warn!(
-                    provider = other,
-                    "unknown default_provider — falling back to 'groq'",
-                );
-            }
+        "groq" => {
             let key = groq::GroqProvider::discover_api_key().ok_or_else(|| {
                 anyhow::anyhow!(
-                    "no GROQ_API_KEY configured. Edit ~/.mori/config.json or set $GROQ_API_KEY \
-                     (or set default_provider to 'ollama' / 'claude-cli' if you want to use \
-                      a local provider)"
+                    "no GROQ_API_KEY configured. Edit ~/.mori/config.json or set $GROQ_API_KEY"
                 )
             })?;
             let model = mori_config_path()
                 .as_deref()
                 .and_then(|p| groq::read_json_pointer(p, "/providers/groq/chat_model"))
                 .unwrap_or_else(|| groq::GroqProvider::DEFAULT_CHAT_MODEL.to_string());
-            tracing::info!(provider = "groq", model = %model, "chat provider selected");
             let p = groq::GroqProvider::new(key, model);
             let p = if let Some(cb) = retry_cb {
                 p.with_retry_callback(cb)
@@ -101,8 +79,283 @@ pub fn build_chat_provider(
             };
             Ok(Arc::new(p))
         }
+        other => anyhow::bail!(
+            "unknown provider name '{}' — supported: groq, ollama, claude-cli",
+            other
+        ),
     }
 }
+
+/// 從 `~/.mori/config.json` 蓋出**主 chat provider**。配置:
+/// - `default_provider`: "groq"(預設) | "ollama" | "claude-cli"
+/// - `providers.<name>.<...>` 各 provider 細節
+///
+/// 未知 default_provider 會 silently fallback 到 groq + warn(舊行為,
+/// 不破壞既有 user)。retry_callback 只在 Groq 路徑套用。
+///
+/// **Note**:5A-3 起若有 `routing` 區塊,主 agent 應該用 [`Routing`]
+/// 而不是這個函式;這個只給沒設 routing 的舊路徑用。
+pub fn build_chat_provider(
+    retry_cb: Option<groq::RetryCallback>,
+) -> anyhow::Result<Arc<dyn LlmProvider>> {
+    let default = read_default_provider();
+    let resolved = match default.as_str() {
+        "groq" | "ollama" | "claude-cli" => default.as_str(),
+        other => {
+            tracing::warn!(
+                provider = other,
+                "unknown default_provider — falling back to 'groq'",
+            );
+            "groq"
+        }
+    };
+    let p = build_named_provider(resolved, retry_cb)?;
+    tracing::info!(provider = %p.name(), model = %p.model(), "chat provider selected");
+    Ok(p)
+}
+
+/// 5A-3:per-skill provider routing。Mori agent loop 跟每個 skill 內部
+/// chat 都可以指定不同 provider,用來:
+/// - 讓 agent 走 Groq tool-calling(快、會 dispatch tool),skill 內部
+///   推理走 Claude CLI(quota 用 user 自己的 Pro/Max)或 Ollama(本機免錢)
+/// - 之後加 fallback chain(5A-3b)時也以這個結構為基礎
+///
+/// 沒有 `routing` block 的 config 會退化成全部用 `default_provider`,
+/// 跟 5A-2 之前的行為一致。
+pub struct Routing {
+    /// 主 agent loop 的 provider。**必須** supports_tool_calling,否則
+    /// skill dispatch 會失效(只會拿到純文字 fallback)— build 時若
+    /// 不支援會 warn 但不 fail。
+    pub agent: Arc<dyn LlmProvider>,
+    /// Skill 名字 → provider 的 override map。Map 沒列到的 skill 用
+    /// `agent` 當 fallback。
+    pub skills: HashMap<String, Arc<dyn LlmProvider>>,
+}
+
+impl Routing {
+    /// 取 skill `name` 該用的 provider — 先看 override 再 fallback 到 agent。
+    pub fn skill_provider(&self, name: &str) -> Arc<dyn LlmProvider> {
+        self.skills
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| self.agent.clone())
+    }
+
+    /// 從 `~/.mori/config.json` 的 `routing` block 蓋出整套 routing。
+    ///
+    /// retry_cb 只會 attach 到構造出的 Groq 實例 — 即便 routing 用了多個
+    /// provider,Groq 那個會收到 callback,其他不會。
+    pub fn build_from_config(
+        retry_cb: Option<groq::RetryCallback>,
+    ) -> anyhow::Result<Self> {
+        let default = read_default_provider();
+        let cfg = read_routing_config();
+
+        let agent_name = cfg
+            .agent
+            .clone()
+            .unwrap_or_else(|| default.clone());
+
+        // 收集所有需要構造的 provider names — agent + 所有 skill override values
+        let mut needed: HashSet<String> = HashSet::new();
+        needed.insert(agent_name.clone());
+        for v in cfg.skills.values() {
+            needed.insert(v.clone());
+        }
+
+        // 蓋出每個 unique provider。retry_cb 只發給 groq;其他 None。
+        let mut built: HashMap<String, Arc<dyn LlmProvider>> = HashMap::new();
+        for name in &needed {
+            let cb = if name == "groq" { retry_cb.clone() } else { None };
+            let p = build_named_provider(name, cb)
+                .with_context(|| format!("build provider '{}'", name))?;
+            built.insert(name.clone(), p);
+        }
+
+        let agent = built
+            .get(&agent_name)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("agent provider '{}' not built", agent_name))?;
+
+        if !agent.supports_tool_calling() {
+            tracing::warn!(
+                agent = %agent_name,
+                "configured agent provider does not support tool calling — \
+                 main agent loop will get text-only fallback responses, skill \
+                 dispatch will not fire. Use 'groq' or 'ollama' for agent, \
+                 keep chat-only providers (claude-cli) for skill overrides."
+            );
+        }
+
+        let skills: HashMap<String, Arc<dyn LlmProvider>> = cfg
+            .skills
+            .iter()
+            .filter_map(|(skill_name, provider_name)| {
+                built
+                    .get(provider_name)
+                    .map(|p| (skill_name.clone(), p.clone()))
+            })
+            .collect();
+
+        tracing::info!(
+            agent = %agent_name,
+            agent_model = %agent.model(),
+            agent_tools = agent.supports_tool_calling(),
+            skill_overrides = ?cfg.skills,
+            "routing built"
+        );
+
+        Ok(Self { agent, skills })
+    }
+}
+
+/// `routing` block 解析快照 — 結構簡單,純 String 對應。給 IPC / log /
+/// `Routing::build_from_config` 用。
+#[derive(Default, Debug, Clone)]
+pub struct RoutingConfig {
+    /// `routing.agent`(可選),沒設就退化成 `default_provider`
+    pub agent: Option<String>,
+    /// `routing.skills` 的 skill→provider 對應表
+    pub skills: HashMap<String, String>,
+}
+
+fn read_default_provider() -> String {
+    mori_config_path()
+        .as_deref()
+        .and_then(|p| groq::read_json_pointer(p, "/default_provider"))
+        .unwrap_or_else(|| "groq".to_string())
+}
+
+/// 讀 `routing.agent` + `routing.skills` 子物件。沒檔案 / 沒 routing /
+/// 解析失敗都回 default(空 routing,等於沿用 default_provider 行為)。
+pub fn read_routing_config() -> RoutingConfig {
+    match mori_config_path() {
+        Some(path) => read_routing_config_at(&path),
+        None => RoutingConfig::default(),
+    }
+}
+
+/// 純函式版本(可測):從指定 path 讀 routing block。
+pub fn read_routing_config_at(path: &std::path::Path) -> RoutingConfig {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return RoutingConfig::default();
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return RoutingConfig::default();
+    };
+
+    let agent = json
+        .pointer("/routing/agent")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let skills: HashMap<String, String> = json
+        .pointer("/routing/skills")
+        .and_then(|v| v.as_object())
+        .map(|map| {
+            map.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    RoutingConfig { agent, skills }
+}
+
+#[cfg(test)]
+mod routing_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn write_config(json: &str) -> tempfile::TempDir {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("config.json"), json).unwrap();
+        dir
+    }
+
+    #[test]
+    fn nonexistent_file_returns_default() {
+        let dir = tempdir().unwrap();
+        let cfg = read_routing_config_at(&dir.path().join("nope.json"));
+        assert!(cfg.agent.is_none());
+        assert!(cfg.skills.is_empty());
+    }
+
+    #[test]
+    fn malformed_json_returns_default() {
+        let dir = write_config("{ invalid json");
+        let cfg = read_routing_config_at(&dir.path().join("config.json"));
+        assert!(cfg.agent.is_none());
+        assert!(cfg.skills.is_empty());
+    }
+
+    #[test]
+    fn missing_routing_block_returns_default() {
+        let dir = write_config(r#"{"default_provider":"groq"}"#);
+        let cfg = read_routing_config_at(&dir.path().join("config.json"));
+        assert!(cfg.agent.is_none());
+        assert!(cfg.skills.is_empty());
+    }
+
+    #[test]
+    fn agent_only_no_skills() {
+        let dir = write_config(r#"{"routing":{"agent":"ollama"}}"#);
+        let cfg = read_routing_config_at(&dir.path().join("config.json"));
+        assert_eq!(cfg.agent.as_deref(), Some("ollama"));
+        assert!(cfg.skills.is_empty());
+    }
+
+    #[test]
+    fn skills_only_no_agent() {
+        let dir = write_config(
+            r#"{"routing":{"skills":{"translate":"claude-cli","polish":"ollama"}}}"#,
+        );
+        let cfg = read_routing_config_at(&dir.path().join("config.json"));
+        assert!(cfg.agent.is_none());
+        assert_eq!(cfg.skills.len(), 2);
+        assert_eq!(cfg.skills.get("translate").map(String::as_str), Some("claude-cli"));
+        assert_eq!(cfg.skills.get("polish").map(String::as_str), Some("ollama"));
+    }
+
+    #[test]
+    fn null_agent_treated_as_unset() {
+        let dir = write_config(r#"{"routing":{"agent":null,"skills":{}}}"#);
+        let cfg = read_routing_config_at(&dir.path().join("config.json"));
+        assert!(cfg.agent.is_none());
+    }
+
+    #[test]
+    fn full_routing_block() {
+        let dir = write_config(
+            r#"{
+                "default_provider":"groq",
+                "routing":{
+                    "agent":"groq",
+                    "skills":{
+                        "translate":"claude-cli",
+                        "polish":"claude-cli",
+                        "summarize":"ollama"
+                    }
+                }
+            }"#,
+        );
+        let cfg = read_routing_config_at(&dir.path().join("config.json"));
+        assert_eq!(cfg.agent.as_deref(), Some("groq"));
+        assert_eq!(cfg.skills.len(), 3);
+    }
+
+    #[test]
+    fn non_string_skill_value_filtered_out() {
+        // 例如 user 誤打成 number — 不該炸,只 skip 那個 key
+        let dir = write_config(r#"{"routing":{"skills":{"a":"groq","b":42}}}"#);
+        let cfg = read_routing_config_at(&dir.path().join("config.json"));
+        assert_eq!(cfg.skills.len(), 1);
+        assert!(cfg.skills.contains_key("a"));
+        assert!(!cfg.skills.contains_key("b"));
+    }
+}
+
+use anyhow::Context as _;
 
 /// 目前生效的 chat provider 設定快照。給 UI / IPC / warm-up 用,
 /// 避免各處重複讀 config + 各自落 fallback。
@@ -115,12 +368,12 @@ pub struct ProviderSnapshot {
 }
 
 pub fn active_chat_provider_snapshot() -> ProviderSnapshot {
-    let default = mori_config_path()
-        .as_deref()
-        .and_then(|p| groq::read_json_pointer(p, "/default_provider"))
-        .unwrap_or_else(|| "groq".to_string());
+    // 5A-3 起:agent 走 `routing.agent`(若設)→ `default_provider`(若設)→ "groq"
+    let routing = read_routing_config();
+    let default = read_default_provider();
+    let active = routing.agent.unwrap_or_else(|| default.clone());
 
-    match default.as_str() {
+    match active.as_str() {
         "ollama" => {
             let base_url = mori_config_path()
                 .as_deref()
@@ -283,6 +536,15 @@ pub trait LlmProvider: Send + Sync {
 
     /// 模型 id
     fn model(&self) -> &str;
+
+    /// 這個 provider 是否能 dispatch tool calls。
+    /// `true`(default):可以當主 agent loop 的 provider。
+    /// `false`:只能拿來做 skill 內部 chat — 例如 Claude CLI 沒有 OpenAI 風格
+    /// 的 function-calling channel。Routing 在挑 agent provider 時會檢查這個
+    /// 旗標,若使用者誤把 chat-only provider 配給 agent 會 warn(或 fail)。
+    fn supports_tool_calling(&self) -> bool {
+        true
+    }
 
     /// 跑一輪 chat completion。
     async fn chat(

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -161,21 +161,26 @@ fn build_info() -> serde_json::Value {
     })
 }
 
-/// 目前生效的 chat provider + model + Ollama warm-up 狀態。讀
-/// ~/.mori/config.json,跟 build_chat_provider() 走同一條 fallback。
-/// 前端拿來秀 status row,user 不用 grep config 就知道是 groq 還是 ollama。
+/// 目前生效的 chat provider + model + Ollama warm-up 狀態 + 5A-3 routing
+/// overrides。讀 ~/.mori/config.json,跟 Routing::build_from_config 走同一條
+/// fallback。前端拿來秀 status row + tooltip 顯示 skill 級別的路由。
 ///
-/// `warmup` 從 AppState 取目前快照(loading/ready/failed/null),
-/// 解決 React listener 來不及訂閱就錯過 emit 的 race。後續 transition
-/// 仍走 `ollama-warmup` event。
+/// `warmup` 從 AppState 取目前快照(loading/ready/failed/null),解決 React
+/// listener 來不及訂閱就錯過 emit 的 race。後續 transition 仍走
+/// `ollama-warmup` event。
+///
+/// `skill_overrides` 是 routing.skills 的原始 mapping(skill name → provider name)。
+/// 沒設 routing 就回空物件,等於「全部用 agent」。
 #[tauri::command]
 fn chat_provider_info(state: tauri::State<Arc<AppState>>) -> serde_json::Value {
     let snap = mori_core::llm::active_chat_provider_snapshot();
+    let routing = mori_core::llm::read_routing_config();
     let warmup = *state.ollama_warmup.lock();
     serde_json::json!({
         "name": snap.name,
         "model": snap.model,
         "warmup": warmup,
+        "skill_overrides": routing.skills,
     })
 }
 
@@ -272,11 +277,12 @@ fn submit_text(app: AppHandle, state: tauri::State<Arc<AppState>>, text: String)
         }
     }
 
-    // Phase 5A-1: chat provider 走 config-driven factory
-    // (default_provider="groq" / "ollama"),retry callback 只對 Groq 有意義
-    // 也透傳進 factory(內部會 ignore 給 Ollama)。
-    let provider = match mori_core::llm::build_chat_provider(Some(retry_callback_for(app.clone()))) {
-        Ok(p) => p,
+    // Phase 5A-3: routing 拆出 agent provider + per-skill provider override。
+    // Agent 走 `routing.agent`(可走 tool calling 的:groq / ollama);個別 skill
+    // 可在 `routing.skills.<name>` 指到 chat-only provider(claude-cli)用 user
+    // 自己的 quota。沒設 routing 時整套退化成全部用 default_provider。
+    let routing = match mori_core::llm::Routing::build_from_config(Some(retry_callback_for(app.clone()))) {
+        Ok(r) => r,
         Err(e) => {
             state.set_phase(
                 &app,
@@ -287,10 +293,11 @@ fn submit_text(app: AppHandle, state: tauri::State<Arc<AppState>>, text: String)
             return;
         }
     };
+    let routing = Arc::new(routing);
 
     let state_clone = state.inner().clone();
     tauri::async_runtime::spawn(async move {
-        run_chat_pipeline(app, state_clone, text, provider).await;
+        run_chat_pipeline(app, state_clone, text, routing).await;
     });
 }
 
@@ -479,12 +486,11 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
             }
         };
 
-        // Stage 2: chat provider 走 config-driven factory(可能 Groq、可能
-        // Ollama,phase 5A-2 後也可能 Claude CLI)。STT 跟 chat 解耦了,語音
-        // 一定走 Groq Whisper,但接 chat 那輪可以 free-pick。
-        let provider_arc =
-            match mori_core::llm::build_chat_provider(Some(retry_callback_for(app.clone()))) {
-                Ok(p) => p,
+        // Stage 2: routing 拆 agent + per-skill provider(5A-3)。STT 一定走 Groq
+        // Whisper(stage 1),但 chat 跟 skill 各自的 provider 由 routing 決定。
+        let routing =
+            match mori_core::llm::Routing::build_from_config(Some(retry_callback_for(app.clone()))) {
+                Ok(r) => Arc::new(r),
                 Err(e) => {
                     state.set_phase(
                         &app,
@@ -495,7 +501,7 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
                     return;
                 }
             };
-        run_chat_pipeline(app, state, transcript, provider_arc).await;
+        run_chat_pipeline(app, state, transcript, routing).await;
     });
 }
 
@@ -509,7 +515,7 @@ async fn run_chat_pipeline(
     app: AppHandle,
     state: Arc<AppState>,
     transcript: String,
-    provider: Arc<dyn LlmProvider>,
+    routing: Arc<mori_core::llm::Routing>,
 ) {
     state.set_phase(
         &app,
@@ -553,11 +559,12 @@ async fn run_chat_pipeline(
         registry.register(Arc::new(RecallMemorySkill::new(memory_for_skills.clone())));
         registry.register(Arc::new(ForgetMemorySkill::new(memory_for_skills.clone())));
         registry.register(Arc::new(EditMemorySkill::new(memory_for_skills.clone())));
-        // Text skills(phase 2)
-        registry.register(Arc::new(TranslateSkill::new(provider.clone())));
-        registry.register(Arc::new(PolishSkill::new(provider.clone())));
-        registry.register(Arc::new(SummarizeSkill::new(provider.clone())));
-        registry.register(Arc::new(ComposeSkill::new(provider.clone())));
+        // Text skills(phase 2)— 5A-3 起每個 skill 走自己的 routing override,
+        // 沒設 override 就 fallback 到 routing.agent。
+        registry.register(Arc::new(TranslateSkill::new(routing.skill_provider("translate"))));
+        registry.register(Arc::new(PolishSkill::new(routing.skill_provider("polish"))));
+        registry.register(Arc::new(SummarizeSkill::new(routing.skill_provider("summarize"))));
+        registry.register(Arc::new(ComposeSkill::new(routing.skill_provider("compose"))));
         // Mode 控制 skill(phase 4B-2):「晚安」/「醒醒」走這條
         let mode_controller: Arc<dyn ModeController> = Arc::new(StateModeController {
             state: state.clone(),
@@ -575,7 +582,7 @@ async fn run_chat_pipeline(
         }
         let registry = Arc::new(registry);
 
-        let agent = Agent::new(provider, registry);
+        let agent = Agent::new(routing.agent.clone(), registry);
         let turn = agent
             .respond(&system_prompt, &history_snapshot, &transcript, &ctx)
             .await?;


### PR DESCRIPTION
## Summary
Splits the single \"chat provider\" into agent + per-skill providers. Users can now route the agent loop and individual text skills to different LLMs:

```json
{
  \"routing\": {
    \"agent\": \"groq\",
    \"skills\": {
      \"translate\": \"claude-cli\",
      \"polish\":    \"claude-cli\",
      \"summarize\": \"claude-cli\",
      \"compose\":   \"ollama\"
    }
  }
}
```

Use cases:
- Agent stays on Groq (fast, tool-calling) so skill dispatch keeps working
- Translation/polish lean on user's Claude Pro/Max quota instead of Groq TPD
- Compose runs free on local Ollama

Without `routing` in config, behavior is identical to 5A-2 — everything uses `default_provider`.

## Key changes
- `LlmProvider::supports_tool_calling()` — defaults true; `ClaudeCliProvider` overrides false. Routing warns when an agent provider can't tool-call but doesn't fail (lets the user test).
- `build_named_provider(name, retry_cb)` — refactored core builder. Unknown names now fail loudly here (vs old silent groq fallback in `build_chat_provider`, which is preserved for the no-routing path).
- `Routing { agent, skills }` + `skill_provider(name)` fallback. Builds each unique provider exactly once per chat invocation and shares via Arc; retry callback only attaches to Groq.
- `chat_provider_info` IPC adds `skill_overrides` map (UI surfacing deferred — no React change here).
- Bootstrap config writes a `routing: {agent: null, skills: {}}` template so the shape is visible to new users.

## Tests
- 8 new unit tests for routing config parsing (missing file / malformed JSON / null agent / etc.)
- All 31 mori-core tests pass

## Out of scope (5A-3b — separate PR)
Auto-fallback chain on 429/TPD/unavailable. Routing struct is designed to extend without breaks.

## Test plan
- [x] cargo test — 31 unit + 2 ignored integration tests pass
- [ ] On Acer: leave config without routing block → behavior unchanged from 5A-2
- [ ] Add `routing.skills.translate = \"claude-cli\"`, restart Mori, speak \"翻譯這句:hello\" → translate skill calls Claude CLI, agent dispatch still works
- [ ] Set `routing.agent = \"claude-cli\"` (intentional misuse) → log shows the warning, skills don't dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)