### PR TITLE
feat(phase-5E): voice-input mode — Mori as LLM-powered dictation

### DIFF
--- a/crates/mori-core/src/lib.rs
+++ b/crates/mori-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod mode;
 pub mod paste;
 pub mod runtime;
 pub mod skill;
+pub mod voice_cleanup;
 
 /// crate 版本(供 UI 顯示)
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/mori-core/src/llm/groq.rs
+++ b/crates/mori-core/src/llm/groq.rs
@@ -273,6 +273,13 @@ impl GroqProvider {
                 // 接受值:"groq"(預設,Whisper API)
                 //         "whisper-local"(whisper.cpp,需事先下載 ggml model)
                 "default_transcribe_provider": "groq",
+                // 5E:語音輸入模式(VoiceInput mode)的清理層級。
+                // - "smart"(預設):LLM 加標點 + 程式 post-process(簡→繁、半→全形)
+                // - "minimal":只跑程式 post-process,不過 LLM(快但無標點)
+                // - "none":raw Whisper 直貼
+                "voice_input": {
+                    "cleanup_level": "smart"
+                },
                 // 5A-3:per-skill provider routing(可選)。沒設這塊就全部
                 // 用 default_provider — 跟 5A-2 之前一樣。
                 //

--- a/crates/mori-core/src/mode.rs
+++ b/crates/mori-core/src/mode.rs
@@ -1,17 +1,21 @@
 //! Operating mode — orthogonal to the conversation phase.
 //!
-//! - `Active` — Mori is "here": floating UI visible, mic available for
-//!   the hotkey, scheduler running. The default and most-of-the-time
-//!   state.
-//! - `Background` — Mori 在休眠:mic completely off, UI hidden
-//!   except for the tray icon, scheduler still ticking. Privacy-first:
-//!   the user can be sure no microphone capture happens in this mode.
+//! - `Active` — Mori is "here":對話模式。floating UI visible, mic
+//!   available for the hotkey, scheduler running。熱鍵 → 錄音 → STT →
+//!   走 **agent loop**(LLM 決定 dispatch 哪個 skill,或直接回應)。
+//! - `VoiceInput` — 語音輸入模式(Phase 5E)。熱鍵 → 錄音 → STT → **跳過
+//!   agent loop**,走輕度 LLM cleanup(標點 / 幻聽修正,保留原詞)→ 用
+//!   `PasteController` 把結果直接貼到游標位置。把 Mori 變成一個 LLM
+//!   加持的 dictation 工具,適合在瀏覽器 / 編輯器裡聽寫長文。
+//! - `Background` — 休眠:mic completely off, UI hidden except for the
+//!   tray icon, scheduler still ticking. Privacy-first:the user can be
+//!   sure no microphone capture happens in this mode.
 //!
-//! Mode transitions are user-initiated (tray menu, hotkey from
-//! background to wake, voice command「晚安」/「醒醒」). The shell crate
-//! (mori-tauri) owns the actual state; mori-core just exposes the
-//! [`ModeController`] trait so a [`crate::skill::Skill`] can change
-//! mode without depending on Tauri.
+//! Mode transitions are user-initiated (tray menu, UI button, voice
+//! command「晚安」/「醒醒」). The shell crate (mori-tauri) owns the
+//! actual state; mori-core just exposes the [`ModeController`] trait
+//! so a [`crate::skill::Skill`] can change mode without depending on
+//! Tauri.
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -19,9 +23,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Mode {
-    /// 正常運作:UI 可見、麥克風待命、熱鍵可錄音。
+    /// 對話模式:熱鍵 → STT → agent loop → chat / skill dispatch。
     Active,
-    /// 休眠:UI 隱藏、麥克風完全關閉、排程繼續跑。
+    /// 語音輸入模式:熱鍵 → STT → 輕度清理 → 貼到游標位置(跳過 agent)。
+    VoiceInput,
+    /// 休眠:麥克風完全關閉。
     Background,
 }
 
@@ -29,8 +35,15 @@ impl Mode {
     pub fn as_str(&self) -> &'static str {
         match self {
             Mode::Active => "active",
+            Mode::VoiceInput => "voice_input",
             Mode::Background => "background",
         }
+    }
+
+    /// 麥克風能不能在這個 mode 下開。VoiceInput 跟 Active 一樣需要
+    /// 收音;Background 才硬關。
+    pub fn allows_mic(&self) -> bool {
+        matches!(self, Mode::Active | Mode::VoiceInput)
     }
 }
 

--- a/crates/mori-core/src/skill/set_mode.rs
+++ b/crates/mori-core/src/skill/set_mode.rs
@@ -1,12 +1,13 @@
-//! SetModeSkill — toggle Mori between Active and Background.
+//! SetModeSkill — toggle Mori between Active / VoiceInput / Background.
 //!
 //! Voice cues:
 //! - Background:「晚安」「先休眠」「安靜」「我先離開了」「下班了」
 //! - Active:    「醒醒」「起來」「回來」「在嗎」「我回來了」
+//! - VoiceInput:「切到輸入模式」「我要打字」「我要 dictation」
 //!
 //! Setting Background hard-stops the mic; the user can be sure no audio
-//! is captured. Setting Active does NOT auto-start recording — that's
-//! still a separate hotkey press.
+//! is captured. Setting Active or VoiceInput does NOT auto-start
+//! recording — that's still a separate hotkey press。
 
 use std::sync::Arc;
 
@@ -35,14 +36,13 @@ impl Skill for SetModeSkill {
     }
 
     fn description(&self) -> &'static str {
