### PR TITLE
feat(phase-5D-3): gemini-cli + codex-cli chat-only provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Mori 不是孤立的 app,是一隻**契約精靈**在多個 repo 各司其職:
 
 ## 目前狀態
 
-**Phase 1 + 2 + 3A + 4B + 4C + 5A + 5C + 5D-1 + 5D-2 + 5E 完成(2026-05-09，持續更新)** — Mori 在 Wayland 上
+**Phase 1 + 2 + 3A + 4B + 4C + 5A + 5C + 5D-1 + 5D-2 + 5D-3 + 5E 完成(2026-05-09，持續更新)** — Mori 在 Wayland 上
 **可以當管家用、可以 100% 離線(Groq-free)、可以挑 LLM、可以當語音輸入法**:
 - 全域熱鍵通了、UI 不偷焦點、剪貼簿與滑鼠反白都自動抓、**3 種 mode**(對話 / 輸入 / 休眠)
 - **反白文字 + 一句話 → 結果直接貼回**(ZeroType / Typeless 招牌動作)
@@ -60,7 +60,7 @@ Mori 不是孤立的 app,是一隻**契約精靈**在多個 repo 各司其職:
 | 🎙️ 聽 | `Ctrl+Alt+Space` 全域熱鍵(Linux 走 xdg-desktop-portal,GNOME Wayland 不偷焦點)/ UI 按鈕 / 「貼文字」textarea(`Ctrl+Enter` 送出) |
 | 🛑 取消 | 錄音中按 `Esc` = 丟掉音檔不送 Whisper |
 | 🗣️ STT | **可選** Groq Whisper API(`whisper-large-v3-turbo`,雲)或本機 whisper.cpp(`ggml-small.bin`,離線、開機 cold load 5-15s) |
-| 🧠 想 | **可選 6 種 LLM**:Groq gpt-oss-120b / 本機 Ollama qwen3:8b / Claude CLI subprocess / **claude-bash** / **gemini-bash** / **codex-bash**。後三者皆透過 Bash tool 呼叫本機 `mori` CLI dispatch skill，multi-turn tool calling MAX 5 輪 |
+| 🧠 想 | **可選 8 種 LLM**:Groq gpt-oss-120b / 本機 Ollama qwen3:8b / Claude CLI subprocess / **claude-bash** / **gemini-bash** / **codex-bash**(三種 agent,透過 Bash tool 呼叫 `mori` CLI) / **gemini-cli** / **codex-cli**(兩種 chat-only,供 `routing.skills` 指定) |
 | 🎚️ Per-skill 路由 | `routing.skills.<name>` 可獨立指定每個 skill 該用哪個 provider(e.g. translate 走 Claude Pro/Max、compose 走 Ollama) |
 | 💬 回 | 繁中為主、不客套,UI 顯示「你說 / Mori」雙塊 + 🔧 skill badges + status panel(build SHA / chat provider / STT provider / warm-up state / clipboard / selection) |
 | 📝 記 / 🔍 查 / ✏️ 改 / 🗑️ 忘 | RememberSkill / RecallMemorySkill / EditMemorySkill / ForgetMemorySkill(走 LlmProvider trait,任何 provider 都能 dispatch;**5D-2 起也接上 Bash CLI proxy** — `mori skill remember/recall-memory/forget-memory/edit-memory`) |
@@ -84,7 +84,6 @@ Mori 不是孤立的 app,是一隻**契約精靈**在多個 repo 各司其職:
 
 | 缺什麼 | 為什麼重要 | 在哪個 Phase |
 |---|---|---|
-| ⏳ gemini-cli / codex-cli(chat-only 模式) | 讓 routing.skills 也能指定 gemini/codex 當 skill 內部 LLM(類似 claude-cli)。目前 chat-only 沒有乾淨的 flag,gemini 靠省略 `--yolo`、codex 無明確分法,暫用 claude-cli 頂替 | 5D-3 |
 | ⏳ Auto-fallback chain | Groq TPD 觸頂自動切 ollama / claude(現在要手改 config) | 5A-3b |
 | ⏳ macOS / Windows voice-input paste-back | 目前只 Linux 走 `LinuxPasteController`(arboard + ydotool),其他平台還沒接 | 5E-2 |
 | ⏳ OpenCC 簡→繁保底 | whisper-rs initial_prompt 已 bias 繁體實測夠用,但若遇 mixed-script 要加 `opencc-rust`(系統依賴 `libopencc-dev`) | 5E-2 |
