### PR TITLE
feat(phase-5D-2): memory skills via Bash CLI proxy — remember/recall/forget/edit

### DIFF
--- a/crates/mori-cli/src/main.rs
+++ b/crates/mori-cli/src/main.rs
@@ -91,6 +91,46 @@ enum SkillCmd {
         #[arg(long)]
         length_hint: Option<String>,
     },
+
+    /// 把一件事存進 Mori 的長期記憶。
+    Remember {
+        /// 簡短標題(3-15 字)
+        #[arg(short, long)]
+        title: String,
+        /// 完整內容
+        #[arg(short, long)]
+        content: String,
+        /// 類別 — user_identity | preference | project | reference | other
+        #[arg(long, default_value = "other")]
+        category: String,
+    },
+
+    /// 讀取單筆記憶的完整內容。
+    RecallMemory {
+        /// Memory id(檔名不含 .md)
+        #[arg(long)]
+        id: String,
+    },
+
+    /// 刪除一筆記憶(destructive)。
+    ForgetMemory {
+        /// Memory id(檔名不含 .md)
+        #[arg(long)]
+        id: String,
+    },
+
+    /// 更新既有記憶的內容。
+    EditMemory {
+        /// Memory id(檔名不含 .md)
+        #[arg(long)]
+        id: String,
+        /// 整合後的完整新內容
+        #[arg(short, long)]
+        content: String,
+        /// 更新索引行的短描述(可選,不給則保留舊的)
+        #[arg(long)]
+        description: Option<String>,
+    },
 }
 
 fn main() {
@@ -124,7 +164,6 @@ fn run() -> Result<()> {
                 audience,
                 length_hint,
             } => {
-                // ComposeSkill 用 `topic` 不是 `prompt`。
                 let mut body = json!({ "kind": kind, "topic": topic });
                 if let Some(a) = audience {
                     body["audience"] = json!(a);
@@ -133,6 +172,22 @@ fn run() -> Result<()> {
                     body["length_hint"] = json!(l);
                 }
                 post_skill("compose", body)
+            }
+            SkillCmd::Remember { title, content, category } => {
+                post_skill("remember", json!({ "title": title, "content": content, "category": category }))
+            }
+            SkillCmd::RecallMemory { id } => {
+                post_skill("recall_memory", json!({ "id": id }))
+            }
+            SkillCmd::ForgetMemory { id } => {
+                post_skill("forget_memory", json!({ "id": id }))
+            }
+            SkillCmd::EditMemory { id, content, description } => {
+                let mut body = json!({ "id": id, "new_content": content });
+                if let Some(d) = description {
+                    body["new_description"] = json!(d);
+                }
+                post_skill("edit_memory", body)
             }
         },
     }

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -1277,8 +1277,9 @@ fn main() {
             // (以及外部 AI agent 透過 Bash tool 呼叫的 mori CLI)能連回來
             // dispatch skill。失敗只 warn 不卡啟動 — Tauri UI 跟語音/chat
             // pipeline 沒這個 server 也能用。
-            tauri::async_runtime::spawn(async {
-                match crate::skill_server::start().await {
+            let memory_for_server = state_for_setup.memory.clone();
+            tauri::async_runtime::spawn(async move {
+                match crate::skill_server::start(memory_for_server).await {
                     Ok(info) => tracing::info!(
                         port = info.port,
                         "skill HTTP server started — Bash CLI proxy ready"

--- a/crates/mori-tauri/src/skill_server.rs
+++ b/crates/mori-tauri/src/skill_server.rs
@@ -27,13 +27,18 @@ use axum::{
     Json, Router,
 };
 use mori_core::context::Context as MoriContext;
+use mori_core::memory::MemoryStore;
 use mori_core::runtime::{generate_auth_token, RuntimeInfo};
-use mori_core::skill::{ComposeSkill, PolishSkill, Skill, SummarizeSkill, TranslateSkill};
+use mori_core::skill::{
+    ComposeSkill, EditMemorySkill, ForgetMemorySkill, PolishSkill, RecallMemorySkill,
+    RememberSkill, Skill, SummarizeSkill, TranslateSkill,
+};
 use serde_json::{json, Value};
 
 #[derive(Clone)]
 pub struct SkillServerState {
     pub auth_token: Arc<str>,
+    pub memory: Arc<dyn MemoryStore>,
 }
 
 /// 啟動 skill HTTP server。
@@ -45,7 +50,7 @@ pub struct SkillServerState {
 ///
 /// 失敗會回 Err 但不該卡 Mori 啟動 — 呼叫端記 log 後繼續就好(只是
 /// 失去 Bash CLI proxy 能力)。
-pub async fn start() -> Result<RuntimeInfo> {
+pub async fn start(memory: Arc<dyn MemoryStore>) -> Result<RuntimeInfo> {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .context("bind skill server to 127.0.0.1:0")?;
@@ -54,6 +59,7 @@ pub async fn start() -> Result<RuntimeInfo> {
     let token = generate_auth_token();
     let state = SkillServerState {
         auth_token: token.clone().into(),
+        memory,
     };
 
     let app = Router::new()
@@ -109,15 +115,16 @@ async fn list_skills(
     headers: HeaderMap,
 ) -> Result<Json<Value>, (StatusCode, String)> {
     check_auth(&headers, &state.auth_token)?;
-    // 5D-1 MVP:先曝光 4 個純 LLM-only 的 text skill。memory / paste / mode
-    // 那幾個有 Mori 平台 state 依賴(memory store / paste controller /
-    // mode controller),5D-2 再 wire 上。
     Ok(Json(json!({
         "skills": [
-            {"name": "translate", "description": describe::translate()},
-            {"name": "polish",    "description": describe::polish()},
-            {"name": "summarize", "description": describe::summarize()},
-            {"name": "compose",   "description": describe::compose()},
+            {"name": "translate",     "description": describe::translate()},
+            {"name": "polish",        "description": describe::polish()},
+            {"name": "summarize",     "description": describe::summarize()},
+            {"name": "compose",       "description": describe::compose()},
+            {"name": "remember",      "description": describe::remember()},
+            {"name": "recall_memory", "description": describe::recall_memory()},
+            {"name": "forget_memory", "description": describe::forget_memory()},
+            {"name": "edit_memory",   "description": describe::edit_memory()},
         ],
     })))
 }
@@ -146,13 +153,17 @@ async fn dispatch_skill(
         "polish" => Box::new(PolishSkill::new(provider.clone())),
         "summarize" => Box::new(SummarizeSkill::new(provider.clone())),
         "compose" => Box::new(ComposeSkill::new(provider.clone())),
-        // memory / paste / mode skill 5D-2 再加(需要把 Mori state 共享進來)
+        "remember" => Box::new(RememberSkill::new(state.memory.clone())),
+        "recall_memory" => Box::new(RecallMemorySkill::new(state.memory.clone())),
+        "forget_memory" => Box::new(ForgetMemorySkill::new(state.memory.clone())),
+        "edit_memory" => Box::new(EditMemorySkill::new(state.memory.clone())),
         _ => {
             return Err((
                 StatusCode::NOT_FOUND,
                 format!(
-                    "unknown or not-yet-exposed skill: {name}\n\
-                     available: translate, polish, summarize, compose"
+                    "unknown skill: {name}\n\
+                     available: translate, polish, summarize, compose, \
+                     remember, recall_memory, forget_memory, edit_memory"
                 ),
             ));
         }
@@ -199,5 +210,29 @@ mod describe {
         "Draft new text from a topic. CLI:\n\
          `mori skill compose --kind email|message|essay|social_post|other --topic \"...\" \
          [--audience \"...\"] [--length-hint short|medium|long]`"
+    }
+
+    pub fn remember() -> &'static str {
+        "Save a fact to Mori's long-term memory. CLI:\n\
+         `mori skill remember --title \"...\" --content \"...\" \
+         --category user_identity|preference|project|reference|other`"
+    }
+
+    pub fn recall_memory() -> &'static str {
+        "Read the full body of a memory by id. CLI:\n\
+         `mori skill recall-memory --id \"<memory-id>\"`\n\
+         id = filename without .md from the memory index."
+    }
+
+    pub fn forget_memory() -> &'static str {
+        "Delete a memory by id (destructive). CLI:\n\
+         `mori skill forget-memory --id \"<memory-id>\"`"
+    }
+
+    pub fn edit_memory() -> &'static str {
+        "Update an existing memory's body. CLI:\n\
+         `mori skill edit-memory --id \"<memory-id>\" --content \"...\" \
+         [--description \"...\"]`\n\
+         Tip: recall first, then edit with the merged content."
     }
 }


### PR DESCRIPTION
## Summary

- **skill_server**: `SkillServerState` 加入 `Arc<dyn MemoryStore>`；`start()` 接受 memory 參數；`list_skills` 從 4 個擴展到 8 個；`dispatch_skill` 加入 remember / recall_memory / forget_memory / edit_memory 四個 match arm
- **mori-tauri/main**: `skill_server::start()` 呼叫處補傳 `state_for_setup.memory`
- **mori-cli**: 新增 `remember` / `recall-memory` / `forget-memory` / `edit-memory` 四個 subcommand

5D-1 只接了 4 個純 LLM skill（translate/polish/summarize/compose），這個 PR 補上 memory 那 4 個，讓 claude-bash agent 透過 Bash tool 也能讀寫 Mori 的長期記憶。

## Test plan

- [x] `cargo build --workspace` 通過
- [x] 啟動 mori-tauri，`mori skill list` 顯示 8 個 skill
- [x] `mori skill remember --title "..." --content "..." --category other` 寫入成功
- [x] `mori skill recall-memory --id "..."` 讀回正確內容
- [x] `mori skill edit-memory --id "..." --content "..."` 更新成功
- [x] `mori skill forget-memory --id "..."` 刪除成功
- [x] 刪後再 recall 回 HTTP 500（正確行為）

🤖 Generated with [Claude Code](https://claude.com/claude-code)