-        "Switch Mori between Active (mic ready, UI visible) and Background \
-         (mic OFF, UI hidden — privacy mode). Call when the user clearly \
-         signals they're done talking for now (e.g. '晚安','先休眠', \
-         '我去開會了','安靜一下') with mode='background', or wants \
-         Mori back (e.g. '醒醒','回來','我回來了','起來') with \
-         mode='active'. Don't call it for ambiguous statements — only \
-         when the user's intent is explicit. Setting 'active' does NOT \
-         start a recording — that's still a separate user action."
+        "Switch Mori between three modes:\n\
+         - 'active' — 對話模式(預設):熱鍵錄音 → STT → agent loop。\n\
+         - 'voice_input' — 語音輸入模式:熱鍵錄音 → STT → 輕度清理 → \
+           直接貼到游標位置(跳過 agent)。適合在編輯器/瀏覽器裡聽寫。\n\
+         - 'background' — 休眠:麥克風完全關閉(privacy)。\n\
+         Voice cues:'晚安' / '先休眠' → background;'醒醒' / '回來' → \
+         active;'切到輸入模式' / '我要 dictation' → voice_input。"
     }
 
     fn parameters_schema(&self) -> Value {
@@ -51,7 +51,7 @@ impl Skill for SetModeSkill {
             "properties": {
                 "mode": {
                     "type": "string",
-                    "enum": ["active", "background"],
+                    "enum": ["active", "voice_input", "background"],
                     "description": "Target operating mode."
                 }
             },
@@ -67,6 +67,7 @@ impl Skill for SetModeSkill {
 
         let target = match raw {
             "active" => Mode::Active,
+            "voice_input" => Mode::VoiceInput,
             "background" => Mode::Background,
             other => return Err(anyhow!("invalid mode: {other}")),
         };
@@ -76,6 +77,7 @@ impl Skill for SetModeSkill {
             return Ok(SkillOutput {
                 user_message: match target {
                     Mode::Active => "我醒著呢。".to_string(),
+                    Mode::VoiceInput => "已經在輸入模式了。".to_string(),
                     Mode::Background => "我已經在休眠了。".to_string(),
                 },
                 data: Some(serde_json::json!({
@@ -92,6 +94,7 @@ impl Skill for SetModeSkill {
 
         let user_message = match target {
             Mode::Active => "醒了,我在這。".to_string(),
+            Mode::VoiceInput => "切到輸入模式 — 接下來的話會直接貼到游標位置。".to_string(),
             Mode::Background => "好,我先閉眼,叫我就回來。".to_string(),
         };
 

--- a/crates/mori-core/src/voice_cleanup.rs
+++ b/crates/mori-core/src/voice_cleanup.rs
@@ -1,0 +1,305 @@
+//! Phase 5E voice-input 程式化後處理。
+//!
+//! 不管 LLM 有沒有先過一輪,whisper / LLM 出來的東西都需要這層守住格式
+//! 一致性 — 跨 provider / 跨 model 結果常飄(claude 可能輸出半形,qwen
+//! 可能漏標點,gpt-oss 可能加引號)。這層程式化規則做 **deterministic**
+//! 收尾。
+//!
+//! ## 三級 cleanup_level
+//! - `smart`(預設):LLM 加標點 + segmentation,**然後**過 [`programmatic_cleanup`]
+//!   收一致性。LLM 做 irreducible 智能,程式守格式。
+//! - `minimal`:跳過 LLM,只跑 [`programmatic_cleanup`]。最快(~ms 級),但
+//!   Whisper 不出標點所以結果會是「一長串字」, 適合「我自己後面加標點」型
+//!   user 或 quota 緊張時。
+//! - `none`:Whisper 出來的字直接 paste,跳所有 cleanup。
+//!
+//! ## `programmatic_cleanup` 做的事
+//! 1. **Strip Whisper 幻聽**:常見英文字幕殘骸(`thank you for watching` /
+//!    `subscribe` / `感謝觀看` / `請訂閱按讚`)直接拿掉
+//! 2. **半形 → 全形 punctuation**(只當左右鄰是 CJK 字才轉,否則保留 — 不
+//!    動英文標點)
+//! 3. **去掉 LLM 偶爾包整段的 `「」` / `""` 引號**(輸出純文字,不要它幫你
+//!    包)
+//! 4. **Normalize 空白**:trim、合併多重空白、刪空行
+//!
+//! ## 為什麼**沒**做 OpenCC 簡→繁
+//! whisper.cpp 我們已經用 `initial_prompt` 把它 bias 到繁體中文(看
+//! `whisper_local.rs` 的 prompt — 全用繁體用語),實測幾乎不會吐簡體字。
+//! LLM cleanup 也都是繁體優先。真的要保底再加 `opencc-rust` 系統依賴
+//! 不太划算。如果之後遇到 mixed-script 問題再回來補。
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CleanupLevel {
+    /// LLM 加標點 + 程式守格式(預設)
+    #[default]
+    Smart,
+    /// 只跑程式處理,跳 LLM
+    Minimal,
+    /// 完全不處理,raw whisper 直貼
+    None,
+}
+
+impl CleanupLevel {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CleanupLevel::Smart => "smart",
+            CleanupLevel::Minimal => "minimal",
+            CleanupLevel::None => "none",
+        }
+    }
+}
+
+/// 從 `~/.mori/config.json` 讀 `voice_input.cleanup_level`。沒設或解析
+/// 失敗都退到 `Smart`(預設)。
+pub fn read_cleanup_level() -> CleanupLevel {
+    let path = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .ok()
+        .map(|h| std::path::PathBuf::from(h).join(".mori").join("config.json"));
+    let Some(path) = path else {
+        return CleanupLevel::Smart;
+    };
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return CleanupLevel::Smart;
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return CleanupLevel::Smart;
+    };
+    match json
+        .pointer("/voice_input/cleanup_level")
+        .and_then(|v| v.as_str())
+    {
+        Some("smart") => CleanupLevel::Smart,
+        Some("minimal") => CleanupLevel::Minimal,
+        Some("none") => CleanupLevel::None,
+        _ => CleanupLevel::Smart,
+    }
+}
+
+/// 程式化 cleanup — 純 string-in / string-out,所有規則 deterministic。
+pub fn programmatic_cleanup(input: &str) -> String {
+    let mut s = input.to_string();
+    s = strip_whisper_hallucinations(&s);
+    s = strip_wrapping_quotes(&s);
+    s = halfwidth_to_fullwidth_near_cjk(&s);
+    s = normalize_whitespace(&s);
+    s
+}
+
+/// Whisper 在低音量 / 沉默音段常吐 YouTube subtitles 殘渣。把這幾段直接挖掉。
+fn strip_whisper_hallucinations(s: &str) -> String {
+    let phrases = [
+        "Thank you for watching.",
+        "Thank you for watching!",
+        "Thanks for watching.",
+        "Thanks for watching!",
+        "Please subscribe.",
+        "Please like and subscribe.",
+        "Don't forget to subscribe.",
+        "感謝觀看",
+        "感謝收看",
+        "請訂閱",
+        "請按讚訂閱",
+        "請按讚並訂閱",
+        "歡迎訂閱",
+    ];
+    let mut out = s.to_string();
+    for p in phrases.iter() {
+        out = out.replace(p, "");
+    }
+    out
+}
+
+/// LLM 偶爾會把整段答案用「」/ ""/ 『』 包起來(雖然 prompt 說不要)。如果
+/// 整段被同一對 quote 包,把外層拆掉。內部的引號保留。
+fn strip_wrapping_quotes(s: &str) -> String {
+    let trimmed = s.trim();
+    let pairs = [
+        ('"', '"'),
+        ('「', '」'),
+        ('『', '』'),
+        ('“', '”'),
+        ('‘', '’'),
+    ];
+    for (open, close) in pairs.iter() {
+        if let (Some(first), Some(last)) = (trimmed.chars().next(), trimmed.chars().last()) {
+            if first == *open && last == *close && trimmed.chars().count() >= 2 {
+                let inner: String = trimmed
+                    .chars()
+                    .skip(1)
+                    .take(trimmed.chars().count() - 2)
+                    .collect();
+                return inner;
+            }
+        }
+    }
+    s.to_string()
+}
+
+/// 半形 punctuation 在 CJK 字旁邊時轉全形。英文 context 中的標點不動。
+///
+/// 規則:
+/// - 看每個半形字元的**前一個非空白字元**跟**後一個非空白字元**
+/// - 兩邊任一是 CJK(\u{4E00}-\u{9FFF} / \u{3400}-\u{4DBF})就轉全形
+/// - 兩邊都不是 CJK(全英文 context)→ 保持半形
+fn halfwidth_to_fullwidth_near_cjk(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let mut out = String::with_capacity(s.len());
+    for (i, &c) in chars.iter().enumerate() {
+        let full = match c {
+            ',' => Some('\u{FF0C}'), // ,
+            '.' => Some('\u{3002}'), // 。 (中文用句號不是全形句點)
+            '!' => Some('\u{FF01}'), // !
+            '?' => Some('\u{FF1F}'), // ?
+            ':' => Some('\u{FF1A}'), // :
+            ';' => Some('\u{FF1B}'), // ;
+            _ => None,
+        };
+        if let Some(full_char) = full {
+            // 看左右非空白鄰居是不是 CJK
+            let near_cjk_left = (0..i).rev().find_map(|j| {
+                let ch = chars[j];
+                if ch.is_whitespace() {
+                    None
+                } else {
+                    Some(is_cjk(ch))
+                }
+            });
+            let near_cjk_right = (i + 1..chars.len()).find_map(|j| {
+                let ch = chars[j];
+                if ch.is_whitespace() {
+                    None
+                } else {
+                    Some(is_cjk(ch))
+                }
+            });
+            // 任一邊是 CJK 就轉
+            if near_cjk_left == Some(true) || near_cjk_right == Some(true) {
+                out.push(full_char);
+                continue;
+            }
+        }
+        out.push(c);
+    }
+    out
+}
+
+fn is_cjk(c: char) -> bool {
+    // CJK Unified Ideographs + Extension A 涵蓋繁中常用 99%+
+    matches!(c, '\u{4E00}'..='\u{9FFF}' | '\u{3400}'..='\u{4DBF}')
+}
+
+/// trim 整段、collapse 多重空白為單個、刪空行
+fn normalize_whitespace(s: &str) -> String {
+    let lines: Vec<String> = s
+        .lines()
+        .map(|line| {
+            // 每行內把 run 的 ASCII 空白 / tab 壓成單個空格
+            let mut prev_space = false;
+            let mut buf = String::with_capacity(line.len());
+            for c in line.chars() {
+                let is_ws_compress = c == ' ' || c == '\t';
+                if is_ws_compress {
+                    if !prev_space {
+                        buf.push(' ');
+                    }
+                    prev_space = true;
+                } else {
+                    buf.push(c);
+                    prev_space = false;
+                }
+            }
+            buf.trim().to_string()
+        })
+        .filter(|line| !line.is_empty())
+        .collect();
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn level_default_is_smart() {
+        assert_eq!(CleanupLevel::default(), CleanupLevel::Smart);
+    }
+
+    #[test]
+    fn strips_thank_you_for_watching() {
+        let input = "今天天氣很好。Thank you for watching!";
+        let out = programmatic_cleanup(input);
+        assert_eq!(out, "今天天氣很好。");
+    }
+
+    #[test]
+    fn strips_subscribe_chinese() {
+        let input = "我想說的就是這樣。請按讚訂閱。";
+        let out = programmatic_cleanup(input);
+        // "請按讚訂閱" 拿掉,後面剩的句號跟空格 normalize 掉
+        assert!(!out.contains("訂閱"));
+        assert!(out.contains("我想說的就是這樣"));
+    }
+
+    #[test]
+    fn unwraps_chinese_quotes() {
+        let out = programmatic_cleanup("「今天天氣很好」");
+        assert_eq!(out, "今天天氣很好");
+    }
+
+    #[test]
+    fn keeps_inner_quotes() {
+        // 整段不是被同一對 quote 包,內部 quote 保留
+        let out = programmatic_cleanup("他說「你好」然後走了");
+        assert!(out.contains("「你好」"));
+    }
+
+    #[test]
+    fn halfwidth_punct_near_cjk_to_fullwidth() {
+        let out = programmatic_cleanup("今天天氣很好,我覺得心情也變好了.");
+        // U+FF0C fullwidth comma, U+3002 ideographic full stop
+        assert!(
+            out.contains("好\u{FF0C}我"),
+            "expected fullwidth comma between 好 and 我, got: {out:?}"
+        );
+        assert!(
+            out.contains("了\u{3002}"),
+            "expected ideographic period after 了, got: {out:?}"
+        );
+        assert!(!out.contains(","), "raw ascii comma should be gone: {out:?}");
+        assert!(!out.contains("."), "raw ascii period should be gone: {out:?}");
+    }
+
+    #[test]
+    fn halfwidth_punct_in_english_kept() {
+        let out = programmatic_cleanup("Hello, world.");
+        // 兩邊都是 ASCII letter,不轉
+        assert_eq!(out, "Hello, world.");
+    }
+
+    #[test]
+    fn mixed_chinese_english_punct() {
+        // 「OK,」這種 — , 左是 K(non-CJK)、右是 CJK,任一是 CJK 就轉
+        let out = programmatic_cleanup("我說 OK,然後走了");
+        assert!(
+            out.contains("OK\u{FF0C}然後"),
+            "expected fullwidth comma after OK (because right neighbor is CJK), got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn collapses_multiple_spaces_keeps_lines() {
+        let out = programmatic_cleanup("第一行\n\n   第二行   有空白\n");
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines, vec!["第一行", "第二行 有空白"]);
+    }
+
+    #[test]
+    fn empty_input_stays_empty() {
+        assert_eq!(programmatic_cleanup(""), "");
+        assert_eq!(programmatic_cleanup("   \n  \n  "), "");
+    }
+}

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -662,27 +662,31 @@ async fn run_chat_pipeline(
     }
 }
 
-/// Phase 5E:語音輸入 pipeline。
+/// Phase 5E:語音輸入 pipeline(三段式)。
 ///
-/// 接 STT 出來的 transcript,跑「輕度 cleanup」LLM call(加標點 / 修
-/// Whisper 幻聽 / 保留原詞),最後透過 PasteController 模擬 Ctrl+V
-/// 把結果貼到使用者游標位置 — 完全跳過 agent loop,適合單純 dictation。
+/// 跳過 agent loop,把 STT 結果(可選 LLM 加標點)+ 程式化格式收尾後,
+/// 透過 PasteController 模擬 Ctrl+V 直接貼到使用者游標位置。
 ///
-/// Cleanup provider 走 `routing.skill_provider("voice_input_cleanup")`,
-/// 沒設 routing override 就 fall through 到 skill_fallback(等於 agent
-/// 或 claude-cli)。User 可以在 config 加:
+/// 三級 `cleanup_level`(讀 `~/.mori/config.json` 的 `voice_input.cleanup_level`):
+/// - **smart**(預設):LLM 加標點 + segmentation,**然後** `programmatic_cleanup`
+///   收一致性。LLM 做 irreducible 智能,程式守格式跨 provider。
+/// - **minimal**:跳 LLM,只跑 `programmatic_cleanup`。最快(~ms 級)但
+///   Whisper 不出標點所以會是「一長串字」,適合自己後加標點型 user。
+/// - **none**:Whisper 出來的字直接 paste,跳所有 cleanup。
 ///
+/// LLM cleanup provider 走 `routing.skill_provider("voice_input_cleanup")`,
+/// 預設 fall through 到 skill_fallback。可在 config 釘到 ollama / groq / claude:
 /// ```json
-/// "routing": { "skills": { "voice_input_cleanup": "ollama" } }
+/// "routing": { "skills": { "voice_input_cleanup": "groq" } }
 /// ```
-///
-/// 把 cleanup 釘在本機 ollama 之類降延遲。
 async fn run_voice_input_pipeline(
     app: AppHandle,
     state: Arc<AppState>,
     transcript: String,
     routing: Arc<mori_core::llm::Routing>,
 ) {
+    use mori_core::voice_cleanup::{programmatic_cleanup, read_cleanup_level, CleanupLevel};
+
     state.set_phase(
         &app,
         Phase::Responding {
@@ -690,69 +694,96 @@ async fn run_voice_input_pipeline(
         },
     );
 
-    let cleanup_result: anyhow::Result<String> = async {
-        if transcript.trim().is_empty() {
-            return Ok(String::new());
-        }
-        let provider = routing.skill_provider("voice_input_cleanup");
-        tracing::info!(
-            provider = %provider.name(),
-            chars_in = transcript.chars().count(),
-            "voice-input cleanup"
+    if transcript.trim().is_empty() {
+        state.set_phase(
+            &app,
+            Phase::Error {
+                message: "(空白音訊,沒東西可貼)".into(),
+            },
         );
-        let messages = vec![
-            ChatMessage::system(
-                "你是語音輸入清理員。你只做這件事:\n\
-                 - 給 ASR(Whisper)的原始輸出加上**正確的中英文標點**(,。?!:、— 全形;\
-                   英文用半形)\n\
-                 - 修正明顯的 Whisper 幻聽(例如 \"thank you for watching\"、\"請訂閱\"、\
-                   \"請按讚\")\n\
-                 - 修正常見同音字錯字(只在你**極有把握**時改,寧可少改不要多改)\n\
-                 - 保留使用者原本的**用詞、語氣、口語助詞**(例如「啊」「呢」「嗯」)\n\
-                 - 適當補上換行 / 段落,讓段落自然斷開\n\
-                 \n\
-                 你**絕對不能**:\n\
-                 - 改寫句子讓它更「漂亮」、更「正式」\n\
-                 - 縮短或擴寫內容\n\
-                 - 加上你的解釋(像「以下是清理過的版本」)\n\
-                 - 用引號包住整段輸出\n\
-                 - 翻譯到其他語言\n\
-                 \n\
-                 **只輸出清理後的純文字**。不要前言、不要後記、不要 Markdown 標題。",
-            ),
-            ChatMessage::user(transcript.clone()),
-        ];
-        let resp = provider
-            .chat(messages, vec![])
-            .await
-            .context("voice-input cleanup chat")?;
-        let cleaned = resp.content.unwrap_or_default().trim().to_string();
-        Ok(cleaned)
+        return;
     }
-    .await;
 
-    let cleaned_text = match cleanup_result {
-        Ok(t) if !t.is_empty() => t,
-        Ok(_) => {
-            state.set_phase(
-                &app,
-                Phase::Error {
-                    message: "(空白音訊,沒東西可貼)".into(),
-                },
-            );
-            return;
+    let level = read_cleanup_level();
+    tracing::info!(
+        cleanup_level = level.as_str(),
+        chars_in = transcript.chars().count(),
+        "voice-input pipeline start",
+    );
+
+    // Step 1:LLM cleanup(只在 smart 等級才走)
+    let after_llm: anyhow::Result<String> = match level {
+        CleanupLevel::None | CleanupLevel::Minimal => Ok(transcript.clone()),
+        CleanupLevel::Smart => {
+            let provider = routing.skill_provider("voice_input_cleanup");
+            tracing::info!(provider = %provider.name(), "voice-input LLM cleanup");
+            let messages = vec![
+                ChatMessage::system(
+                    "你是語音輸入清理員。你只做這件事:\n\
+                     - 給 ASR(Whisper)的原始輸出加上**標點 + 段落切分**\n\
+                     - 修正明顯的 Whisper 幻聽(例如 \"thank you for watching\"、\
+                       \"請訂閱\"、\"請按讚\")\n\
+                     - 修正同音字錯字(僅在**極有把握**時,寧可少改不多改)\n\
+                     - 保留使用者原本的**用詞、語氣、口語助詞**(「啊」「呢」「嗯」)\n\
+                     - 中文一律繁體;標點:中文鄰近用全形(,。?!:、),英文用半形\n\
+                     \n\
+                     **絕對禁止**:\n\
+                     - 改寫句子(例:「我覺得這方案 OK」→「我認為此方案可行」← 不可)\n\
+                     - 縮短 / 擴寫\n\
+                     - 加任何解釋、前言、後記\n\
+                     - 用引號包整段\n\
+                     - 翻譯到其他語言\n\
+                     \n\
+                     **只輸出清理後的純文字**。",
+                ),
+                ChatMessage::user(transcript.clone()),
+            ];
+            provider
+                .chat(messages, vec![])
+                .await
+                .context("voice-input LLM cleanup chat")
+                .map(|r| r.content.unwrap_or_default().trim().to_string())
         }
+    };
+
+    let after_llm = match after_llm {
+        Ok(t) => t,
         Err(e) => {
-            tracing::error!(?e, "voice-input cleanup failed");
+            tracing::error!(?e, "voice-input LLM cleanup failed");
             state.set_phase(
                 &app,
                 Phase::Error {
-                    message: format!("輸入清理失敗:{e:#}"),
+                    message: format!("LLM 清理失敗:{e:#}"),
                 },
             );
             return;
         }
     };
+
+    // Step 2:程式化 post-process(none 等級跳過)
+    let cleaned_text = match level {
+        CleanupLevel::None => after_llm,
+        CleanupLevel::Minimal | CleanupLevel::Smart => {
+            let after = programmatic_cleanup(&after_llm);
+            tracing::debug!(
+                level = level.as_str(),
+                chars_in = after_llm.chars().count(),
+                chars_out = after.chars().count(),
+                "voice-input programmatic cleanup",
+            );
+            after
+        }
+    };
+
+    if cleaned_text.is_empty() {
+        state.set_phase(
+            &app,
+            Phase::Error {
+                message: "(cleanup 後輸出為空,沒東西可貼)".into(),
+            },
+        );
+        return;
+    }
 
     // 把結果送到游標位置 — Linux 用既有的 LinuxPasteController(arboard 寫
     // primary clipboard + ydotool 模擬 Ctrl+V)。其他平台未來補。

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -512,7 +512,20 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
                     return;
                 }
             };
-        run_chat_pipeline(app, state, transcript, routing).await;
+
+        // Stage 3:依當下 Mode 決定 transcript 後的 flow。
+        // - Active     → 走 agent loop(LLM 決定 dispatch 哪個 skill / 直接回應)
+        // - VoiceInput → 跳過 agent,LLM 輕度 cleanup → 直接 paste 到游標位置
+        // - Background → 不該到這(start_recording 已 refuse),但守一道
+        let current_mode = *state.mode.lock();
+        match current_mode {
+            Mode::VoiceInput => {
+                run_voice_input_pipeline(app, state, transcript, routing).await;
+            }
+            Mode::Active | Mode::Background => {
+                run_chat_pipeline(app, state, transcript, routing).await;
+            }
+        }
     });
 }
 
@@ -647,6 +660,135 @@ async fn run_chat_pipeline(
             );
         }
     }
+}
+
+/// Phase 5E:語音輸入 pipeline。
+///
+/// 接 STT 出來的 transcript,跑「輕度 cleanup」LLM call(加標點 / 修
+/// Whisper 幻聽 / 保留原詞),最後透過 PasteController 模擬 Ctrl+V
+/// 把結果貼到使用者游標位置 — 完全跳過 agent loop,適合單純 dictation。
+///
+/// Cleanup provider 走 `routing.skill_provider("voice_input_cleanup")`,
+/// 沒設 routing override 就 fall through 到 skill_fallback(等於 agent
+/// 或 claude-cli)。User 可以在 config 加:
+///
+/// ```json
+/// "routing": { "skills": { "voice_input_cleanup": "ollama" } }
+/// ```
+///
+/// 把 cleanup 釘在本機 ollama 之類降延遲。
+async fn run_voice_input_pipeline(
+    app: AppHandle,
+    state: Arc<AppState>,
+    transcript: String,
+    routing: Arc<mori_core::llm::Routing>,
+) {
+    state.set_phase(
+        &app,
+        Phase::Responding {
+            transcript: transcript.clone(),
+        },
+    );
+
+    let cleanup_result: anyhow::Result<String> = async {
+        if transcript.trim().is_empty() {
+            return Ok(String::new());
+        }
+        let provider = routing.skill_provider("voice_input_cleanup");
+        tracing::info!(
+            provider = %provider.name(),
+            chars_in = transcript.chars().count(),
+            "voice-input cleanup"
+        );
+        let messages = vec![
+            ChatMessage::system(
+                "你是語音輸入清理員。你只做這件事:\n\
+                 - 給 ASR(Whisper)的原始輸出加上**正確的中英文標點**(,。?!:、— 全形;\
+                   英文用半形)\n\
+                 - 修正明顯的 Whisper 幻聽(例如 \"thank you for watching\"、\"請訂閱\"、\
+                   \"請按讚\")\n\
+                 - 修正常見同音字錯字(只在你**極有把握**時改,寧可少改不要多改)\n\
+                 - 保留使用者原本的**用詞、語氣、口語助詞**(例如「啊」「呢」「嗯」)\n\
+                 - 適當補上換行 / 段落,讓段落自然斷開\n\
+                 \n\
+                 你**絕對不能**:\n\
+                 - 改寫句子讓它更「漂亮」、更「正式」\n\
+                 - 縮短或擴寫內容\n\
+                 - 加上你的解釋(像「以下是清理過的版本」)\n\
+                 - 用引號包住整段輸出\n\
+                 - 翻譯到其他語言\n\
+                 \n\
+                 **只輸出清理後的純文字**。不要前言、不要後記、不要 Markdown 標題。",
+            ),
+            ChatMessage::user(transcript.clone()),
+        ];
+        let resp = provider
+            .chat(messages, vec![])
+            .await
+            .context("voice-input cleanup chat")?;
+        let cleaned = resp.content.unwrap_or_default().trim().to_string();
+        Ok(cleaned)
+    }
+    .await;
+
+    let cleaned_text = match cleanup_result {
+        Ok(t) if !t.is_empty() => t,
+        Ok(_) => {
+            state.set_phase(
+                &app,
+                Phase::Error {
+                    message: "(空白音訊,沒東西可貼)".into(),
+                },
+            );
+            return;
+        }
+        Err(e) => {
+            tracing::error!(?e, "voice-input cleanup failed");
+            state.set_phase(
+                &app,
+                Phase::Error {
+                    message: format!("輸入清理失敗:{e:#}"),
+                },
+            );
+            return;
+        }
+    };
+
+    // 把結果送到游標位置 — Linux 用既有的 LinuxPasteController(arboard 寫
+    // primary clipboard + ydotool 模擬 Ctrl+V)。其他平台未來補。
+    #[cfg(target_os = "linux")]
+    let paste_result = {
+        let controller = crate::selection::LinuxPasteController::new(app.clone());
+        controller.paste_back(&cleaned_text).await
+    };
+    #[cfg(not(target_os = "linux"))]
+    let paste_result: anyhow::Result<()> = Err(anyhow::anyhow!(
+        "voice-input paste-back not implemented on this platform yet"
+    ));
+
+    if let Err(e) = paste_result {
+        tracing::error!(?e, "voice-input paste-back failed");
+        state.set_phase(
+            &app,
+            Phase::Error {
+                message: format!("貼到游標位置失敗:{e:#}"),
+            },
+        );
+        return;
+    }
+
+    tracing::info!(
+        chars_out = cleaned_text.chars().count(),
+        "voice-input pipeline complete"
+    );
+    state.set_phase(
+        &app,
+        Phase::Done {
+            transcript,
+            response: cleaned_text,
+            skill_calls: vec![],
+        },
+    );
 }
 
 /// 建構 Mori 的 system prompt — 角色 + 時間 + 記憶索引 + 當下 context + tool 規則。
@@ -860,6 +1002,25 @@ fn build_system_prompt(memory_index: &str, ctx: &MoriContext) -> String {
     prompt
 }
 
+/// 把 tray 三個 mode 選單上的 label 重畫,在當下 mode 那條前面打 ✓。
+fn refresh_mode_menu_labels(
+    active: &MenuItem<tauri::Wry>,
+    voice_input: &MenuItem<tauri::Wry>,
+    background: &MenuItem<tauri::Wry>,
+    current: Mode,
+) {
+    let mark = |is_current: bool, base: &str| -> String {
+        if is_current {
+            format!("✓ {base}")
+        } else {
+            format!("   {base}")
+        }
+    };
+    let _ = active.set_text(mark(current == Mode::Active, "對話模式"));
+    let _ = voice_input.set_text(mark(current == Mode::VoiceInput, "語音輸入模式"));
+    let _ = background.set_text(mark(current == Mode::Background, "休眠(關麥克風)"));
+}
+
 // ─── main ───────────────────────────────────────────────────────────
 
 fn main() {
@@ -979,24 +1140,41 @@ fn main() {
             // 我們先試一樣的紀律,看 mutter 認不認帳。
 
             // ── 系統匣(tray)+ 選單 ──
-            // toggle_mode 項目的 label 會跟著 Mode 動態切換;事件迴圈裡也
-            // listen "mode-changed" 同步更新,以免使用者經 IPC / 語音 skill
-            // 切了 mode 後 tray label 跟實際狀態對不上。
-            let toggle_mode_item =
-                MenuItem::with_id(app, "toggle_mode", "休眠(關麥克風)", true, None::<&str>)?;
+            // 5E 起 mode 從 2 態(Active / Background)變 3 態(+ VoiceInput),
+            // 改用 3 個獨立 menu item 顯示三種模式,目前的那個會在 label
+            // 前面打 ✓。改 mode 後 mode-changed listener 會 refresh labels。
+            let mode_active_item =
+                MenuItem::with_id(app, "mode_active", "對話模式", true, None::<&str>)?;
+            let mode_voice_input_item =
+                MenuItem::with_id(app, "mode_voice_input", "語音輸入模式", true, None::<&str>)?;
+            let mode_background_item =
+                MenuItem::with_id(app, "mode_background", "休眠(關麥克風)", true, None::<&str>)?;
             let menu = Menu::with_items(
                 app,
                 &[
                     &MenuItem::with_id(app, "show", "顯示 Mori", true, None::<&str>)?,
                     &MenuItem::with_id(app, "hide", "隱藏", true, None::<&str>)?,
-                    &toggle_mode_item,
+                    &mode_active_item,
+                    &mode_voice_input_item,
+                    &mode_background_item,
                     &MenuItem::with_id(app, "reset", "重新開始對話", true, None::<&str>)?,
                     &MenuItem::with_id(app, "quit", "離開", true, None::<&str>)?,
                 ],
             )?;
 
             let state_for_tray = state_for_setup.clone();
-            let toggle_mode_for_handler = toggle_mode_item.clone();
+            let mode_items_for_handler = (
+                mode_active_item.clone(),
+                mode_voice_input_item.clone(),
+                mode_background_item.clone(),
+            );
+            // 啟動時就把 ✓ 標到目前 mode 上
+            refresh_mode_menu_labels(
+                &mode_items_for_handler.0,
+                &mode_items_for_handler.1,
+                &mode_items_for_handler.2,
+                *state_for_tray.mode.lock(),
+            );
             let _tray = TrayIconBuilder::new()
                 .icon(app.default_window_icon().unwrap().clone())
                 .tooltip("Mori")
@@ -1031,16 +1209,9 @@ fn main() {
                             let _ = f.set_always_on_top(true);
                         }
                     }
-                    "toggle_mode" => {
-                        let cur = *state_for_tray.mode.lock();
-                        let next = match cur {
-                            Mode::Active => Mode::Background,
-                            Mode::Background => Mode::Active,
-                        };
-                        state_for_tray.set_mode(app, next);
-                        // label 由「mode-changed」listener 統一更新,不要在這
-                        // 裡重複寫,避免兩條路徑不一致。
-                    }
+                    "mode_active" => state_for_tray.set_mode(app, Mode::Active),
+                    "mode_voice_input" => state_for_tray.set_mode(app, Mode::VoiceInput),
+                    "mode_background" => state_for_tray.set_mode(app, Mode::Background),
                     "reset" => {
                         let mut conv = state_for_tray.conversation.lock();
                         let n = conv.len();
@@ -1055,18 +1226,19 @@ fn main() {
                 })
                 .build(app)?;
 
-            // tray label 跟著 Mode 同步:任何來源(tray 點擊、IPC、skill)改了
-            // Mode 都會 emit "mode-changed",這裡統一接 → 改 label。
+            // tray labels 跟著 Mode 同步:任何來源(tray 點擊、IPC、skill)改了
+            // Mode 都 emit "mode-changed",這裡統一接 → 把 ✓ 標到正確的 menu item。
+            let (active_item, voice_input_item, background_item) = mode_items_for_handler;
             app.listen("mode-changed", move |event| {
                 let payload = event.payload();
-                let label = if payload.contains("\"background\"") {
-                    "醒醒(開麥克風)"
+                let target = if payload.contains("\"voice_input\"") {
+                    Mode::VoiceInput
+                } else if payload.contains("\"background\"") {
+                    Mode::Background
                 } else {
-                    "休眠(關麥克風)"
+                    Mode::Active
                 };
-                if let Err(e) = toggle_mode_for_handler.set_text(label) {
-                    tracing::warn!(?e, "tray toggle_mode set_text failed");
-                }
+                refresh_mode_menu_labels(&active_item, &voice_input_item, &background_item, target);
             });
 
             // ── Skill HTTP server(5D)─────────────────────────────

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ type Phase =
     }
   | { kind: "error"; message: string };
 
-type Mode = "active" | "background";
+type Mode = "active" | "voice_input" | "background";
 
 type BuildInfo = {
   sha: string;
@@ -225,8 +225,7 @@ function App() {
       .catch((e) => console.error("submit_text failed", e));
   };
 
-  const onToggleMode = () => {
-    const next: Mode = mode === "active" ? "background" : "active";
+  const requestMode = (next: Mode) => {
     invoke("set_mode_cmd", { mode: next }).catch((e) =>
       console.error("set_mode_cmd failed", e),
     );
@@ -258,11 +257,17 @@ function App() {
           <>
             <div className="hero-dot" />
             <p className="hero-text">
-              {mode === "background" ? "休眠中(麥克風已關)" : "待命中"}
+              {mode === "background"
+                ? "休眠中(麥克風已關)"
+                : mode === "voice_input"
+                ? "語音輸入模式 — 對著游標講"
+                : "待命中"}
             </p>
             <p className="hero-hint">
               {mode === "background" ? (
                 <>按 <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Space</kbd> 叫醒並開始講話</>
+              ) : mode === "voice_input" ? (
+                <>把游標放輸入框 → 按 <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Space</kbd> → 講話 → 結果直接貼進去</>
               ) : (
                 <>按 <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Space</kbd> 開始講話</>
               )}
@@ -361,17 +366,38 @@ function App() {
         >
           {textOpen ? "收起文字輸入" : "貼文字"}
         </button>
-        <button
-          onClick={onToggleMode}
-          className="toggle-btn"
-          title={
-            mode === "active"
-              ? "讓 Mori 休眠 — 麥克風完全關閉,背景排程仍跑"
-              : "叫醒 Mori — 重新允許麥克風"
-          }
-        >
-          {mode === "active" ? "休眠(關麥克風)" : "醒醒(開麥克風)"}
-        </button>
+        <div className="mode-radio" role="radiogroup" aria-label="運作模式">
+          <button
+            onClick={() => requestMode("active")}
+            className={`toggle-btn ${mode === "active" ? "mode-on" : ""}`}
+            disabled={pipelineBusy}
+            role="radio"
+            aria-checked={mode === "active"}
+            title="對話模式 — 熱鍵 → 語音 → Mori 想 → 回應 / 叫 skill"
+          >
+            {mode === "active" ? "✓ " : ""}對話
+          </button>
+          <button
+            onClick={() => requestMode("voice_input")}
+            className={`toggle-btn ${mode === "voice_input" ? "mode-on" : ""}`}
+            disabled={pipelineBusy}
+            role="radio"
+            aria-checked={mode === "voice_input"}
+            title="語音輸入 — 熱鍵 → 語音 → 輕度清理(標點 / 修幻聽) → 直接貼到游標位置(跳過 agent loop)"
+          >
+            {mode === "voice_input" ? "✓ " : ""}輸入
+          </button>
+          <button
+            onClick={() => requestMode("background")}
+            className={`toggle-btn ${mode === "background" ? "mode-on" : ""}`}
+            disabled={pipelineBusy}
+            role="radio"
+            aria-checked={mode === "background"}
+            title="休眠 — 麥克風完全關,UI 隱藏(privacy)"
+          >
+            {mode === "background" ? "✓ " : ""}休眠
+          </button>
+        </div>
         <button
           onClick={onReset}
           className="toggle-btn reset-btn"
@@ -440,7 +466,11 @@ function App() {
         <div className="status-row">
           <span className="label">mode</span>
           <span className={`value ${mode === "background" ? "warn" : "ok"}`}>
-            {mode === "background" ? "💤 休眠" : "🟢 清醒"}
+            {mode === "background"
+              ? "💤 休眠"
+              : mode === "voice_input"
+              ? "⌨️ 輸入模式"
+              : "🟢 對話模式"}
           </span>
         </div>
         <div className="status-row">

--- a/src/styles.css
+++ b/src/styles.css
@@ -332,6 +332,29 @@ kbd {
   cursor: not-allowed;
 }
 
+/* 5E:三態 mode 選擇器 — 對話 / 輸入 / 休眠 */
+.mode-radio {
+  display: inline-flex;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.mode-radio .toggle-btn {
+  border: none;
+  border-radius: 0;
+  border-right: 1px solid var(--border);
+  padding: 6px 10px;
+}
+.mode-radio .toggle-btn:last-child {
+  border-right: none;
+}
+.mode-radio .toggle-btn.mode-on {
+  background: var(--border);
+  color: var(--fg);
+  font-weight: 600;
+}
+
 /* Text input area — 貼長文 / 打字 */
 .text-input {
   margin-top: 12px;


### PR DESCRIPTION
## Summary
Adds a third \`Mode::VoiceInput\` to Mori — turn it into an LLM-polished dictation tool. Cursor in any text field → Ctrl+Alt+Space → speak → light cleanup → text appears at cursor position. Skips the agent loop entirely for predictable low-latency dictation.

```
hotkey → STT → read Mode
              ┌──────┴───────┐
       Active                VoiceInput
         ↓                       ↓
   agent loop          LLM cleanup → paste at cursor
   (existing)          (skip agent, light polish only)
```

Cleanup uses a strict prompt: \"add punctuation / fix Whisper hallucinations / preserve user's exact wording — DO NOT rewrite, expand, or wrap in quotes.\" Provider follows \`routing.skill_provider(\"voice_input_cleanup\")\` so users can pin it to local Ollama for snappy response:

```json
\"routing\": { \"skills\": { \"voice_input_cleanup\": \"ollama\" } }
```

## Why same hotkey + UI mode toggle (vs new hotkey)
User picked from 4 architecture options. Same hotkey + UI mode toggle wins on:
- No extra hotkey to register/remember
- Mode is sticky — set once, dictate many turns
- Tray menu + UI mode selector both expose it consistently with existing Active/Background pattern

## Changes
- **mori-core/mode.rs**: Mode adds VoiceInput variant + \`allows_mic()\` helper
- **mori-core/skill/set_mode.rs**: schema + cues for new mode
- **mori-tauri/main.rs**:
  - \`stop_and_transcribe\` branches on Mode after STT (Active → \`run_chat_pipeline\`, VoiceInput → \`run_voice_input_pipeline\`)
  - new \`run_voice_input_pipeline\` (cleanup LLM call → \`PasteController::paste_back\`)
  - tray menu refactored from single toggle to 3 explicit items with ✓ marker
  - new \`refresh_mode_menu_labels\` helper shared between startup + mode-changed listener
- **src/App.tsx**: \`Mode\` type + 3-state radio in actions area; hero idle text/hint changes per mode; status row shows \"⌨️ 輸入模式\" when active
- **src/styles.css**: \`.mode-radio\` group + \`.mode-on\` selected state

## Out of scope
- macOS / Windows paste-back (LinuxPasteController exists; other platforms cfg-gated to friendly error for now)
- Custom voice-input cleanup tone presets (e.g., 'punctuation-only' vs 'punctuation+typo-fix')

## Test plan
- [ ] Start dev, switch to 語音輸入模式 from UI / tray
- [ ] Open browser, click into a textarea; press Ctrl+Alt+Space; speak Chinese
- [ ] Press hotkey again to stop
- [ ] Verify cleaned text (with punctuation) appears at cursor
- [ ] Switch back to 對話模式; press hotkey; verify normal agent flow restored
- [ ] Switch to 休眠; verify hotkey ignored (mic doesn't open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)