@@ -275,6 +274,30 @@ agent 跟個別 skill 可走不同 provider:
 ```
 
 省 Groq TPD,把重活分給其他 provider。沒設 `routing` 整套退回 `default_provider`。
+
+**5D-3 新增:`gemini-cli` / `codex-cli`** — chat-only 變體,可用在 `routing.skills`。
+兩者省略 agent 旗標(`--yolo` / `--dangerously-bypass-approvals-and-sandbox`),
+non-TTY 下 tool 執行無法被核准 → 實質純文字 in/out:
+
+```json
+{
+  "default_provider": "groq",
+  "routing": {
+    "agent": "groq",
+    "skills": {
+      "translate": "gemini-cli",
+      "polish":    "gemini-cli",
+      "summarize": "codex-cli"
+    }
+  },
+  "providers": {
+    "gemini-cli": { "binary": "gemini" },
+    "codex-cli":  { "binary": "codex" }
+  }
+}
+```
+
+`binary` 選填,預設靠 PATH 找 `gemini` / `codex`。
 
 ### 進階:語音輸入 cleanup_level + 專屬 provider(5E)
 

--- a/crates/mori-core/src/llm/bash_cli_agent.rs
+++ b/crates/mori-core/src/llm/bash_cli_agent.rs
@@ -40,6 +40,12 @@ pub enum CliProtocol {
     Gemini,
     /// `codex exec --dangerously-bypass-approvals-and-sandbox`，system prompt 嵌 stdin 頂部
     Codex,
+    /// `gemini -p "" --output-format text`(省略 `--yolo`)— chat-only。
+    /// non-TTY 下無法核准 tool 執行 → 實質只輸出文字,不 dispatch shell tool。
+    GeminiChat,
+    /// `codex exec`(省略 `--dangerously-bypass-approvals-and-sandbox`)— chat-only。
+    /// 純文字任務 codex 不會嘗試執行 shell 命令,且 non-TTY 下也無法取得核准。
+    CodexChat,
 }
 
 impl CliProtocol {
@@ -95,6 +101,30 @@ impl BashCliAgentProvider {
         }
     }
 
+    /// Chat-only 變體(gemini-cli / codex-cli)用 — 由呼叫端顯式指定 protocol,
+    /// 不靠 binary 名稱自動偵測。mori_cli_path 不使用(PATH 不注入,system prompt
+    /// 也不帶 mori CLI 說明),傳 `PathBuf::from("mori")` 做 dummy 即可。
+    pub fn new_with_protocol(
+        binary: impl Into<String>,
+        mori_cli_path: PathBuf,
+        model: Option<String>,
+        protocol: CliProtocol,
+    ) -> Self {
+        let binary = binary.into();
+        let mori_basename = mori_cli_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("mori")
+            .to_string();
+        Self {
+            binary,
+            mori_cli_path,
+            model,
+            mori_basename,
+            protocol,
+        }
+    }
+
     /// 嘗試自動找 mori CLI:先看 `current_exe()` 旁邊(dev:`target/debug/mori`),
     /// 找不到 fallback 到 PATH 上的 `mori`。
     pub fn detect_mori_cli() -> PathBuf {
@@ -110,6 +140,13 @@ impl BashCliAgentProvider {
     }
 
     fn system_prompt(&self) -> String {
+        // chat-only 變體不透過 mori CLI dispatch,system prompt 簡化成純對話規則。
+        if matches!(self.protocol, CliProtocol::GeminiChat | CliProtocol::CodexChat) {
+            return "你是 Mori — 使用者的個人 AI 管家精靈,繁體中文為主、不客套。\n\
+                    直接輸出結果,禁止前言(「我來幫你」「以下是」「好的」等),\
+                    禁止尾綴補充說明,禁止執行任何 shell 命令。"
+                .into();
+        }
         format!(
             "你是 Mori — 使用者的個人 AI 管家精靈,繁體中文為主、不客套、不用 Markdown 標題。\n\
              \n\
@@ -152,9 +189,11 @@ impl BashCliAgentProvider {
 impl LlmProvider for BashCliAgentProvider {
     fn name(&self) -> &'static str {
         match self.protocol {
-            CliProtocol::Claude => "bash-cli-agent",
-            CliProtocol::Gemini => "gemini-bash",
-            CliProtocol::Codex  => "codex-bash",
+            CliProtocol::Claude     => "bash-cli-agent",
+            CliProtocol::Gemini     => "gemini-bash",
+            CliProtocol::Codex      => "codex-bash",
+            CliProtocol::GeminiChat => "gemini-cli",
+            CliProtocol::CodexChat  => "codex-cli",
         }
     }
 
@@ -163,9 +202,9 @@ impl LlmProvider for BashCliAgentProvider {
     }
 
     fn supports_tool_calling(&self) -> bool {
-        // 假性 true:Mori agent loop 一輪 round-trip 結束;但 CLI 內部會做
-        // 真正的 reasoning + tool dispatch,所以可以當主 agent provider。
-        true
+        // Agent 變體(Claude/Gemini/Codex):內部有 Bash tool loop → 可當主 agent。
+        // Chat-only 變體(GeminiChat/CodexChat):純文字 in/out → 只能當 skill 內部 LLM。
+        !matches!(self.protocol, CliProtocol::GeminiChat | CliProtocol::CodexChat)
     }
 
     async fn chat(
@@ -224,6 +263,29 @@ impl LlmProvider for BashCliAgentProvider {
                 let mut c = Command::new(&self.binary);
                 c.arg("exec")
                     .arg("--dangerously-bypass-approvals-and-sandbox");
+                if let Some(model) = &self.model {
+                    c.arg("--model").arg(model);
+                }
+                (c, stdin_content.into_bytes(), false)
+            }
+            CliProtocol::GeminiChat => {
+                // chat-only:省略 --yolo → gemini 不自動執行 tool;
+                // non-TTY 下無法取得使用者核准 → 實質只輸出文字。
+                let stdin_content = format_stdin_with_system(&system_prompt, &transcript);
+                let mut c = Command::new(&self.binary);
+                c.arg("-p").arg("")
+                    .arg("--output-format").arg("text");
+                if let Some(model) = &self.model {
+                    c.arg("--model").arg(model);
+                }
+                (c, stdin_content.into_bytes(), true)
+            }
+            CliProtocol::CodexChat => {
+                // chat-only:省略 --dangerously-bypass-approvals-and-sandbox →
+                // tool 執行需手動核准;non-TTY 下核准不可得 → 純文字任務實質 chat-only。
+                let stdin_content = format_stdin_with_system(&system_prompt, &transcript);
+                let mut c = Command::new(&self.binary);
+                c.arg("exec");
                 if let Some(model) = &self.model {
                     c.arg("--model").arg(model);
                 }
@@ -342,14 +404,60 @@ mod tests {
         let claude = BashCliAgentProvider::new("claude", PathBuf::from("/tmp/mori"), None);
         assert_eq!(claude.protocol, CliProtocol::Claude);
         assert_eq!(claude.name(), "bash-cli-agent");
+        assert!(claude.supports_tool_calling());
 
         let gemini = BashCliAgentProvider::new("gemini", PathBuf::from("/tmp/mori"), None);
         assert_eq!(gemini.protocol, CliProtocol::Gemini);
         assert_eq!(gemini.name(), "gemini-bash");
+        assert!(gemini.supports_tool_calling());
 
         let codex = BashCliAgentProvider::new("codex", PathBuf::from("/tmp/mori"), None);
         assert_eq!(codex.protocol, CliProtocol::Codex);
         assert_eq!(codex.name(), "codex-bash");
+        assert!(codex.supports_tool_calling());
+    }
+
+    #[test]
+    fn chat_only_variants_via_new_with_protocol() {
+        let g = BashCliAgentProvider::new_with_protocol(
+            "gemini",
+            PathBuf::from("mori"),
+            None,
+            CliProtocol::GeminiChat,
+        );
+        assert_eq!(g.name(), "gemini-cli");
+        assert!(!g.supports_tool_calling(), "gemini-cli must be chat-only");
+
+        let c = BashCliAgentProvider::new_with_protocol(
+            "codex",
+            PathBuf::from("mori"),
+            None,
+            CliProtocol::CodexChat,
+        );
+        assert_eq!(c.name(), "codex-cli");
+        assert!(!c.supports_tool_calling(), "codex-cli must be chat-only");
+    }
+
+    #[test]
+    fn chat_only_system_prompt_has_no_mori_cli_instructions() {
+        let g = BashCliAgentProvider::new_with_protocol(
+            "gemini",
+            PathBuf::from("mori"),
+            None,
+            CliProtocol::GeminiChat,
+        );
+        let sys = g.system_prompt();
+        assert!(!sys.contains("mori skill"), "chat-only prompt must not reference mori CLI");
+        assert!(sys.contains("Mori"), "should still identify as Mori");
+
+        let c = BashCliAgentProvider::new_with_protocol(
+            "codex",
+            PathBuf::from("mori"),
+            None,
+            CliProtocol::CodexChat,
+        );
+        let sys = c.system_prompt();
+        assert!(!sys.contains("mori skill"), "chat-only prompt must not reference mori CLI");
     }
 
     #[test]
@@ -409,5 +517,63 @@ mod tests {
         assert!(t.starts_with("User: hi"));
         assert!(t.contains("Assistant: hello!"));
         assert!(t.ends_with("translate this"));
+    }
+
+    /// gemini-cli chat-only 真實呼叫。需要 `gemini` 在 PATH 且已登入。
+    /// `cargo test -p mori-core --lib -- --ignored integration_gemini_cli` 觸發。
+    #[tokio::test]
+    #[ignore]
+    async fn integration_gemini_cli_real_binary() {
+        let p = BashCliAgentProvider::new_with_protocol(
+            "gemini",
+            PathBuf::from("mori"),
+            None,
+            CliProtocol::GeminiChat,
+        );
+        let resp = p
+            .chat(
+                vec![
+                    ChatMessage::system("Answer in one short English word, no punctuation."),
+                    ChatMessage::user("What color is grass?"),
+                ],
+                vec![],
+            )
+            .await
+            .expect("gemini-cli chat should succeed");
+        let answer = resp.content.expect("content").to_lowercase();
+        assert!(
+            answer.contains("green"),
+            "expected 'green', got: {answer:?}"
+        );
+        assert!(resp.tool_calls.is_empty(), "gemini-cli must not return tool_calls");
+    }
+
+    /// codex-cli chat-only 真實呼叫。需要 `codex` 在 PATH 且已登入。
+    /// `cargo test -p mori-core --lib -- --ignored integration_codex_cli` 觸發。
+    #[tokio::test]
+    #[ignore]
+    async fn integration_codex_cli_real_binary() {
+        let p = BashCliAgentProvider::new_with_protocol(
+            "codex",
+            PathBuf::from("mori"),
+            None,
+            CliProtocol::CodexChat,
+        );
+        let resp = p
+            .chat(
+                vec![
+                    ChatMessage::system("Answer in one short English word, no punctuation."),
+                    ChatMessage::user("What color is grass?"),
+                ],
+                vec![],
+            )
+            .await
+            .expect("codex-cli chat should succeed");
+        let answer = resp.content.expect("content").to_lowercase();
+        assert!(
+            answer.contains("green"),
+            "expected 'green', got: {answer:?}"
+        );
+        assert!(resp.tool_calls.is_empty(), "codex-cli must not return tool_calls");
     }
 }

--- a/crates/mori-core/src/llm/mod.rs
+++ b/crates/mori-core/src/llm/mod.rs
@@ -115,6 +115,39 @@ pub fn build_named_provider(
                 .and_then(|p| groq::read_json_pointer(p, "/providers/codex-bash/model"));
             Ok(Arc::new(bash_cli_agent::BashCliAgentProvider::new(binary, mori_cli, model)))
         }
+        // 5D-3:chat-only 變體 — 類似 claude-cli,但走 gemini / codex binary。
+        // 省略 agent 旗標(--yolo / --dangerously-bypass-approvals-and-sandbox)→
+        // non-TTY 下 tool 執行無法被核准 → 純文字 in/out,可用於 routing.skills。
+        "gemini-cli" => {
+            let binary = mori_config_path()
+                .as_deref()
+                .and_then(|p| groq::read_json_pointer(p, "/providers/gemini-cli/binary"))
+                .unwrap_or_else(|| "gemini".to_string());
+            let model = mori_config_path()
+                .as_deref()
+                .and_then(|p| groq::read_json_pointer(p, "/providers/gemini-cli/model"));
+            Ok(Arc::new(bash_cli_agent::BashCliAgentProvider::new_with_protocol(
+                binary,
+                std::path::PathBuf::from("mori"),
+                model,
+                bash_cli_agent::CliProtocol::GeminiChat,
+            )))
+        }
+        "codex-cli" => {
+            let binary = mori_config_path()
+                .as_deref()
+                .and_then(|p| groq::read_json_pointer(p, "/providers/codex-cli/binary"))
+                .unwrap_or_else(|| "codex".to_string());
+            let model = mori_config_path()
+                .as_deref()
+                .and_then(|p| groq::read_json_pointer(p, "/providers/codex-cli/model"));
+            Ok(Arc::new(bash_cli_agent::BashCliAgentProvider::new_with_protocol(
+                binary,
+                std::path::PathBuf::from("mori"),
+                model,
+                bash_cli_agent::CliProtocol::CodexChat,
+            )))
+        }
         "groq" => {
             let key = groq::GroqProvider::discover_api_key().ok_or_else(|| {
                 anyhow::anyhow!(
@@ -134,7 +167,8 @@ pub fn build_named_provider(
             Ok(Arc::new(p))
         }
         other => anyhow::bail!(
-            "unknown provider name '{}' — supported: groq, ollama, claude-cli",
+            "unknown provider name '{}' — supported: groq, ollama, claude-cli, \
+             claude-bash, gemini-bash, codex-bash, gemini-cli, codex-cli",
             other
         ),
     }
@@ -154,7 +188,8 @@ pub fn build_chat_provider(
 ) -> anyhow::Result<Arc<dyn LlmProvider>> {
     let default = read_default_provider();
     let resolved = match default.as_str() {
-        "groq" | "ollama" | "claude-cli" | "claude-bash" | "gemini-bash" | "codex-bash" => default.as_str(),
+        "groq" | "ollama" | "claude-cli" | "claude-bash"
+        | "gemini-bash" | "codex-bash" | "gemini-cli" | "codex-cli" => default.as_str(),
         other => {
             tracing::warn!(
                 provider = other,
@@ -518,6 +553,20 @@ pub fn active_chat_provider_snapshot() -> ProviderSnapshot {
                 .and_then(|p| groq::read_json_pointer(p, "/providers/codex-bash/model"))
                 .unwrap_or_else(|| "(codex default)".to_string());
             ProviderSnapshot { name: "codex-bash".into(), model, base_url: None }
+        }
+        "gemini-cli" => {
+            let model = mori_config_path()
+                .as_deref()
+                .and_then(|p| groq::read_json_pointer(p, "/providers/gemini-cli/model"))
+                .unwrap_or_else(|| "(gemini default)".to_string());
+            ProviderSnapshot { name: "gemini-cli".into(), model, base_url: None }
+        }
+        "codex-cli" => {
+            let model = mori_config_path()
+                .as_deref()
+                .and_then(|p| groq::read_json_pointer(p, "/providers/codex-cli/model"))
+                .unwrap_or_else(|| "(codex default)".to_string());
+            ProviderSnapshot { name: "codex-cli".into(), model, base_url: None }
         }
         _ => {
             let model = mori_config_path()

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -108,6 +108,14 @@
 - [ ] Audit log 寫入 `~/.mori/audit.log`
 - [ ] `DownloadMediaSkill`(yt-dlp wrapper)
 
+## Phase 5D-3 — gemini-cli + codex-cli chat-only(2026-05-09,完成)
+
+- [x] `CliProtocol::GeminiChat` / `CodexChat`:省略 agent 旗標,non-TTY 下 tool 執行無法被核准 → chat-only
+- [x] `BashCliAgentProvider::new_with_protocol()`:顯式指定 protocol,不靠 binary 名稱偵測
+- [x] `supports_tool_calling() = false` → 可安全用於 `routing.skills`,不觸發 anti-recursion guard
+- [x] `build_named_provider` 新增 `"gemini-cli"` / `"codex-cli"` provider key
+- [x] README 補 config 範例
+
 ## Phase 5 — 記憶加速 + UI 美感(2026-10-11)
 
 - [ ] `MemoryStore` 加 `sqlite-vec` 加速層(向量搜尋)


### PR DESCRIPTION
## Summary

- Add `gemini-cli` and `codex-cli` as **chat-only** provider variants, so `routing.skills` can point gemini/codex as skill-internal LLM (analogous to `claude-cli`)
- New `CliProtocol::GeminiChat` / `CodexChat` — omit `--yolo` / `--dangerously-bypass-approvals-and-sandbox`; non-TTY makes tool execution impossible → effectively pure text in/out
- `supports_tool_calling() = false` prevents anti-recursion guard from kicking in and allows safe use in `routing.skills`
- `new_with_protocol()` constructor for explicit protocol selection (binary name auto-detection can't distinguish `-bash` vs `-cli` variants since they use the same binary)

## Test plan

- [x] Unit tests: `chat_only_variants_via_new_with_protocol`, `chat_only_system_prompt_has_no_mori_cli_instructions`, `protocol_detected_from_binary` (updated with `supports_tool_calling` assertions)
- [x] `cargo test -p mori-core --lib` — 55 passed, 4 ignored
- [x] `cargo build --workspace` — clean
- [ ] Manual: set `routing.skills.translate = "gemini-cli"` in `~/.mori/config.json`, say 「翻譯成英文」 → should route to gemini without triggering bash agent loop
- [ ] `cargo test -p mori-core --lib -- --ignored integration_gemini_cli` (needs `gemini` in PATH + login)

🤖 Generated with [Claude Code](https://claude.com/claude-code)