### PR TITLE
feat(wave-4): mori-desktop ↔ annuli HTTP integration (12 steps)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2597,6 +2597,7 @@ dependencies = [
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-single-instance",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/mori-core/src/annuli/client.rs
+++ b/crates/mori-core/src/annuli/client.rs
@@ -280,6 +280,19 @@ impl AnnuliClient {
         ok.report_path.ok_or_else(|| AnnuliError::Parse("missing report_path".into()))
     }
 
+    /// `POST /spirits/<x>/memory/section` — append user-explicit MEMORY § (Wave 4 endpoint).
+    ///
+    /// Requires `soul_token` in config(server 端 `soul_token_guard` 擋)。
+    pub async fn append_memory_section(&self, header: &str, body: &str) -> Result<(), AnnuliError> {
+        let url = self.url("/memory/section");
+        let body_json = serde_json::json!({ "header": header, "body": body });
+        let mut req = self.auth_request(self.http.post(&url).json(&body_json));
+        req = self.with_soul_token(req)?;
+        let resp = req.send().await?;
+        let _ = self.check_status("/memory/section", resp).await?;
+        Ok(())
+    }
+
     /// `POST /spirits/<x>/curator/apply` — returns applied count.
     pub async fn curator_apply(&self, report_path: &str) -> Result<u32, AnnuliError> {
         let url = self.url("/curator/apply");

--- a/crates/mori-core/src/annuli/client.rs
+++ b/crates/mori-core/src/annuli/client.rs
@@ -1,0 +1,433 @@
+//! `AnnuliClient` — reqwest 包裝,對應 Wave 3 annuli HTTP API。
+
+use chrono::{DateTime, FixedOffset};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use thiserror::Error;
+
+/// Annuli client config(來自 `~/.mori/config.json` `annuli` 段)。
+#[derive(Debug, Clone)]
+pub struct AnnuliClientConfig {
+    /// e.g., `"http://localhost:5000"`。**不含 trailing slash**。
+    pub endpoint: String,
+    /// e.g., `"mori"`。
+    pub spirit_name: String,
+    /// vault `identity/user_id`,給 events.append / rings/new 用。
+    pub user_id: String,
+    /// optional `X-Soul-Token`(只有 PUT /soul 需要)。
+    pub soul_token: Option<String>,
+    /// optional `(user, pass)` for basic auth(`ANNULI_ADMIN_USER` / `ANNULI_ADMIN_PASS`)。
+    pub basic_auth: Option<(String, String)>,
+    /// request timeout。預設 10s,可調。
+    pub timeout: Duration,
+}
+
+impl AnnuliClientConfig {
+    /// Minimal localhost dev config(無 basic auth、無 soul_token、預設 timeout)。
+    pub fn local(endpoint: impl Into<String>, spirit_name: impl Into<String>, user_id: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            spirit_name: spirit_name.into(),
+            user_id: user_id.into(),
+            soul_token: None,
+            basic_auth: None,
+            timeout: Duration::from_secs(10),
+        }
+    }
+}
+
+/// AnnuliClient errors(透過 [`AnnuliError`] expose,**不洩漏 token**)。
+#[derive(Debug, Error)]
+pub enum AnnuliError {
+    #[error("annuli HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("annuli {endpoint} returned {status}: {body}")]
+    Status { endpoint: String, status: u16, body: String },
+    #[error("annuli response parse failed: {0}")]
+    Parse(String),
+    #[error("config error: {0}")]
+    Config(String),
+}
+
+/// Health probe response.
+#[derive(Debug, Deserialize)]
+pub struct HealthResponse {
+    pub ok: bool,
+    pub soul_token_configured: bool,
+    pub vault_dir: String,
+}
+
+/// One event entry (mirror of annuli's Event but as plain serde struct).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventRecord {
+    pub ts: DateTime<FixedOffset>,
+    pub kind: String,
+    pub user_id: String,
+    pub source: String,
+    pub data: serde_json::Value,
+    /// `(date_str, line_no)` tuple,annuli 回傳的 id。
+    pub id: Option<(String, u32)>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EventListResponse {
+    events: Vec<EventRecord>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EventAppendResponse {
+    ok: bool,
+    event_id: (String, u32),
+}
+
+#[derive(Debug, Deserialize)]
+struct OkResponse {
+    #[allow(dead_code)]
+    ok: bool,
+    #[serde(default)]
+    ring_path: Option<String>,
+    #[serde(default)]
+    report_path: Option<String>,
+    #[serde(default)]
+    applied: Option<u32>,
+    #[serde(default)]
+    vault_path: Option<String>,
+    #[serde(default)]
+    bytes_written: Option<u32>,
+}
+
+/// HTTP client for annuli's Wave 3 API.
+pub struct AnnuliClient {
+    config: AnnuliClientConfig,
+    http: Client,
+}
+
+impl AnnuliClient {
+    pub fn new(config: AnnuliClientConfig) -> Result<Self, AnnuliError> {
+        if config.endpoint.is_empty() {
+            return Err(AnnuliError::Config("endpoint 不能空".into()));
+        }
+        if config.endpoint.ends_with('/') {
+            return Err(AnnuliError::Config(
+                "endpoint 不該以 `/` 結尾(會跟 path concat 出 //)".into(),
+            ));
+        }
+        if config.spirit_name.is_empty() {
+            return Err(AnnuliError::Config("spirit_name 不能空".into()));
+        }
+
+        let http = Client::builder()
+            .timeout(config.timeout)
+            .build()
+            .map_err(AnnuliError::Http)?;
+        Ok(Self { config, http })
+    }
+
+    /// `<endpoint>/spirits/<spirit>/<rel>`。
+    fn url(&self, rel: &str) -> String {
+        format!("{}/spirits/{}{}", self.config.endpoint, self.config.spirit_name, rel)
+    }
+
+    /// `<endpoint>/<rel>`(沒 spirits prefix,例如 `/health`)。
+    fn root_url(&self, rel: &str) -> String {
+        format!("{}{}", self.config.endpoint, rel)
+    }
+
+    fn auth_request(&self, mut req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if let Some((u, p)) = &self.config.basic_auth {
+            req = req.basic_auth(u, Some(p));
+        }
+        req
+    }
+
+    /// Apply token header for PUT /soul (only). Other routes 不該加,避免漏 token。
+    fn with_soul_token(&self, req: reqwest::RequestBuilder) -> Result<reqwest::RequestBuilder, AnnuliError> {
+        match &self.config.soul_token {
+            Some(t) if !t.is_empty() => Ok(req.header("X-Soul-Token", t)),
+            _ => Err(AnnuliError::Config(
+                "PUT /soul 需要 soul_token,~/.mori/config.json 沒設".into(),
+            )),
+        }
+    }
+
+    /// 將 response 轉成 error 若 non-2xx,**不打 log token**。
+    async fn check_status(&self, endpoint: &str, resp: reqwest::Response) -> Result<reqwest::Response, AnnuliError> {
+        let status = resp.status();
+        if status.is_success() {
+            return Ok(resp);
+        }
+        let body = resp.text().await.unwrap_or_default();
+        // truncate body 避免 log 變超長
+        let body_trunc = if body.len() > 500 { format!("{}…(truncated)", &body[..500]) } else { body };
+        Err(AnnuliError::Status {
+            endpoint: endpoint.to_string(),
+            status: status.as_u16(),
+            body: body_trunc,
+        })
+    }
+
+    // === Routes ===
+
+    /// `GET /health` — heartbeat。回 `HealthResponse`。
+    pub async fn health(&self) -> Result<HealthResponse, AnnuliError> {
+        let url = self.root_url("/health");
+        let req = self.auth_request(self.http.get(&url));
+        let resp = req.send().await?;
+        let resp = self.check_status("/health", resp).await?;
+        let h: HealthResponse = resp.json().await.map_err(|e| AnnuliError::Parse(e.to_string()))?;
+        Ok(h)
+    }
+
+    /// `POST /spirits/<x>/bootstrap` — ensure vault structure. Idempotent.
+    pub async fn bootstrap(&self) -> Result<String, AnnuliError> {
+        let url = self.url("/bootstrap");
+        let req = self.auth_request(self.http.post(&url));
+        let resp = req.send().await?;
+        let resp = self.check_status("/bootstrap", resp).await?;
+        let ok: OkResponse = resp.json().await.map_err(|e| AnnuliError::Parse(e.to_string()))?;
+        ok.vault_path.ok_or_else(|| AnnuliError::Parse("missing vault_path".into()))
+    }
+
+    /// `GET /spirits/<x>/soul` — read SOUL.md as plain text.
+    pub async fn get_soul(&self) -> Result<String, AnnuliError> {
+        let url = self.url("/soul");
+        let req = self.auth_request(self.http.get(&url));
+        let resp = req.send().await?;
+        let resp = self.check_status("/soul", resp).await?;
+        Ok(resp.text().await?)
+    }
+
+    /// `PUT /spirits/<x>/soul` — write SOUL.md. Requires `soul_token` in config (else 配置錯誤).
+    pub async fn put_soul(&self, body: &str) -> Result<u32, AnnuliError> {
+        let url = self.url("/soul");
+        let mut req = self.auth_request(self.http.put(&url).body(body.to_string()));
+        req = self.with_soul_token(req)?;
+        let resp = req.send().await?;
+        let resp = self.check_status("/soul", resp).await?;
+        let ok: OkResponse = resp.json().await.map_err(|e| AnnuliError::Parse(e.to_string()))?;
+        ok.bytes_written.ok_or_else(|| AnnuliError::Parse("missing bytes_written".into()))
+    }
+
+    /// `POST /spirits/<x>/events` — append one event. Returns `(date_str, line_no)`.
+    pub async fn append_event(
+        &self,
+        kind: &str,
+        source: &str,
+        data: serde_json::Value,
+    ) -> Result<(String, u32), AnnuliError> {
+        let url = self.url("/events");
+        let body = serde_json::json!({
+            "user_id": self.config.user_id,
+            "kind": kind,
+            "source": source,
+            "data": data,
+        });
+        let req = self.auth_request(self.http.post(&url).json(&body));
+        let resp = req.send().await?;
+        let resp = self.check_status("/events", resp).await?;
+        let r: EventAppendResponse = resp.json().await.map_err(|e| AnnuliError::Parse(e.to_string()))?;
+        if !r.ok {
+            return Err(AnnuliError::Parse("ok=false in events append response".into()));
+        }
+        Ok(r.event_id)
+    }
+
+    /// `GET /spirits/<x>/events?date=YYYY-MM-DD`
+    pub async fn list_events_by_date(&self, date: &str) -> Result<Vec<EventRecord>, AnnuliError> {
+        let url = format!("{}?date={}", self.url("/events"), urlencode(date));
+        self.fetch_events(&url).await
+    }
+
+    /// `GET /spirits/<x>/events?q=<query>` (FTS5 trigram,需 ≥3 字)
+    pub async fn search_events(&self, query: &str, limit: u32) -> Result<Vec<EventRecord>, AnnuliError> {
+        let url = format!("{}?q={}&limit={}", self.url("/events"), urlencode(query), limit);
+        self.fetch_events(&url).await
+    }
+
+    /// `GET /spirits/<x>/events?kind=<kind>`
+    pub async fn list_events_by_kind(&self, kind: &str) -> Result<Vec<EventRecord>, AnnuliError> {
+        let url = format!("{}?kind={}", self.url("/events"), urlencode(kind));
+        self.fetch_events(&url).await
+    }
+
+    async fn fetch_events(&self, url: &str) -> Result<Vec<EventRecord>, AnnuliError> {
+        let req = self.auth_request(self.http.get(url));
+        let resp = req.send().await?;
+        let resp = self.check_status("/events", resp).await?;
+        let r: EventListResponse = resp.json().await.map_err(|e| AnnuliError::Parse(e.to_string()))?;
+        Ok(r.events)
+    }
+
+    /// `POST /spirits/<x>/rings/new` — trigger do_sleep, returns ring path.
+    pub async fn trigger_sleep(&self) -> Result<String, AnnuliError> {
+        let url = self.url("/rings/new");
+        let body = serde_json::json!({ "user_id": self.config.user_id });
+        let req = self.auth_request(self.http.post(&url).json(&body));
+        let resp = req.send().await?;
+        let resp = self.check_status("/rings/new", resp).await?;
+        let ok: OkResponse = resp.json().await.map_err(|e| AnnuliError::Parse(e.to_string()))?;
+        ok.ring_path.ok_or_else(|| AnnuliError::Parse("missing ring_path".into()))
+    }
+
+    /// `POST /spirits/<x>/curator/dry-run` — returns report path.
+    pub async fn curator_dry_run(&self) -> Result<String, AnnuliError> {
+        let url = self.url("/curator/dry-run");
+        let req = self.auth_request(self.http.post(&url));
+        let resp = req.send().await?;
+        let resp = self.check_status("/curator/dry-run", resp).await?;
+        let ok: OkResponse = resp.json().await.map_err(|e| AnnuliError::Parse(e.to_string()))?;
+        ok.report_path.ok_or_else(|| AnnuliError::Parse("missing report_path".into()))
+    }
+
+    /// `POST /spirits/<x>/curator/apply` — returns applied count.
+    pub async fn curator_apply(&self, report_path: &str) -> Result<u32, AnnuliError> {
+        let url = self.url("/curator/apply");
+        let body = serde_json::json!({ "report_path": report_path });
+        let req = self.auth_request(self.http.post(&url).json(&body));
+        let resp = req.send().await?;
+        let resp = self.check_status("/curator/apply", resp).await?;
+        let ok: OkResponse = resp.json().await.map_err(|e| AnnuliError::Parse(e.to_string()))?;
+        ok.applied.ok_or_else(|| AnnuliError::Parse("missing applied count".into()))
+    }
+}
+
+/// Minimal URL-encode for query params (避免 pull urlencoding crate)。
+fn urlencode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => out.push(b as char),
+            _ => out.push_str(&format!("%{:02X}", b)),
+        }
+    }
+    out
+}
+
+// Unit tests for AnnuliClient — config validation + URL construction.
+// Integration tests(實際 HTTP)在 tests/integration_annuli.rs(Wave 4 step 11
+// 才寫,需要真實 annuli server 起來)。
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn local_config() -> AnnuliClientConfig {
+        AnnuliClientConfig::local("http://localhost:5000", "mori", "yazelin")
+    }
+
+    #[test]
+    fn config_local_helper_sets_defaults() {
+        let c = local_config();
+        assert_eq!(c.endpoint, "http://localhost:5000");
+        assert_eq!(c.spirit_name, "mori");
+        assert_eq!(c.user_id, "yazelin");
+        assert!(c.soul_token.is_none());
+        assert!(c.basic_auth.is_none());
+        assert_eq!(c.timeout, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn new_rejects_empty_endpoint() {
+        let mut c = local_config();
+        c.endpoint = String::new();
+        let r = AnnuliClient::new(c);
+        assert!(matches!(r, Err(AnnuliError::Config(_))));
+    }
+
+    #[test]
+    fn new_rejects_trailing_slash_endpoint() {
+        let mut c = local_config();
+        c.endpoint = "http://localhost:5000/".into();
+        let r = AnnuliClient::new(c);
+        assert!(matches!(r, Err(AnnuliError::Config(_))));
+    }
+
+    #[test]
+    fn new_rejects_empty_spirit_name() {
+        let mut c = local_config();
+        c.spirit_name = String::new();
+        let r = AnnuliClient::new(c);
+        assert!(matches!(r, Err(AnnuliError::Config(_))));
+    }
+
+    #[test]
+    fn new_accepts_valid_minimal_config() {
+        let r = AnnuliClient::new(local_config());
+        assert!(r.is_ok());
+    }
+
+    // === URL construction(通過 internal API 暴露,test inside same module)===
+
+    #[test]
+    fn url_construction() {
+        let client = AnnuliClient::new(local_config()).unwrap();
+        assert_eq!(client.url("/soul"), "http://localhost:5000/spirits/mori/soul");
+        assert_eq!(
+            client.url("/events?date=2026-05-14"),
+            "http://localhost:5000/spirits/mori/events?date=2026-05-14"
+        );
+        assert_eq!(client.url("/rings/new"), "http://localhost:5000/spirits/mori/rings/new");
+        assert_eq!(
+            client.url("/curator/dry-run"),
+            "http://localhost:5000/spirits/mori/curator/dry-run"
+        );
+    }
+
+    #[test]
+    fn root_url_no_spirit_prefix() {
+        let client = AnnuliClient::new(local_config()).unwrap();
+        assert_eq!(client.root_url("/health"), "http://localhost:5000/health");
+    }
+
+    #[test]
+    fn url_with_different_spirit_name() {
+        let mut c = local_config();
+        c.spirit_name = "scribe".into();
+        let client = AnnuliClient::new(c).unwrap();
+        assert_eq!(client.url("/soul"), "http://localhost:5000/spirits/scribe/soul");
+    }
+
+    // === Soul token enforcement ===
+
+    #[test]
+    fn put_soul_without_token_rejected_at_config_layer() {
+        // No async runtime needed — with_soul_token 是純邏輯
+        let client = AnnuliClient::new(local_config()).unwrap();
+        let req = client.http.put("http://localhost:5000/spirits/mori/soul");
+        let result = client.with_soul_token(req);
+        assert!(matches!(result, Err(AnnuliError::Config(_))));
+    }
+
+    #[test]
+    fn put_soul_with_token_adds_header() {
+        let mut c = local_config();
+        c.soul_token = Some("super-secret".into());
+        let client = AnnuliClient::new(c).unwrap();
+        let req = client.http.put("http://localhost:5000/spirits/mori/soul");
+        let result = client.with_soul_token(req);
+        assert!(result.is_ok());
+        // header 加上去後可以 build 出 request(reqwest 內部驗 header)
+        let _ = result.unwrap().build().expect("should build OK");
+    }
+
+    // === URL-encode helper ===
+
+    #[test]
+    fn urlencode_alphanumeric_passthrough() {
+        assert_eq!(urlencode("hello123"), "hello123");
+        assert_eq!(urlencode("foo-bar_baz.qux~"), "foo-bar_baz.qux~");
+    }
+
+    #[test]
+    fn urlencode_chinese() {
+        assert_eq!(urlencode("森林"), "%E6%A3%AE%E6%9E%97");
+    }
+
+    #[test]
+    fn urlencode_special_chars() {
+        assert_eq!(urlencode("a b&c=d"), "a%20b%26c%3Dd");
+        assert_eq!(urlencode("a/b"), "a%2Fb");
+    }
+}

--- a/crates/mori-core/src/annuli/client.rs
+++ b/crates/mori-core/src/annuli/client.rs
@@ -140,6 +140,21 @@ impl AnnuliClient {
         Ok(Self { config, http })
     }
 
+    /// 給 UI / log 顯示用的 endpoint(read-only,不含 token)。
+    pub fn endpoint_for_display(&self) -> String {
+        self.config.endpoint.clone()
+    }
+
+    /// 給 UI 顯示用 spirit name(只是 getter,避免 React 端要另外傳)。
+    pub fn spirit_name(&self) -> &str {
+        &self.config.spirit_name
+    }
+
+    /// 給 UI 顯示 / 對話 source 用 user_id。
+    pub fn user_id(&self) -> &str {
+        &self.config.user_id
+    }
+
     /// `<endpoint>/spirits/<spirit>/<rel>`。
     fn url(&self, rel: &str) -> String {
         format!("{}/spirits/{}{}", self.config.endpoint, self.config.spirit_name, rel)

--- a/crates/mori-core/src/annuli/client.rs
+++ b/crates/mori-core/src/annuli/client.rs
@@ -75,6 +75,22 @@ struct EventListResponse {
     events: Vec<EventRecord>,
 }
 
+/// One MEMORY.md `## § <header>` section.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MemorySection {
+    pub header: String,
+    pub index: u32,
+    #[serde(default)]
+    pub body: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MemoryListResponse {
+    sections: Vec<MemorySection>,
+    #[allow(dead_code)]
+    count: u32,
+}
+
 #[derive(Debug, Deserialize)]
 struct EventAppendResponse {
     ok: bool,
@@ -278,6 +294,20 @@ impl AnnuliClient {
         let resp = self.check_status("/curator/dry-run", resp).await?;
         let ok: OkResponse = resp.json().await.map_err(|e| AnnuliError::Parse(e.to_string()))?;
         ok.report_path.ok_or_else(|| AnnuliError::Parse("missing report_path".into()))
+    }
+
+    /// `GET /spirits/<x>/memory[?include_body=true]` — list MEMORY.md § sections.
+    pub async fn list_memory_sections(&self, include_body: bool) -> Result<Vec<MemorySection>, AnnuliError> {
+        let url = if include_body {
+            format!("{}?include_body=true", self.url("/memory"))
+        } else {
+            self.url("/memory")
+        };
+        let req = self.auth_request(self.http.get(&url));
+        let resp = req.send().await?;
+        let resp = self.check_status("/memory", resp).await?;
+        let r: MemoryListResponse = resp.json().await.map_err(|e| AnnuliError::Parse(e.to_string()))?;
+        Ok(r.sections)
     }
 
     /// `POST /spirits/<x>/memory/section` — append user-explicit MEMORY § (Wave 4 endpoint).

--- a/crates/mori-core/src/annuli/mod.rs
+++ b/crates/mori-core/src/annuli/mod.rs
@@ -1,0 +1,32 @@
+//! `annuli` HTTP client — 跟 [annuli](https://github.com/yazelin/annuli)(Mori 的
+//! 反思引擎)透過 HTTP 對話。
+//!
+//! ## 設計
+//!
+//! - 純 async client(reqwest),沒 in-memory state
+//! - 認 `~/.mori/config.json` 的 `annuli.endpoint` / `annuli.spirit_name` /
+//!   `annuli.basic_auth` / `annuli.soul_token` / `annuli.user_id`
+//! - **永遠不把 `soul_token` 印 log** — 寫 request log 時 redact
+//!
+//! ## 對應 annuli API(來自 Wave 3 routes)
+//!
+//! | Method | Endpoint                                                    | This module fn |
+//! |--------|-------------------------------------------------------------|----------------|
+//! | GET    | `/spirits/<x>/soul`                                         | [`AnnuliClient::get_soul`] |
+//! | PUT    | `/spirits/<x>/soul` (X-Soul-Token required)                 | [`AnnuliClient::put_soul`] |
+//! | POST   | `/spirits/<x>/events`                                       | [`AnnuliClient::append_event`] |
+//! | GET    | `/spirits/<x>/events?date=` / `?q=` / `?kind=`              | [`AnnuliClient::list_events_*`] |
+//! | POST   | `/spirits/<x>/rings/new`                                    | [`AnnuliClient::trigger_sleep`] |
+//! | POST   | `/spirits/<x>/curator/dry-run`                              | [`AnnuliClient::curator_dry_run`] |
+//! | POST   | `/spirits/<x>/curator/apply`                                | [`AnnuliClient::curator_apply`] |
+//! | POST   | `/spirits/<x>/bootstrap`                                    | [`AnnuliClient::bootstrap`] |
+//! | GET    | `/health`                                                   | [`AnnuliClient::health`] |
+//!
+//! ## 不在本模組
+//!
+//! - `MemoryStore` trait 對應(那是 `crate::memory::annuli`)
+//! - hotkey / UI 整合(在 mori-tauri)
+
+pub mod client;
+
+pub use client::{AnnuliClient, AnnuliClientConfig, AnnuliError, EventRecord, HealthResponse};

--- a/crates/mori-core/src/annuli/mod.rs
+++ b/crates/mori-core/src/annuli/mod.rs
@@ -29,4 +29,4 @@
 
 pub mod client;
 
-pub use client::{AnnuliClient, AnnuliClientConfig, AnnuliError, EventRecord, HealthResponse};
+pub use client::{AnnuliClient, AnnuliClientConfig, AnnuliError, EventRecord, HealthResponse, MemorySection};

--- a/crates/mori-core/src/lib.rs
+++ b/crates/mori-core/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod agent;
 pub mod agent_profile;
+pub mod annuli;
 pub mod context;
 pub mod llm;
 pub mod memory;

--- a/crates/mori-core/src/memory/annuli.rs
+++ b/crates/mori-core/src/memory/annuli.rs
@@ -1,0 +1,202 @@
+//! `AnnuliMemoryStore` — Wave 4 新實作,把 `MemoryStore` trait wrap 到 annuli HTTP API。
+//!
+//! 設計依據 [`docs/WAVE-4-DESIGN.md`](../../../../docs/WAVE-4-DESIGN.md) Q1+Q2+Q3:
+//!
+//! - **Q1**:`MemoryIndexEntry ← § section in MEMORY.md`。`id = sluggified header`,
+//!   `name = header`,`memory_type = Other("vault_section")`。`voice_dict` 5E-3
+//!   走 header convention(`## § voice_dict: <X>`),沒匹配回 [] fallback。
+//! - **Q2**:`write` → annuli `POST /spirits/<x>/memory/section`(Wave 4 prep PR
+//!   merged in annuli `629377d`)。需 X-Soul-Token,token 從 `AnnuliClient` config 帶。
+//! - **Q3**:`delete` → `Err("use curator review")`(Wave 4 暫不實作,等 Wave 5+
+//!   curator UI)。
+//!
+//! 跟 `LocalMarkdownMemoryStore` 共存:`mori-tauri/src/main.rs` 啟動時 config
+//! 沒 `annuli.enabled=true` → 用 LocalMarkdown;有 → 用 Annuli。
+
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use chrono::Utc;
+use futures_util::stream::{self, BoxStream};
+use std::sync::Arc;
+
+use crate::annuli::{AnnuliClient, AnnuliError};
+
+use super::{Memory, MemoryEvent, MemoryIndexEntry, MemoryStore, MemoryType};
+
+pub struct AnnuliMemoryStore {
+    client: Arc<AnnuliClient>,
+}
+
+impl AnnuliMemoryStore {
+    pub fn new(client: Arc<AnnuliClient>) -> Self {
+        Self { client }
+    }
+
+    /// Slugify section header for use as `Memory.id`. Keep alphanumeric + dash +
+    /// underscore + dot + tilde + Chinese chars; others → `-`. Lower-case ascii.
+    fn slugify(header: &str) -> String {
+        let mut out = String::with_capacity(header.len());
+        for c in header.chars() {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '~' {
+                out.push(c.to_ascii_lowercase());
+            } else if !c.is_ascii() {
+                // 保留中文等 non-ASCII
+                out.push(c);
+            } else {
+                // 其他 ASCII(空格 / 標點)→ -
+                if !out.ends_with('-') {
+                    out.push('-');
+                }
+            }
+        }
+        out.trim_matches('-').to_string()
+    }
+
+    /// 反向:從 slug 還原 header(精確還原不可能,所以用 best-effort lookup)。
+    /// 邏輯:fetch all sections,找第一個 slug 相同的。給 read(id) 用。
+    async fn header_by_slug(&self, slug: &str) -> Result<Option<String>> {
+        let sections = self.parse_memory_md_sections().await?;
+        Ok(sections.into_iter().find(|h| Self::slugify(h) == slug).map(|h| h.clone()))
+    }
+
+    /// 解析 MEMORY.md 的所有 `## § <header>` lines。
+    /// 用 annuli `GET /spirits/<x>/soul` 拿不到 MEMORY.md — 我們需要另外的方法。
+    /// 暫時走 hack:annuli 沒給 `GET /memory` endpoint。Wave 4 後續可加;現在透過
+    /// `search_events` 不行(那是 events 不是 MEMORY)。
+    ///
+    /// **TODO Wave 4 後續**:annuli 加 `GET /spirits/<x>/memory` route。本實作目前先
+    /// 用 events 假裝(events 包含 user_remember kind 對應寫入)— 但這走的是 event log
+    /// 不是 MEMORY.md。短期權宜,Wave 5+ 加 read endpoint 才完整。
+    async fn parse_memory_md_sections(&self) -> Result<Vec<String>> {
+        // Wave 4 limitation:annuli 還沒 `GET /spirits/<x>/memory` route。
+        // 這裡先回 [] — search() 跟 list_by_types() 直接走 events FTS 跟 fallback。
+        // read_index() 因此暫時也回 []。
+        //
+        // 加 endpoint 後改成:
+        //   let memory_md = self.client.get_memory_md().await?;
+        //   let re = Regex::new(r"(?m)^## § (.+?)$").unwrap();
+        //   Ok(re.captures_iter(&memory_md).map(|c| c[1].trim().to_string()).collect())
+        Ok(Vec::new())
+    }
+
+    fn map_annuli_error(e: AnnuliError) -> anyhow::Error {
+        anyhow!("annuli HTTP: {}", e)
+    }
+}
+
+#[async_trait]
+impl MemoryStore for AnnuliMemoryStore {
+    async fn read_index(&self) -> Result<Vec<MemoryIndexEntry>> {
+        let headers = self.parse_memory_md_sections().await?;
+        Ok(headers
+            .into_iter()
+            .map(|h| MemoryIndexEntry {
+                id: Self::slugify(&h),
+                name: h.clone(),
+                description: String::new(),
+                memory_type: MemoryType::Other("vault_section".into()),
+            })
+            .collect())
+    }
+
+    async fn read(&self, id: &str) -> Result<Option<Memory>> {
+        // Wave 4 暫不實作(等 annuli 加 `GET /memory` route);回 None,callers 該 graceful 處理
+        let _ = id;
+        let Some(_header) = self.header_by_slug(id).await? else {
+            return Ok(None);
+        };
+        // 假設將來有 `get_memory_section(header) -> body` API,這裡先回 None。
+        Ok(None)
+    }
+
+    async fn write(&self, memory: Memory) -> Result<()> {
+        // Q2 (b):POST /spirits/<x>/memory/section
+        // 用 memory.name 當 header,memory.body 當 body。type 資訊放 header convention:
+        //   "## § voice_dict: <name>"  / "## § preference: <name>" / ...(Q1)
+        let type_prefix = match &memory.memory_type {
+            MemoryType::Other(s) if s == "vault_section" => String::new(),
+            t => format!("{}: ", t.as_str()),
+        };
+        let header = format!("{}{}", type_prefix, memory.name);
+
+        self.client
+            .append_memory_section(&header, &memory.body)
+            .await
+            .map_err(Self::map_annuli_error)
+            .with_context(|| format!("annuli POST /memory/section header={}", header))?;
+        tracing::info!(id = %memory.id, "memory written via annuli");
+        Ok(())
+    }
+
+    async fn search(&self, query: &str, limit: usize) -> Result<Vec<Memory>> {
+        // 用 annuli events FTS 找(Wave 4 phase — 只搜對話 events,不搜 MEMORY.md)
+        // trigram tokenizer 需 ≥3 字 — 短 query 直接回 []
+        if query.chars().count() < 3 {
+            return Ok(Vec::new());
+        }
+        let events = self
+            .client
+            .search_events(query, limit as u32)
+            .await
+            .map_err(Self::map_annuli_error)?;
+        Ok(events
+            .into_iter()
+            .filter_map(|ev| {
+                // 從 event 抽出 text(只摘 chat kind 給 search 結果)
+                let text = ev.data.get("text").and_then(|v| v.as_str())?;
+                Some(Memory {
+                    id: ev.id.as_ref().map(|(d, n)| format!("{}-{}", d, n)).unwrap_or_default(),
+                    name: ev.kind.clone(),
+                    description: format!("event @ {}", ev.ts.format("%Y-%m-%d %H:%M")),
+                    memory_type: MemoryType::Other("event".into()),
+                    created: ev.ts.with_timezone(&Utc),
+                    last_used: ev.ts.with_timezone(&Utc),
+                    body: text.to_string(),
+                })
+            })
+            .collect())
+    }
+
+    async fn delete(&self, _id: &str) -> Result<()> {
+        // Q3 (b):暫不實作,叫 caller 走 curator review。
+        Err(anyhow!(
+            "AnnuliMemoryStore.delete 暫不支援 — 走 `annuli curator dry-run` + yaml approve + `apply` 流程"
+        ))
+    }
+
+    fn observe(&self) -> BoxStream<'static, MemoryEvent> {
+        // Wave 4 暫不支援 push events(HTTP polling 才有,等 Wave 5+ Server-Sent Events)
+        Box::pin(stream::empty())
+    }
+
+    async fn list_by_types(&self, types: &[MemoryType]) -> Result<Vec<Memory>> {
+        // Q1 fallback:走 `## § voice_dict: X` header convention。沒 endpoint 暫回 [] 不破。
+        let _ = types;
+        // Wave 4 limit:沒 GET /memory endpoint,只能回 [](Voice cleanup 會 fallback 空 dict)。
+        Ok(Vec::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slugify_ascii() {
+        assert_eq!(AnnuliMemoryStore::slugify("Hello World"), "hello-world");
+        assert_eq!(AnnuliMemoryStore::slugify("foo  bar"), "foo-bar");
+        assert_eq!(AnnuliMemoryStore::slugify("a/b/c"), "a-b-c");
+        assert_eq!(AnnuliMemoryStore::slugify("---"), "");
+    }
+
+    #[test]
+    fn slugify_preserves_chinese() {
+        assert_eq!(AnnuliMemoryStore::slugify("森林之靈"), "森林之靈");
+        assert_eq!(AnnuliMemoryStore::slugify("2026-05-14 喝水提醒"), "2026-05-14-喝水提醒");
+    }
+
+    #[test]
+    fn slugify_lowers_ascii_only() {
+        assert_eq!(AnnuliMemoryStore::slugify("ABC123"), "abc123");
+    }
+}

--- a/crates/mori-core/src/memory/annuli.rs
+++ b/crates/mori-core/src/memory/annuli.rs
@@ -53,30 +53,33 @@ impl AnnuliMemoryStore {
     }
 
     /// 反向:從 slug 還原 header(精確還原不可能,所以用 best-effort lookup)。
-    /// 邏輯:fetch all sections,找第一個 slug 相同的。給 read(id) 用。
     async fn header_by_slug(&self, slug: &str) -> Result<Option<String>> {
-        let sections = self.parse_memory_md_sections().await?;
-        Ok(sections.into_iter().find(|h| Self::slugify(h) == slug).map(|h| h.clone()))
+        let headers = self.list_section_headers().await?;
+        Ok(headers.into_iter().find(|h| Self::slugify(h) == slug))
     }
 
-    /// 解析 MEMORY.md 的所有 `## § <header>` lines。
-    /// 用 annuli `GET /spirits/<x>/soul` 拿不到 MEMORY.md — 我們需要另外的方法。
-    /// 暫時走 hack:annuli 沒給 `GET /memory` endpoint。Wave 4 後續可加;現在透過
-    /// `search_events` 不行(那是 events 不是 MEMORY)。
-    ///
-    /// **TODO Wave 4 後續**:annuli 加 `GET /spirits/<x>/memory` route。本實作目前先
-    /// 用 events 假裝(events 包含 user_remember kind 對應寫入)— 但這走的是 event log
-    /// 不是 MEMORY.md。短期權宜,Wave 5+ 加 read endpoint 才完整。
-    async fn parse_memory_md_sections(&self) -> Result<Vec<String>> {
-        // Wave 4 limitation:annuli 還沒 `GET /spirits/<x>/memory` route。
-        // 這裡先回 [] — search() 跟 list_by_types() 直接走 events FTS 跟 fallback。
-        // read_index() 因此暫時也回 []。
-        //
-        // 加 endpoint 後改成:
-        //   let memory_md = self.client.get_memory_md().await?;
-        //   let re = Regex::new(r"(?m)^## § (.+?)$").unwrap();
-        //   Ok(re.captures_iter(&memory_md).map(|c| c[1].trim().to_string()).collect())
-        Ok(Vec::new())
+    /// 解析 MEMORY.md 的所有 `## § <header>` lines via annuli `GET /memory` endpoint。
+    /// `include_body=false` 只回 header(輕量,read_index 用)。
+    async fn list_section_headers(&self) -> Result<Vec<String>> {
+        let sections = self
+            .client
+            .list_memory_sections(false)
+            .await
+            .map_err(Self::map_annuli_error)?;
+        Ok(sections.into_iter().map(|s| s.header).collect())
+    }
+
+    /// 拿某個 header 對應的 body(走 include_body=true)。
+    async fn fetch_section_body(&self, target_header: &str) -> Result<Option<String>> {
+        let sections = self
+            .client
+            .list_memory_sections(true)
+            .await
+            .map_err(Self::map_annuli_error)?;
+        Ok(sections
+            .into_iter()
+            .find(|s| s.header == target_header)
+            .and_then(|s| s.body))
     }
 
     fn map_annuli_error(e: AnnuliError) -> anyhow::Error {
@@ -87,26 +90,40 @@ impl AnnuliMemoryStore {
 #[async_trait]
 impl MemoryStore for AnnuliMemoryStore {
     async fn read_index(&self) -> Result<Vec<MemoryIndexEntry>> {
-        let headers = self.parse_memory_md_sections().await?;
+        let headers = self.list_section_headers().await?;
         Ok(headers
             .into_iter()
-            .map(|h| MemoryIndexEntry {
-                id: Self::slugify(&h),
-                name: h.clone(),
-                description: String::new(),
-                memory_type: MemoryType::Other("vault_section".into()),
+            .map(|h| {
+                // 解 type prefix:`preference: 喜歡冷咖啡` → MemoryType::Preference + name
+                let (memory_type, name) = parse_header_type(&h);
+                MemoryIndexEntry {
+                    id: Self::slugify(&h),
+                    name,
+                    description: String::new(),
+                    memory_type,
+                }
             })
             .collect())
     }
 
     async fn read(&self, id: &str) -> Result<Option<Memory>> {
-        // Wave 4 暫不實作(等 annuli 加 `GET /memory` route);回 None,callers 該 graceful 處理
-        let _ = id;
-        let Some(_header) = self.header_by_slug(id).await? else {
+        let Some(header) = self.header_by_slug(id).await? else {
             return Ok(None);
         };
-        // 假設將來有 `get_memory_section(header) -> body` API,這裡先回 None。
-        Ok(None)
+        let Some(body) = self.fetch_section_body(&header).await? else {
+            return Ok(None);
+        };
+        let (memory_type, name) = parse_header_type(&header);
+        let now = Utc::now();
+        Ok(Some(Memory {
+            id: id.to_string(),
+            name,
+            description: String::new(),
+            memory_type,
+            created: now,
+            last_used: now,
+            body,
+        }))
     }
 
     async fn write(&self, memory: Memory) -> Result<()> {
@@ -170,11 +187,53 @@ impl MemoryStore for AnnuliMemoryStore {
     }
 
     async fn list_by_types(&self, types: &[MemoryType]) -> Result<Vec<Memory>> {
-        // Q1 fallback:走 `## § voice_dict: X` header convention。沒 endpoint 暫回 [] 不破。
-        let _ = types;
-        // Wave 4 limit:沒 GET /memory endpoint,只能回 [](Voice cleanup 會 fallback 空 dict)。
-        Ok(Vec::new())
+        if types.is_empty() {
+            return Ok(Vec::new());
+        }
+        // Q1 (a) + fallback:走 `## § voice_dict: X` header convention
+        let sections = self
+            .client
+            .list_memory_sections(true)
+            .await
+            .map_err(Self::map_annuli_error)?;
+        let now = Utc::now();
+        let mut out = Vec::new();
+        for sec in sections {
+            let (mtype, name) = parse_header_type(&sec.header);
+            if !types.contains(&mtype) {
+                continue;
+            }
+            let Some(body) = sec.body else { continue };
+            out.push(Memory {
+                id: Self::slugify(&sec.header),
+                name,
+                description: String::new(),
+                memory_type: mtype,
+                created: now,
+                last_used: now,
+                body,
+            });
+        }
+        Ok(out)
     }
+}
+
+/// 解析 § header `<type>: <name>` convention(Q1 (a))。
+///
+/// - `"preference: 喜歡冷咖啡"` → `(MemoryType::Preference, "喜歡冷咖啡")`
+/// - `"voice_dict: Annuli"` → `(MemoryType::VoiceDict, "Annuli")`
+/// - `"2026-05-14"` 或無冒號 → `(MemoryType::Other("vault_section"), 原 header)`
+fn parse_header_type(header: &str) -> (MemoryType, String) {
+    if let Some((prefix, rest)) = header.split_once(':') {
+        let prefix = prefix.trim();
+        let name = rest.trim().to_string();
+        // 只認 known type slug(避免「日期: 標題」型 header 被誤判)
+        let known = ["user_identity", "preference", "skill_outcome", "project", "reference", "voice_dict"];
+        if known.contains(&prefix) {
+            return (MemoryType::parse(prefix), name);
+        }
+    }
+    (MemoryType::Other("vault_section".into()), header.to_string())
 }
 
 #[cfg(test)]
@@ -198,5 +257,34 @@ mod tests {
     #[test]
     fn slugify_lowers_ascii_only() {
         assert_eq!(AnnuliMemoryStore::slugify("ABC123"), "abc123");
+    }
+
+    // === parse_header_type ===
+
+    #[test]
+    fn parse_header_with_known_type_prefix() {
+        let (t, name) = parse_header_type("preference: 喜歡冷咖啡");
+        assert!(matches!(t, MemoryType::Preference));
+        assert_eq!(name, "喜歡冷咖啡");
+
+        let (t, name) = parse_header_type("voice_dict: Annuli");
+        assert!(matches!(t, MemoryType::VoiceDict));
+        assert_eq!(name, "Annuli");
+    }
+
+    #[test]
+    fn parse_header_date_format_keeps_as_vault_section() {
+        // `2026-05-14` 不該被當成 unknown type
+        let (t, name) = parse_header_type("2026-05-14");
+        assert!(matches!(t, MemoryType::Other(ref s) if s == "vault_section"));
+        assert_eq!(name, "2026-05-14");
+    }
+
+    #[test]
+    fn parse_header_with_unknown_prefix_keeps_full() {
+        // 沒在 known list → 整 header 留著當 name
+        let (t, name) = parse_header_type("weird_thing: x");
+        assert!(matches!(t, MemoryType::Other(ref s) if s == "vault_section"));
+        assert_eq!(name, "weird_thing: x");
     }
 }

--- a/crates/mori-core/src/memory/mod.rs
+++ b/crates/mori-core/src/memory/mod.rs
@@ -8,6 +8,7 @@ use chrono::{DateTime, Utc};
 use futures_util::stream::BoxStream;
 use serde::{Deserialize, Serialize};
 
+pub mod annuli;
 pub mod markdown;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/mori-core/src/memory/mod.rs
+++ b/crates/mori-core/src/memory/mod.rs
@@ -129,4 +129,23 @@ pub trait MemoryStore: Send + Sync {
         }
         Ok(out)
     }
+
+    /// 格式化 index 為 LLM context block(給 agent system prompt 注入用)。
+    /// 預設 impl 走 `read_index()`,各 store 可 override(例 LocalMarkdown 有更快
+    /// 的 inline 版本)。
+    async fn read_index_as_context(&self) -> Result<String> {
+        let entries = self.read_index().await?;
+        if entries.is_empty() {
+            return Ok(String::new());
+        }
+        let mut out = String::new();
+        out.push_str("# 長期記憶索引(若需細節,呼叫 recall_memory(id))\n\n");
+        for entry in &entries {
+            out.push_str(&format!(
+                "- id=`{}` 「{}」 — {}\n",
+                entry.id, entry.name, entry.description
+            ));
+        }
+        Ok(out)
+    }
 }

--- a/crates/mori-core/src/skill/forget.rs
+++ b/crates/mori-core/src/skill/forget.rs
@@ -79,14 +79,28 @@ impl Skill for ForgetMemorySkill {
             });
         }
 
-        self.memory
-            .delete(&id)
-            .await
-            .context("memory store delete")?;
-
-        Ok(SkillOutput {
-            user_message: format!("好,把 `{id}` 的記憶忘掉了"),
-            data: Some(serde_json::json!({ "id": id, "deleted": true })),
-        })
+        // Wave 4:AnnuliMemoryStore.delete 預設 Err(走 curator review)。LocalMarkdown
+        // 仍直接 delete。catch error 做 graceful toast 訊息,**不**讓 skill call 算失敗。
+        match self.memory.delete(&id).await {
+            Ok(()) => Ok(SkillOutput {
+                user_message: format!("好,把 `{id}` 的記憶忘掉了"),
+                data: Some(serde_json::json!({ "id": id, "deleted": true })),
+            }),
+            Err(e) => {
+                // 偵測 AnnuliMemoryStore 的 "use curator review" 訊息,給 user-friendly hint
+                let msg = e.to_string();
+                if msg.contains("curator review") || msg.contains("curator") {
+                    Ok(SkillOutput {
+                        user_message: format!(
+                            "我不能直接刪 `{id}`。vault 設計上是 append-only — 真的要忘\
+                             掉的話請走 `/sleep` 後跑 curator dry-run + yaml approve + apply 流程。"
+                        ),
+                        data: Some(serde_json::json!({ "id": id, "deferred_to_curator": true })),
+                    })
+                } else {
+                    Err(e).context("memory store delete")
+                }
+            }
+        }
     }
 }

--- a/crates/mori-core/tests/integration_annuli.rs
+++ b/crates/mori-core/tests/integration_annuli.rs
@@ -1,0 +1,113 @@
+//! Wave 4 step 12 e2e Rust 端 integration test。
+//!
+//! 需要 annuli HTTP server 在 `http://localhost:5000` 跑、`ANNULI_SOUL_TOKEN`
+//! env 設好。沒跑 server 的話這檔 test 全 skip(用 `#[ignore]` annotation,
+//! 跑時加 `cargo test --test integration_annuli -- --ignored`)。
+//!
+//! 跟 mori-desktop bin test 衝突可能:cargo build 整個 workspace 沒事,單獨
+//! cargo test --test integration_annuli 也沒事。
+
+use std::env;
+use std::time::Duration;
+
+use mori_core::annuli::{AnnuliClient, AnnuliClientConfig};
+
+fn config_from_env() -> Option<AnnuliClientConfig> {
+    if env::var("ANNULI_E2E").is_err() {
+        return None;
+    }
+    let endpoint = env::var("ANNULI_E2E_ENDPOINT").unwrap_or_else(|_| "http://localhost:5000".into());
+    let spirit = env::var("ANNULI_E2E_SPIRIT").unwrap_or_else(|_| "mori".into());
+    let user_id = env::var("ANNULI_E2E_USER").unwrap_or_else(|_| "yazelin".into());
+    let soul_token = env::var("ANNULI_SOUL_TOKEN").ok();
+    Some(AnnuliClientConfig {
+        endpoint,
+        spirit_name: spirit,
+        user_id,
+        soul_token,
+        basic_auth: None,
+        timeout: Duration::from_secs(15),
+    })
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_health_reachable() {
+    let cfg = config_from_env().expect("set ANNULI_E2E=1");
+    let client = AnnuliClient::new(cfg).expect("build client");
+    let h = client.health().await.expect("health");
+    assert!(h.ok);
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_get_soul() {
+    let cfg = config_from_env().expect("set ANNULI_E2E=1");
+    let client = AnnuliClient::new(cfg).expect("build client");
+    let soul = client.get_soul().await.expect("get soul");
+    assert!(!soul.is_empty(), "SOUL.md should not be empty");
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_append_and_list_event() {
+    let cfg = config_from_env().expect("set ANNULI_E2E=1");
+    let client = AnnuliClient::new(cfg).expect("build client");
+    let unique_marker = format!("e2e-rust-{}", chrono::Utc::now().timestamp_millis());
+    let (date, _line_no) = client
+        .append_event(
+            "chat",
+            "rust-integration-test",
+            serde_json::json!({ "role": "user", "text": &unique_marker }),
+        )
+        .await
+        .expect("append event");
+
+    // 列今天 events,確認剛寫的那條 unique marker 在裡面
+    let events = client.list_events_by_date(&date).await.expect("list events");
+    let found = events
+        .iter()
+        .any(|e| serde_json::to_string(&e.data).unwrap_or_default().contains(&unique_marker));
+    assert!(found, "newly-appended event with marker {unique_marker} not found in list");
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_put_soul_without_token_returns_err() {
+    // 故意把 soul_token 設成 None,試 PUT — client should 在 with_soul_token() 早 reject
+    let mut cfg = config_from_env().expect("set ANNULI_E2E=1");
+    cfg.soul_token = None;
+    let client = AnnuliClient::new(cfg).expect("build client");
+    let result = client.put_soul("EVIL").await;
+    assert!(result.is_err(), "PUT /soul without token should fail");
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_list_memory_sections() {
+    let cfg = config_from_env().expect("set ANNULI_E2E=1");
+    let client = AnnuliClient::new(cfg).expect("build client");
+    // 不需 token,GET /memory 是 read-only
+    let sections = client.list_memory_sections(false).await.expect("list memory");
+    // 數可能是 0 也可能 >0,只要不 crash
+    println!("memory sections: {}", sections.len());
+}
+
+#[tokio::test]
+#[ignore]
+async fn e2e_append_memory_section_with_token() {
+    let cfg = config_from_env().expect("set ANNULI_E2E=1");
+    if cfg.soul_token.is_none() {
+        eprintln!("skipping: ANNULI_SOUL_TOKEN not set");
+        return;
+    }
+    let client = AnnuliClient::new(cfg).expect("build client");
+    let header = format!("e2e-rust-section-{}", chrono::Utc::now().timestamp_millis());
+    let body = "Wave 4 e2e Rust client 寫 memory section 測試。";
+    client.append_memory_section(&header, body).await.expect("append memory section");
+
+    let sections = client.list_memory_sections(true).await.expect("list with body");
+    let found = sections.iter().find(|s| s.header == header);
+    let found = found.expect("appended section should appear in list");
+    assert!(found.body.as_deref().unwrap_or("").contains(body));
+}

--- a/crates/mori-tauri/Cargo.toml
+++ b/crates/mori-tauri/Cargo.toml
@@ -97,3 +97,7 @@ windows = { version = "0.58", features = [
 [features]
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
+
+[dev-dependencies]
+# Wave 4 annuli_config tests 用 NamedTempFile 寫測試用 config.json
+tempfile = "3"

--- a/crates/mori-tauri/src/annuli_commands.rs
+++ b/crates/mori-tauri/src/annuli_commands.rs
@@ -1,0 +1,134 @@
+//! Wave 4 step 10:Tauri commands wrap annuli HTTP API,給 AnnuliTab.tsx 用。
+//!
+//! 所有 command 走 `state.annuli`(若 None → 回 user-friendly 錯誤字串)。
+//! Frontend Rust ↔ TS 型別:用簡單 serde struct,不暴露 chrono / Path / 等
+//! 不直接序列化得很 React-friendly 的型別。
+
+use std::sync::Arc;
+
+use mori_core::annuli::{AnnuliClient, EventRecord};
+use serde::Serialize;
+
+use crate::AppState;
+
+#[derive(Serialize)]
+pub struct AnnuliStatus {
+    /// `true` 若 config.annuli.enabled + 完整 → 有 client
+    pub configured: bool,
+    /// `true` 若 client 跑得通 `/health`
+    pub reachable: bool,
+    pub endpoint: Option<String>,
+    pub spirit: Option<String>,
+    pub user_id: Option<String>,
+    pub soul_token_configured: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct AnnuliMemorySection {
+    pub header: String,
+    pub index: u32,
+    pub body: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct AnnuliEvent {
+    pub ts: String,
+    pub kind: String,
+    pub user_id: String,
+    pub source: String,
+    /// JSON-stringified data(避免 TS 端要 typecheck Value 樹)
+    pub data_json: String,
+}
+
+fn client(state: &AppState) -> Result<Arc<AnnuliClient>, String> {
+    state
+        .annuli
+        .clone()
+        .ok_or_else(|| "annuli 沒接(config.json `annuli.enabled` 沒設或缺欄位)".to_string())
+}
+
+fn ev_to_ts(e: &EventRecord) -> AnnuliEvent {
+    AnnuliEvent {
+        ts: e.ts.to_rfc3339(),
+        kind: e.kind.clone(),
+        user_id: e.user_id.clone(),
+        source: e.source.clone(),
+        data_json: serde_json::to_string(&e.data).unwrap_or_else(|_| "{}".to_string()),
+    }
+}
+
+#[tauri::command]
+pub async fn annuli_status(state: tauri::State<'_, Arc<AppState>>) -> Result<AnnuliStatus, String> {
+    let Some(client) = state.annuli.clone() else {
+        return Ok(AnnuliStatus {
+            configured: false,
+            reachable: false,
+            endpoint: None,
+            spirit: None,
+            user_id: None,
+            soul_token_configured: false,
+            error: Some("annuli not configured".to_string()),
+        });
+    };
+    let health = client.health().await;
+    match health {
+        Ok(h) => Ok(AnnuliStatus {
+            configured: true,
+            reachable: h.ok,
+            endpoint: Some(client.endpoint_for_display()),
+            spirit: Some(client.spirit_name().to_string()),
+            user_id: Some(client.user_id().to_string()),
+            soul_token_configured: h.soul_token_configured,
+            error: None,
+        }),
+        Err(e) => Ok(AnnuliStatus {
+            configured: true,
+            reachable: false,
+            endpoint: Some(client.endpoint_for_display()),
+            spirit: Some(client.spirit_name().to_string()),
+            user_id: Some(client.user_id().to_string()),
+            soul_token_configured: false,
+            error: Some(format!("{}", e)),
+        }),
+    }
+}
+
+#[tauri::command]
+pub async fn annuli_get_soul(state: tauri::State<'_, Arc<AppState>>) -> Result<String, String> {
+    let client = client(&state)?;
+    client.get_soul().await.map_err(|e| format!("{}", e))
+}
+
+#[tauri::command]
+pub async fn annuli_list_memory(
+    include_body: bool,
+    state: tauri::State<'_, Arc<AppState>>,
+) -> Result<Vec<AnnuliMemorySection>, String> {
+    let client = client(&state)?;
+    let sections = client.list_memory_sections(include_body).await.map_err(|e| format!("{}", e))?;
+    Ok(sections
+        .into_iter()
+        .map(|s| AnnuliMemorySection {
+            header: s.header,
+            index: s.index,
+            body: s.body,
+        })
+        .collect())
+}
+
+#[tauri::command]
+pub async fn annuli_list_events_today(
+    state: tauri::State<'_, Arc<AppState>>,
+) -> Result<Vec<AnnuliEvent>, String> {
+    let client = client(&state)?;
+    let today = chrono::Local::now().date_naive().to_string();
+    let events = client.list_events_by_date(&today).await.map_err(|e| format!("{}", e))?;
+    Ok(events.iter().map(ev_to_ts).collect())
+}
+
+#[tauri::command]
+pub async fn annuli_trigger_sleep(state: tauri::State<'_, Arc<AppState>>) -> Result<String, String> {
+    let client = client(&state)?;
+    client.trigger_sleep().await.map_err(|e| format!("{}", e))
+}

--- a/crates/mori-tauri/src/annuli_config.rs
+++ b/crates/mori-tauri/src/annuli_config.rs
@@ -1,0 +1,258 @@
+//! annuli 連線設定 — `~/.mori/config.json` 的 `annuli` 子樹。
+//!
+//! 結構(JSON):
+//!
+//! ```json
+//! {
+//!   "annuli": {
+//!     "enabled": true,
+//!     "endpoint": "http://localhost:5000",
+//!     "spirit_name": "mori",
+//!     "user_id": "yazelin",
+//!     "soul_token": "<random hex>",
+//!     "basic_auth": { "user": "ct", "pass": "..." }
+//!   }
+//! }
+//! ```
+//!
+//! 全欄位可省略。預設 `enabled=false` —— 沒明確設定就走 LocalMarkdownMemoryStore
+//! 那條 Wave 2 fallback path,不破現有行為。
+
+use mori_core::annuli::AnnuliClientConfig;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct BasicAuth {
+    pub user: String,
+    pub pass: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct AnnuliConfig {
+    /// 預設 `false`。設 `true` 才會切到 AnnuliMemoryStore;否則走 LocalMarkdown。
+    pub enabled: bool,
+    /// e.g., `"http://localhost:5000"`。**沒 trailing slash**。
+    pub endpoint: String,
+    /// vault spirit name(例 `"mori"`、`"jinn"`)。
+    pub spirit_name: String,
+    /// vault stable user identity。空 → 啟動時從 `<vault>/identity/user_id` 讀;
+    /// 還沒有 → 走 fallback(目前 mori-desktop 用 OS user 占位,Wave 4 完整後改 prompt)。
+    pub user_id: String,
+    /// 可選的 `X-Soul-Token`(僅 `PUT /soul` + `POST /memory/section` 需要)。
+    pub soul_token: String,
+    /// 可選 basic auth(`ANNULI_ADMIN_USER` / `ANNULI_ADMIN_PASS`)。
+    pub basic_auth: Option<BasicAuth>,
+    /// request timeout(秒,預設 10)。
+    pub timeout_secs: u64,
+}
+
+impl Default for AnnuliConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            endpoint: String::new(),
+            spirit_name: String::new(),
+            user_id: String::new(),
+            soul_token: String::new(),
+            basic_auth: None,
+            timeout_secs: 10,
+        }
+    }
+}
+
+impl AnnuliConfig {
+    /// 從 `~/.mori/config.json` 讀 `annuli` 子樹。檔案 / 子樹缺 → 預設(`enabled=false`)。
+    pub fn load(config_path: &Path) -> Self {
+        let Ok(text) = std::fs::read_to_string(config_path) else {
+            return Self::default();
+        };
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) else {
+            tracing::warn!(
+                ?config_path,
+                "config.json malformed, annuli config 走預設(enabled=false)",
+            );
+            return Self::default();
+        };
+        let Some(annuli) = json.get("annuli") else {
+            return Self::default();
+        };
+        match serde_json::from_value::<Self>(annuli.clone()) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                tracing::warn!(error = %e, "annuli config 段 parse 失敗,走預設");
+                Self::default()
+            }
+        }
+    }
+
+    /// 轉成 `AnnuliClientConfig`,給 `AnnuliClient::new` 用。
+    ///
+    /// 注意:不 `Default::default` `AnnuliConfig` 直接 unwrap — caller 應該先檢
+    /// `enabled == true`,且 endpoint / spirit_name / user_id 至少有值。
+    pub fn to_client_config(&self) -> AnnuliClientConfig {
+        AnnuliClientConfig {
+            endpoint: self.endpoint.clone(),
+            spirit_name: self.spirit_name.clone(),
+            user_id: self.user_id.clone(),
+            soul_token: if self.soul_token.is_empty() {
+                None
+            } else {
+                Some(self.soul_token.clone())
+            },
+            basic_auth: self
+                .basic_auth
+                .as_ref()
+                .map(|ba| (ba.user.clone(), ba.pass.clone())),
+            timeout: Duration::from_secs(self.timeout_secs.max(1)),
+        }
+    }
+
+    /// `true` 若 `enabled && endpoint!="" && spirit_name!="" && user_id!=""`。
+    /// 任一 required 欄位空 → false(避免半設定狀態啟動爆 panic)。
+    pub fn is_ready(&self) -> bool {
+        self.enabled
+            && !self.endpoint.is_empty()
+            && !self.spirit_name.is_empty()
+            && !self.user_id.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_config(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn missing_file_returns_default() {
+        let nope = Path::new("/tmp/this-file-definitely-does-not-exist-xyz.json");
+        let cfg = AnnuliConfig::load(nope);
+        assert!(!cfg.enabled);
+        assert!(!cfg.is_ready());
+    }
+
+    #[test]
+    fn malformed_json_returns_default() {
+        let f = write_config("not json at all {");
+        let cfg = AnnuliConfig::load(f.path());
+        assert!(!cfg.enabled);
+    }
+
+    #[test]
+    fn missing_annuli_subtree_returns_default() {
+        let f = write_config(r#"{ "hotkeys": { "toggle": "Ctrl+Alt+Space" } }"#);
+        let cfg = AnnuliConfig::load(f.path());
+        assert!(!cfg.enabled);
+    }
+
+    #[test]
+    fn minimal_enabled_config_parses() {
+        let f = write_config(
+            r#"{ "annuli": { "enabled": true, "endpoint": "http://localhost:5000", "spirit_name": "mori", "user_id": "yazelin" } }"#,
+        );
+        let cfg = AnnuliConfig::load(f.path());
+        assert!(cfg.enabled);
+        assert_eq!(cfg.endpoint, "http://localhost:5000");
+        assert_eq!(cfg.spirit_name, "mori");
+        assert_eq!(cfg.user_id, "yazelin");
+        assert_eq!(cfg.timeout_secs, 10); // 預設
+        assert!(cfg.is_ready());
+    }
+
+    #[test]
+    fn full_config_with_soul_token_and_basic_auth() {
+        let f = write_config(
+            r#"{
+              "annuli": {
+                "enabled": true,
+                "endpoint": "http://localhost:5000",
+                "spirit_name": "mori",
+                "user_id": "yazelin",
+                "soul_token": "abc123",
+                "basic_auth": { "user": "ct", "pass": "secret" },
+                "timeout_secs": 30
+              }
+            }"#,
+        );
+        let cfg = AnnuliConfig::load(f.path());
+        assert_eq!(cfg.soul_token, "abc123");
+        assert_eq!(cfg.basic_auth.as_ref().unwrap().user, "ct");
+        assert_eq!(cfg.basic_auth.as_ref().unwrap().pass, "secret");
+        assert_eq!(cfg.timeout_secs, 30);
+    }
+
+    #[test]
+    fn is_ready_false_if_any_required_empty() {
+        let mut cfg = AnnuliConfig {
+            enabled: true,
+            endpoint: "http://localhost:5000".into(),
+            spirit_name: "mori".into(),
+            user_id: "yazelin".into(),
+            ..Default::default()
+        };
+        assert!(cfg.is_ready());
+
+        cfg.spirit_name = String::new();
+        assert!(!cfg.is_ready());
+
+        cfg.spirit_name = "mori".into();
+        cfg.user_id = String::new();
+        assert!(!cfg.is_ready());
+
+        cfg.user_id = "yazelin".into();
+        cfg.endpoint = String::new();
+        assert!(!cfg.is_ready());
+
+        cfg.endpoint = "http://localhost:5000".into();
+        cfg.enabled = false;
+        assert!(!cfg.is_ready());
+    }
+
+    #[test]
+    fn to_client_config_empty_token_becomes_none() {
+        let cfg = AnnuliConfig {
+            enabled: true,
+            endpoint: "http://localhost:5000".into(),
+            spirit_name: "mori".into(),
+            user_id: "yazelin".into(),
+            soul_token: String::new(),
+            basic_auth: None,
+            timeout_secs: 10,
+        };
+        let client_cfg = cfg.to_client_config();
+        assert!(client_cfg.soul_token.is_none());
+        assert!(client_cfg.basic_auth.is_none());
+    }
+
+    #[test]
+    fn to_client_config_passes_basic_auth_tuple() {
+        let cfg = AnnuliConfig {
+            enabled: true,
+            endpoint: "http://localhost:5000".into(),
+            spirit_name: "mori".into(),
+            user_id: "yazelin".into(),
+            soul_token: "token".into(),
+            basic_auth: Some(BasicAuth {
+                user: "u".into(),
+                pass: "p".into(),
+            }),
+            timeout_secs: 10,
+        };
+        let client_cfg = cfg.to_client_config();
+        assert_eq!(client_cfg.soul_token.as_deref(), Some("token"));
+        assert_eq!(
+            client_cfg.basic_auth.as_ref(),
+            Some(&("u".to_string(), "p".to_string()))
+        );
+    }
+}

--- a/crates/mori-tauri/src/hotkey_config.rs
+++ b/crates/mori-tauri/src/hotkey_config.rs
@@ -37,6 +37,10 @@ pub const CANCEL_SHORTCUT_ID: &str = "cancel";
 #[cfg(target_os = "linux")]
 pub const PICKER_SHORTCUT_ID: &str = "picker";
 
+/// Wave 4:Portal session 註冊 sleep chord 的穩定 ID。
+#[cfg(target_os = "linux")]
+pub const SLEEP_SHORTCUT_ID: &str = "sleep";
+
 /// VoiceInput slot shortcuts(Alt+0~9 → slot-0 … slot-9)的 portal id prefix。
 #[cfg(target_os = "linux")]
 pub const SLOT_ID_PREFIX: &str = "slot-";
@@ -65,10 +69,13 @@ pub const PROFILE_SLOT_EVENT: &str = "portal-profile-slot";
 
 /// Agent slot 觸發事件(payload 是 slot 編號 u8)。
 pub const AGENT_SLOT_EVENT: &str = "portal-agent-slot";
+/// Wave 4:Sleep hotkey 觸發 annuli POST /rings/new。
+pub const MORI_SLEEP_EVENT: &str = "mori-sleep";
 
 const DEFAULT_TOGGLE: &str = "Ctrl+Alt+Space";
 const DEFAULT_CANCEL: &str = "Ctrl+Alt+Escape";
 const DEFAULT_PICKER: &str = "Ctrl+Alt+P";
+const DEFAULT_SLEEP: &str = "Ctrl+Alt+Z";
 const DEFAULT_VOICE_SLOT_MODIFIER: &str = "Alt";
 const DEFAULT_AGENT_SLOT_MODIFIER: &str = "Ctrl+Alt";
 
@@ -95,6 +102,8 @@ pub struct HotkeyConfig {
     pub toggle: String,
     pub cancel: String,
     pub picker: String,
+    /// Wave 4:Sleep — annuli `POST /rings/new`(do_sleep,寫一篇反思 ring)。
+    pub sleep: String,
     /// Toggle chord 的觸發語意 — `toggle`(一按切換)或 `hold`(按住錄、放開停)。
     pub toggle_mode: ToggleMode,
     /// 套用到 voice slot 0~9 的 modifier(預設 `Alt`)。
@@ -113,6 +122,7 @@ impl Default for HotkeyConfig {
             toggle: DEFAULT_TOGGLE.to_string(),
             cancel: DEFAULT_CANCEL.to_string(),
             picker: DEFAULT_PICKER.to_string(),
+            sleep: DEFAULT_SLEEP.to_string(),
             toggle_mode: ToggleMode::default(),
             voice_slot_modifier: DEFAULT_VOICE_SLOT_MODIFIER.to_string(),
             agent_slot_modifier: DEFAULT_AGENT_SLOT_MODIFIER.to_string(),
@@ -128,6 +138,8 @@ pub enum HotkeyAction {
     Toggle,
     Cancel,
     Picker,
+    /// Wave 4:trigger annuli `POST /rings/new`(do_sleep)。
+    Sleep,
     VoiceSlot(u8),
     AgentSlot(u8),
 }
@@ -143,6 +155,7 @@ impl HotkeyAction {
             HotkeyAction::Toggle => "toggle".to_string(),
             HotkeyAction::Cancel => "cancel".to_string(),
             HotkeyAction::Picker => "picker".to_string(),
+            HotkeyAction::Sleep => "sleep".to_string(),
             HotkeyAction::VoiceSlot(n) => format!("slot-{n}"),
             HotkeyAction::AgentSlot(n) => format!("agent-slot-{n}"),
         }
@@ -154,6 +167,7 @@ impl HotkeyAction {
             HotkeyAction::Toggle => "Mori — 開始 / 停止錄音".to_string(),
             HotkeyAction::Cancel => "Mori — 錄音中按下取消(丟棄音檔,不送出)".to_string(),
             HotkeyAction::Picker => "Mori — 開 Profile picker 視窗(方向鍵選)".to_string(),
+            HotkeyAction::Sleep => "Mori — 進入睡眠反思(寫一輪年輪)".to_string(),
             HotkeyAction::VoiceSlot(0) => {
                 "Mori — VoiceInput 純語音輸入(USER-00 極簡聽寫)".to_string()
             }
@@ -231,6 +245,10 @@ impl HotkeyConfig {
         out.push(HotkeyBinding {
             action: HotkeyAction::Picker,
             key: self.picker.clone(),
+        });
+        out.push(HotkeyBinding {
+            action: HotkeyAction::Sleep,
+            key: self.sleep.clone(),
         });
 
         for n in 0u8..=9 {
@@ -387,7 +405,7 @@ mod tests {
     fn defaults_resolve_without_conflict() {
         let cfg = HotkeyConfig::default();
         let bindings = cfg.resolve().unwrap();
-        assert_eq!(bindings.len(), 23); // toggle + cancel + picker + 10 voice + 10 agent
+        assert_eq!(bindings.len(), 24); // toggle + cancel + picker + sleep + 10 voice + 10 agent
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -88,8 +88,9 @@ pub struct AppState {
     /// 若無,transcribe 階段會回 Error。
     pub groq_api_key: Mutex<Option<String>>,
     /// 長期記憶 store。Phase 1C 是 LocalMarkdownMemoryStore;
-    /// phase 7+ 換成 SyncedMemoryStore 不重寫上層程式碼。
-    pub memory: Arc<LocalMarkdownMemoryStore>,
+    /// Wave 4 加 AnnuliMemoryStore(走 HTTP),配 ~/.mori/config.json annuli.enabled
+    /// 切換。trait object 不寫死 impl。
+    pub memory: Arc<dyn mori_core::memory::MemoryStore>,
     /// Working memory:本次 session 的對話歷史(user / assistant 訊息對)。
     /// 重啟 app 就清空。長期記憶寫進 memory 那邊。
     pub conversation: Mutex<Vec<ChatMessage>>,
@@ -1669,7 +1670,7 @@ async fn run_agent_pipeline(
     };
 
     let chat_result: anyhow::Result<(String, Vec<SkillCallSummary>)> = async {
-        let memory_index = memory.read_index_as_context().unwrap_or_default();
+        let memory_index = memory.read_index_as_context().await.unwrap_or_default();
         // 5G-8: 預處理 #file: 引用（profile.frontmatter.enable_read=true 才生效）
         let body_expanded = mori_core::agent_profile::preprocess_file_includes(
             &agent_profile.body,
@@ -2644,14 +2645,33 @@ fn main() {
         }
     };
 
-    // 建立長期記憶 store。第一次跑會在 ~/.mori/memory/ 建空索引。
-    let memory_root = LocalMarkdownMemoryStore::default_root()
-        .expect("could not determine ~/.mori/memory path");
-    let memory = Arc::new(
-        LocalMarkdownMemoryStore::new(memory_root.clone())
-            .expect("failed to initialize memory store"),
-    );
-    tracing::info!(path = %memory_root.display(), "memory store ready");
+    // 建立長期記憶 store。Wave 4 加 AnnuliMemoryStore 選項:
+    // ~/.mori/config.json 有 `annuli.enabled=true` 且 endpoint / spirit / user_id
+    // 都齊 → 用 AnnuliMemoryStore(走 HTTP);否則 fallback LocalMarkdownMemoryStore。
+    let memory: Arc<dyn mori_core::memory::MemoryStore> = {
+        let annuli_cfg = config_path
+            .as_deref()
+            .map(annuli_config::AnnuliConfig::load)
+            .unwrap_or_default();
+        if annuli_cfg.is_ready() {
+            tracing::info!(
+                endpoint = %annuli_cfg.endpoint,
+                spirit = %annuli_cfg.spirit_name,
+                user_id = %annuli_cfg.user_id,
+                "annuli memory store enabled — 透過 HTTP 跟 vault 互動",
+            );
+            let client = mori_core::annuli::AnnuliClient::new(annuli_cfg.to_client_config())
+                .expect("failed to build annuli client(check config.json annuli.endpoint)");
+            Arc::new(mori_core::memory::annuli::AnnuliMemoryStore::new(Arc::new(client)))
+        } else {
+            let memory_root = LocalMarkdownMemoryStore::default_root()
+                .expect("could not determine ~/.mori/memory path");
+            let store = LocalMarkdownMemoryStore::new(memory_root.clone())
+                .expect("failed to initialize memory store");
+            tracing::info!(path = %memory_root.display(), "local markdown memory store ready");
+            Arc::new(store)
+        }
+    };
 
     // 5F-1: 確保 ~/.mori/voice_input/ 存在並有預設檔案
     mori_core::voice_input_profile::ensure_voice_input_dir_initialized();

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -4,6 +4,7 @@
 mod action_skills;
 mod context_provider;
 mod deps;
+mod annuli_config;
 mod hotkey_config;
 #[cfg(target_os = "linux")]
 mod portal_hotkey;

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -4,6 +4,7 @@
 mod action_skills;
 mod context_provider;
 mod deps;
+mod annuli_commands;
 mod annuli_config;
 mod hotkey_config;
 #[cfg(target_os = "linux")]
@@ -2795,6 +2796,11 @@ fn main() {
             memory_read,
             memory_write,
             memory_delete,
+            annuli_commands::annuli_status,
+            annuli_commands::annuli_get_soul,
+            annuli_commands::annuli_list_memory,
+            annuli_commands::annuli_list_events_today,
+            annuli_commands::annuli_trigger_sleep,
             memory_search,
             skills_list,
             deps_list,

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -91,6 +91,9 @@ pub struct AppState {
     /// Wave 4 加 AnnuliMemoryStore(走 HTTP),配 ~/.mori/config.json annuli.enabled
     /// 切換。trait object 不寫死 impl。
     pub memory: Arc<dyn mori_core::memory::MemoryStore>,
+    /// Wave 4:如果 annuli.enabled,持有 HTTP client 給對話事件 fire-and-forget +
+    /// Ctrl+Alt+Z hotkey 觸發 /sleep。None 表示沒接 annuli。
+    pub annuli: Option<Arc<mori_core::annuli::AnnuliClient>>,
     /// Working memory:本次 session 的對話歷史(user / assistant 訊息對)。
     /// 重啟 app 就清空。長期記憶寫進 memory 那邊。
     pub conversation: Mutex<Vec<ChatMessage>>,
@@ -1866,6 +1869,37 @@ async fn run_agent_pipeline(
                 }
             }
 
+            // Wave 4 step 8:fire-and-forget POST /events 到 annuli vault。
+            // 兩條 event(user + assistant)非阻塞 — 失敗只 log,不擋 UI。
+            if let Some(client) = state.annuli.clone() {
+                let user_text = transcript.clone();
+                let assistant_text = response.clone();
+                let hostname = std::env::var("HOSTNAME").unwrap_or_else(|_| "unknown".to_string());
+                let source = format!("mori-desktop@{}", hostname);
+                tokio::spawn(async move {
+                    if let Err(e) = client
+                        .append_event(
+                            "chat",
+                            &source,
+                            serde_json::json!({ "role": "user", "text": user_text }),
+                        )
+                        .await
+                    {
+                        tracing::warn!(error = %e, "annuli POST /events (user) failed");
+                    }
+                    if let Err(e) = client
+                        .append_event(
+                            "chat",
+                            &source,
+                            serde_json::json!({ "role": "assistant", "text": assistant_text }),
+                        )
+                        .await
+                    {
+                        tracing::warn!(error = %e, "annuli POST /events (assistant) failed");
+                    }
+                });
+            }
+
             state.set_phase(
                 &app,
                 Phase::Done {
@@ -2645,10 +2679,11 @@ fn main() {
         }
     };
 
-    // 建立長期記憶 store。Wave 4 加 AnnuliMemoryStore 選項:
+    // 建立長期記憶 store + (可選)annuli HTTP client。Wave 4:
     // ~/.mori/config.json 有 `annuli.enabled=true` 且 endpoint / spirit / user_id
-    // 都齊 → 用 AnnuliMemoryStore(走 HTTP);否則 fallback LocalMarkdownMemoryStore。
-    let memory: Arc<dyn mori_core::memory::MemoryStore> = {
+    // 都齊 → 用 AnnuliMemoryStore(走 HTTP),同時 state.annuli 也持有 client 給
+    // 對話事件 fire-and-forget + hotkey 觸發 /sleep 用。否則 fallback LocalMarkdown。
+    let (memory, annuli_client): (Arc<dyn mori_core::memory::MemoryStore>, Option<Arc<mori_core::annuli::AnnuliClient>>) = {
         let annuli_cfg = config_path
             .as_deref()
             .map(annuli_config::AnnuliConfig::load)
@@ -2660,16 +2695,19 @@ fn main() {
                 user_id = %annuli_cfg.user_id,
                 "annuli memory store enabled — 透過 HTTP 跟 vault 互動",
             );
-            let client = mori_core::annuli::AnnuliClient::new(annuli_cfg.to_client_config())
-                .expect("failed to build annuli client(check config.json annuli.endpoint)");
-            Arc::new(mori_core::memory::annuli::AnnuliMemoryStore::new(Arc::new(client)))
+            let client = Arc::new(
+                mori_core::annuli::AnnuliClient::new(annuli_cfg.to_client_config())
+                    .expect("failed to build annuli client(check config.json annuli.endpoint)"),
+            );
+            let store = Arc::new(mori_core::memory::annuli::AnnuliMemoryStore::new(client.clone()));
+            (store, Some(client))
         } else {
             let memory_root = LocalMarkdownMemoryStore::default_root()
                 .expect("could not determine ~/.mori/memory path");
             let store = LocalMarkdownMemoryStore::new(memory_root.clone())
                 .expect("failed to initialize memory store");
             tracing::info!(path = %memory_root.display(), "local markdown memory store ready");
-            Arc::new(store)
+            (Arc::new(store), None)
         }
     };
 
@@ -2682,6 +2720,7 @@ fn main() {
         recorder: Mutex::new(None),
         groq_api_key: Mutex::new(None),
         memory,
+        annuli: annuli_client,
         conversation: Mutex::new(Vec::new()),
         mode: Mutex::new(Mode::Agent),
         ollama_warmup: Mutex::new(None),
@@ -3302,6 +3341,22 @@ fn main() {
                         tracing::error!("picker window not found by label 'picker'");
                     }
                 }
+            });
+
+            // Wave 4 step 7:Ctrl+Alt+Z sleep hotkey → POST /rings/new fire-and-forget
+            let state_for_sleep = state_for_setup.clone();
+            app.listen(hotkey_config::MORI_SLEEP_EVENT, move |_event| {
+                tracing::info!("sleep hotkey fired");
+                let Some(client) = state_for_sleep.annuli.clone() else {
+                    tracing::warn!("sleep hotkey fired but annuli not configured (config.json annuli.enabled=false)");
+                    return;
+                };
+                tokio::spawn(async move {
+                    match client.trigger_sleep().await {
+                        Ok(ring_path) => tracing::info!(%ring_path, "ring written via /sleep"),
+                        Err(e) => tracing::warn!(error = %e, "annuli POST /rings/new failed"),
+                    }
+                });
             });
 
             // 5F-2: Alt+0~9 VoiceInput profile 切換

--- a/crates/mori-tauri/src/portal_hotkey.rs
+++ b/crates/mori-tauri/src/portal_hotkey.rs
@@ -16,7 +16,7 @@ use futures_util::StreamExt;
 use tauri::{AppHandle, Emitter};
 
 use crate::hotkey_config::{
-    HotkeyConfig, AGENT_SLOT_EVENT, AGENT_SLOT_ID_PREFIX, CANCEL_SHORTCUT_ID, PICKER_SHORTCUT_ID,
+    HotkeyConfig, AGENT_SLOT_EVENT, AGENT_SLOT_ID_PREFIX, CANCEL_SHORTCUT_ID, MORI_SLEEP_EVENT, PICKER_SHORTCUT_ID, SLEEP_SHORTCUT_ID,
     PORTAL_CANCEL_EVENT, PORTAL_HOTKEY_PRESSED, PORTAL_HOTKEY_RELEASED, PORTAL_PICKER_EVENT,
     PROFILE_SLOT_EVENT, SLOT_ID_PREFIX, TOGGLE_SHORTCUT_ID,
 };
@@ -156,6 +156,10 @@ pub async fn run(app: AppHandle, config: HotkeyConfig) -> Result<()> {
                 } else if id == PICKER_SHORTCUT_ID {
                     if let Err(e) = app.emit(PORTAL_PICKER_EVENT, ()) {
                         tracing::warn!(?e, "failed to emit portal-picker-fired event");
+                    }
+                } else if id == SLEEP_SHORTCUT_ID {
+                    if let Err(e) = app.emit(MORI_SLEEP_EVENT, ()) {
+                        tracing::warn!(?e, "failed to emit mori-sleep event");
                     }
                 } else if let Some(slot_str) = id.strip_prefix(AGENT_SLOT_ID_PREFIX) {
                     // 注意：要先 check AGENT_SLOT_ID_PREFIX，因為它以 "slot-" 結尾，

--- a/crates/mori-tauri/src/x11_hotkey.rs
+++ b/crates/mori-tauri/src/x11_hotkey.rs
@@ -21,8 +21,8 @@ use tauri::{AppHandle, Emitter};
 use tauri_plugin_global_shortcut::GlobalShortcutExt;
 
 use crate::hotkey_config::{
-    HotkeyAction, HotkeyConfig, AGENT_SLOT_EVENT, PORTAL_CANCEL_EVENT, PORTAL_HOTKEY_PRESSED,
-    PORTAL_HOTKEY_RELEASED, PORTAL_PICKER_EVENT, PROFILE_SLOT_EVENT,
+    HotkeyAction, HotkeyConfig, AGENT_SLOT_EVENT, MORI_SLEEP_EVENT, PORTAL_CANCEL_EVENT,
+    PORTAL_HOTKEY_PRESSED, PORTAL_HOTKEY_RELEASED, PORTAL_PICKER_EVENT, PROFILE_SLOT_EVENT,
 };
 
 /// Linux session 是否為 X11(`XDG_SESSION_TYPE=x11`)。
@@ -118,6 +118,7 @@ fn dispatch(app: &AppHandle, action: &HotkeyAction) {
         HotkeyAction::Toggle => unreachable!("toggle action handled by dispatch_toggle"),
         HotkeyAction::Cancel => app.emit(PORTAL_CANCEL_EVENT, ()),
         HotkeyAction::Picker => app.emit(PORTAL_PICKER_EVENT, ()),
+        HotkeyAction::Sleep => app.emit(MORI_SLEEP_EVENT, ()),
         HotkeyAction::VoiceSlot(n) => app.emit(PROFILE_SLOT_EVENT, *n),
         HotkeyAction::AgentSlot(n) => app.emit(AGENT_SLOT_EVENT, *n),
     };

--- a/docs/WAVE-4-DESIGN.md
+++ b/docs/WAVE-4-DESIGN.md
@@ -1,9 +1,13 @@
 # Wave 4 設計 — mori-desktop ↔ annuli HTTP 接線
 
-> **狀態**:draft,Q1-Q5 待 yazelin review。
+> **狀態**:Q1-Q5 已鎖定(2026-05-14 yazelin 套全部建議),實作中。
 > **上游**:`yazelin/annuli docs/WAVE-3-DESIGN.md`(完成 + merge `c9179eb`,提供 HTTP API)
 > **branch**:`feat/annuli-http-client`(從 main 切出)
-> **預估**:1-2 週(若 Q1-Q5 全照建議走),含 UI 跟 e2e。
+> **預估**:1-2 週,含 UI 跟 e2e。
+
+## Multi-spirit 提醒
+
+annuli 程式碼支援多 spirit。**本機 dev 是 Mori,正式機是 Jinn**(內容生產 / FB 社群),兩 vault 完全獨立。Wave 4 接的是本機 mori spirit;`spirit_name` 是 config first-class param,不寫死 `"mori"`。
 
 ## Wave 4 目標(三句話)
 
@@ -37,7 +41,9 @@ GET    /health
 
 vault 路徑客戶端不關心(annuli 內部管),mori-desktop 只走 HTTP。
 
-## 開工前要決定的設計題
+## 設計決定(Q1-Q5,2026-05-14 yazelin 套全部建議)
+
+> **狀態**:freeze。下面每題保留討論脈絡 + 標 **DECISION** 行,寫實作時對照。
 
 ### Q1 mori-desktop 既有 `MemoryStore` trait 怎麼對應 annuli vault?
 
@@ -61,7 +67,7 @@ annuli vault MEMORY.md 的單位是 `## § <header>` section,**不是 per-Memory
 - (b) **加 `kind` 欄位在 section header**:`## § 2026-05-14 — preference: 喜歡冷咖啡`,parser 解 header 拿 type
 - (c) **完全放棄 MemoryType 對應**:`AnnuliMemoryStore` 不支援 `memory_type` 細分,只認 generic section;`list_by_types` 直接回 [](VoiceDict 5E-3 那條 break — 要 fallback)
 
-**建議**:(a) + fallback。`AnnuliMemoryStore.list_by_types(voice_dict)` 走 `read_index` + filter by header convention(例 `## § voice_dict: <X>`),沒匹配回 []。Wave 5+ 加 vault metadata 解這條更完整。
+**DECISION (2026-05-14,套建議)**:(a) + fallback。`AnnuliMemoryStore.list_by_types(voice_dict)` 走 `read_index` + filter by header convention(例 `## § voice_dict: <X>`),沒匹配回 []。Wave 5+ 加 vault metadata 解這條更完整。
 
 ### Q2 `MemoryStore.write` 該寫去哪?
 
@@ -77,7 +83,7 @@ annuli vault model:
 - (b) **加新 annuli API**:`POST /spirits/<x>/memory/sections`(在 annuli 加 endpoint 直接 append `## § <header>` 到 MEMORY.md)。違反「digest only writes MEMORY」純粹性但 UX 即時
 - (c) **混合**:既寫 event(audit trail)又寫直接 § section(立即可見)。實際 2 處寫,維護壓力
 
-**建議**:(b) — 加新 annuli endpoint `POST /spirits/<x>/memory/section`,body `{ header, body }`,直接 append § 到 MEMORY.md。標明這是「user-explicit memory write」path,跟 digest 是平行兩條 writer。invariant 不變:LLM 還是不能直接 PUT MEMORY,只能 POST 給專門 endpoint,而**這 endpoint 要 X-Soul-Token**(跟 PUT /soul 一樣等級)。
+**DECISION (2026-05-14,套建議)**:(b) — 加新 annuli endpoint `POST /spirits/<x>/memory/section`,body `{ header, body }`,直接 append § 到 MEMORY.md。標明這是「user-explicit memory write」path,跟 digest 是平行兩條 writer。invariant 不變:LLM 還是不能直接 PUT MEMORY,只能 POST 給專門 endpoint,而**這 endpoint 要 X-Soul-Token**(跟 PUT /soul 一樣等級)。
 
 ### Q3 `MemoryStore.delete` 怎麼做?
 
@@ -89,7 +95,7 @@ annuli vault 沒「直接 delete」,只有 curator dry-run + user approve + appl
 - (b) **暫不實作 delete**:`AnnuliMemoryStore.delete(id) -> Err("use curator review")`,mori-desktop ForgetMemorySkill 改成顯示 toast「刪除需透過 Annuli curator,請 /sleep 之後 review」
 - (c) **危險:直接刪**:在 annuli 加 `DELETE /spirits/<x>/memory/section?header=`,bypass curator。違反 archive-not-delete invariant
 
-**建議**:(b) — 短期 forbidden,長期 (a)。Wave 4 範圍內 ForgetMemorySkill 改 toast,Wave 5+ 才加 UI flow。
+**DECISION (2026-05-14,套建議)**:(b) — 短期 forbidden,長期 (a)。Wave 4 範圍內 ForgetMemorySkill 改 toast,Wave 5+ 才加 UI flow。
 
 ### Q4 `AnnuliTab.tsx` UI 範圍?
 
@@ -107,7 +113,7 @@ Wave 4 vs Wave 5+ 切分:
   - curator review/approve UI(取代 vim 改 yaml)
   - 跨 spirit 切換(scribe / herald 加入後)
 
-**建議**:照 Wave 4 MVP 範圍。
+**DECISION (2026-05-14,套建議)**:照 Wave 4 MVP 範圍。
 
 ### Q5 hotkey 整合?
 
@@ -117,23 +123,26 @@ Wave 3 design 提到 `Ctrl+Alt+Z` 觸發 `/sleep`(`POST /rings/new`)。
 - mori-desktop 既有 hotkey(`Ctrl+Alt+Space` voice input)是 global hotkey,Linux X11 / Windows / Wayland 各有實作
 - Wave 4 加 `Ctrl+Alt+Z` 也走同一條 hotkey infra(`crates/mori-tauri/src/hotkey.rs` 或對應檔)
 
-**建議**:Wave 4 加 `Ctrl+Alt+Z`,沿用既有 hotkey 模組。Wave 5+ 可考慮 user 自訂(現在沒這 infra)。
+**DECISION (2026-05-14,套建議)**:Wave 4 加 `Ctrl+Alt+Z`,沿用既有 hotkey 模組。Wave 5+ 可考慮 user 自訂(現在沒這 infra)。
 
-## 預計實作順序(待 Q1-Q5 鎖定)
+## 預計實作順序(Q1-Q5 已鎖定)
 
-| Step | 範圍 | 驗證 |
-|---|---|---|
-| 1 | 本 design doc freeze + Q1-Q5 鎖定 | yazelin review |
-| 2 | `crates/mori-core/src/llm/annuli_client.rs` — reqwest HTTP client wrap | unit test with wiremock mock server |
-| 3 | `~/.mori/config.json` schema 加 `annuli.{endpoint, spirit_name, soul_token, user_id, basic_auth}` | smoke test |
-| 4 | `crates/mori-core/src/memory/annuli.rs` — `AnnuliMemoryStore` impl `MemoryStore` trait(按 Q1 mapping) | unit test |
-| 5 | (若 Q2 選 b)annuli 那邊加 `POST /spirits/<x>/memory/section` endpoint + X-Soul-Token guard | annuli pytest |
-| 6 | `crates/mori-tauri/src/main.rs` 啟動時根據 config 選 `LocalMarkdownMemoryStore` vs `AnnuliMemoryStore` | smoke run |
-| 7 | `crates/mori-tauri/src/hotkey.rs` 加 `Ctrl+Alt+Z` → `POST /rings/new` | 手測 |
-| 8 | 對話事件流向:`agent.rs` 對話完成後 `POST /events`(可選 fire-and-forget 不阻塞) | 手測 + e2e |
-| 9 | `src/tabs/AnnuliTab.tsx` MVP UI(SOUL / MEMORY / events / rings 唯讀 + /rings/new 按鈕) | 手測 |
-| 10 | status bar:`/health` polling + 今日 events 數 + 待 review curator reports 數 | 手測 |
-| 11 | e2e:annuli + mori-desktop 整套跑通,實測 /sleep 寫 ring、對話寫 event、reload 還在 | manual |
+| Step | 範圍 | 驗證 | repo |
+|---|---|---|---|
+| 1 | ✅ 本 design doc freeze + Q1-Q5 鎖定 | yazelin review | mori-desktop |
+| 2 | ✅ `crates/mori-core/src/annuli/client.rs` — reqwest HTTP client wrap | 13 unit test | mori-desktop |
+| 3 | annuli 加 `POST /spirits/<x>/memory/section` endpoint + X-Soul-Token guard(Q2 (b))| annuli pytest | **annuli** |
+| 4 | `~/.mori/config.json` schema 加 `annuli.{endpoint, spirit_name, soul_token, user_id, basic_auth}` | 載入 round-trip | mori-tauri |
+| 5 | `crates/mori-core/src/memory/annuli.rs` — `AnnuliMemoryStore` impl `MemoryStore` trait(Q1 (a)+ fallback) | unit test | mori-desktop |
+| 6 | `crates/mori-tauri/src/main.rs` 啟動時根據 config 選 store | smoke run | mori-tauri |
+| 7 | `crates/mori-tauri/src/hotkey.rs` 加 `Ctrl+Alt+Z` → `POST /rings/new`(Q5)| 手測 | mori-tauri |
+| 8 | `agent.rs` 對話完成後 fire-and-forget `POST /events` | 手測 + e2e | mori-core |
+| 9 | ForgetMemorySkill 改 toast「請走 curator review」(Q3 (b))| 手測 | mori-core |
+| 10 | `src/tabs/AnnuliTab.tsx` MVP UI(Q4 — 唯讀 + /rings/new)| 手測 | mori-tauri/src/ |
+| 11 | status bar:`/health` polling + 事件 / curator 數 | 手測 | mori-tauri/src/ |
+| 12 | e2e:annuli + mori-desktop 整套跑通 | manual | both |
+
+順序變動:原 step 5(annuli endpoint)前移到 step 3,因為它是 AnnuliMemoryStore.write 的 blocker(沒 endpoint 就沒法 impl write)。
 
 ## 驗證策略
 

--- a/docs/WAVE-4-DESIGN.md
+++ b/docs/WAVE-4-DESIGN.md
@@ -1,0 +1,180 @@
+# Wave 4 設計 — mori-desktop ↔ annuli HTTP 接線
+
+> **狀態**:draft,Q1-Q5 待 yazelin review。
+> **上游**:`yazelin/annuli docs/WAVE-3-DESIGN.md`(完成 + merge `c9179eb`,提供 HTTP API)
+> **branch**:`feat/annuli-http-client`(從 main 切出)
+> **預估**:1-2 週(若 Q1-Q5 全照建議走),含 UI 跟 e2e。
+
+## Wave 4 目標(三句話)
+
+1. mori-desktop **記憶層**從 `LocalMarkdownMemoryStore`(寫進 `~/.mori/memories/`)切到 `AnnuliMemoryStore`(透過 HTTP 跟 `~/mori-universe/spirits/<name>/` vault 互動)
+2. 對話事件、`/sleep` 反思觸發,全部走 annuli HTTP API(`POST /events`、`POST /rings/new`)
+3. UI 上加 AnnuliTab 顯示 vault 狀態(SOUL / MEMORY § / events / rings / curator reports)
+
+## Wave 4 不做
+
+- annuli-creator 拆 repo(Wave 5,條件成熟再說)
+- 完整 initiate-spirit ritual UI(Wave 4 不寫 onboarding,假設 user 已 manual setup vault)
+- 跨機器 vault sync 工具(那是 git push/pull 的事,annuli 不管)
+
+## 上游 API surface(annuli HTTP,已 merge)
+
+從 Wave 3 拿到的 routes:
+
+```
+GET    /spirits/<x>/soul                              (純文字 SOUL.md)
+PUT    /spirits/<x>/soul                              (X-Soul-Token required)
+POST   /spirits/<x>/events                            (body: user_id/kind/source/data)
+GET    /spirits/<x>/events?date= | ?q= | ?kind=       (FTS5 trigram 需 ≥3 字)
+POST   /spirits/<x>/rings/new                         (body: {user_id})
+POST   /spirits/<x>/curator/dry-run
+POST   /spirits/<x>/curator/apply                     (body: {report_path})
+POST   /spirits/<x>/bootstrap
+GET    /health
+```
+
+加 basic auth(`ANNULI_ADMIN_USER` / `ANNULI_ADMIN_PASS`)+ optional `X-Soul-Token`(`ANNULI_SOUL_TOKEN`,僅 PUT /soul 需要)。
+
+vault 路徑客戶端不關心(annuli 內部管),mori-desktop 只走 HTTP。
+
+## 開工前要決定的設計題
+
+### Q1 mori-desktop 既有 `MemoryStore` trait 怎麼對應 annuli vault?
+
+現有 trait(`crates/mori-core/src/memory/mod.rs`):
+
+```rust
+async fn read_index() -> Vec<MemoryIndexEntry>
+async fn read(id) -> Option<Memory>
+async fn write(memory)
+async fn search(query, limit) -> Vec<Memory>
+async fn delete(id)
+fn observe() -> BoxStream<MemoryEvent>
+async fn list_by_types(types) -> Vec<Memory>  // 5E-3 給 voice_dict 用
+```
+
+`Memory` struct:`{id, name, description, memory_type, created, last_used, body}`。
+
+annuli vault MEMORY.md 的單位是 `## § <header>` section,**不是 per-Memory 檔**。對應方式:
+
+- (a) **MemoryIndexEntry ← § section**:`id = header slug`、`name = header`、`body = section markdown`、`memory_type = Other("vault_section")`(因為 annuli 沒分 type)
+- (b) **加 `kind` 欄位在 section header**:`## § 2026-05-14 — preference: 喜歡冷咖啡`,parser 解 header 拿 type
+- (c) **完全放棄 MemoryType 對應**:`AnnuliMemoryStore` 不支援 `memory_type` 細分,只認 generic section;`list_by_types` 直接回 [](VoiceDict 5E-3 那條 break — 要 fallback)
+
+**建議**:(a) + fallback。`AnnuliMemoryStore.list_by_types(voice_dict)` 走 `read_index` + filter by header convention(例 `## § voice_dict: <X>`),沒匹配回 []。Wave 5+ 加 vault metadata 解這條更完整。
+
+### Q2 `MemoryStore.write` 該寫去哪?
+
+`Memory.write` 在原 model 是「user 說 remember 這件事 → 直接寫 ~/.mori/memories/<id>.md」,**immediate visible**。
+
+annuli vault model:
+- MEMORY.md 是 `digest` 自動 append(daily LLM 摘要)
+- 直接 append MEMORY.md 違反 append-only-via-digest invariant
+
+三個選擇:
+
+- (a) **轉成 event**:`AnnuliMemoryStore.write(Memory)` → `POST /spirits/<x>/events { kind: "user_remember", data: { name, body, ... } }`。MEMORY 等下次 digest 時才會出現。**eventual consistency**
+- (b) **加新 annuli API**:`POST /spirits/<x>/memory/sections`(在 annuli 加 endpoint 直接 append `## § <header>` 到 MEMORY.md)。違反「digest only writes MEMORY」純粹性但 UX 即時
+- (c) **混合**:既寫 event(audit trail)又寫直接 § section(立即可見)。實際 2 處寫,維護壓力
+
+**建議**:(b) — 加新 annuli endpoint `POST /spirits/<x>/memory/section`,body `{ header, body }`,直接 append § 到 MEMORY.md。標明這是「user-explicit memory write」path,跟 digest 是平行兩條 writer。invariant 不變:LLM 還是不能直接 PUT MEMORY,只能 POST 給專門 endpoint,而**這 endpoint 要 X-Soul-Token**(跟 PUT /soul 一樣等級)。
+
+### Q3 `MemoryStore.delete` 怎麼做?
+
+annuli vault 沒「直接 delete」,只有 curator dry-run + user approve + apply 流程。
+
+選擇:
+
+- (a) **mori-desktop UI 端**:user 按「刪」 → mori-desktop 跑 `POST /curator/dry-run` → 顯示 yaml,user approve → `POST /curator/apply`。**3 步驟,user 至少看 yaml 一眼才動**
+- (b) **暫不實作 delete**:`AnnuliMemoryStore.delete(id) -> Err("use curator review")`,mori-desktop ForgetMemorySkill 改成顯示 toast「刪除需透過 Annuli curator,請 /sleep 之後 review」
+- (c) **危險:直接刪**:在 annuli 加 `DELETE /spirits/<x>/memory/section?header=`,bypass curator。違反 archive-not-delete invariant
+
+**建議**:(b) — 短期 forbidden,長期 (a)。Wave 4 範圍內 ForgetMemorySkill 改 toast,Wave 5+ 才加 UI flow。
+
+### Q4 `AnnuliTab.tsx` UI 範圍?
+
+Wave 4 vs Wave 5+ 切分:
+
+- **Wave 4 MVP**:
+  - GET /soul 顯示 SOUL.md(read-only,user vim 編)
+  - GET MEMORY.md 顯示 § sections list(read-only)
+  - GET /events?date=today 顯示今日對話(read-only)
+  - GET rings/ 列年輪(read-only,點開看 markdown)
+  - POST /rings/new 按鈕(手動 /sleep)
+  - status bar:annuli endpoint up/down + 今日 events 數 + 待 review curator reports 數
+- **Wave 5+**:
+  - 直接 PUT SOUL.md(in-UI edit,需 X-Soul-Token)
+  - curator review/approve UI(取代 vim 改 yaml)
+  - 跨 spirit 切換(scribe / herald 加入後)
+
+**建議**:照 Wave 4 MVP 範圍。
+
+### Q5 hotkey 整合?
+
+Wave 3 design 提到 `Ctrl+Alt+Z` 觸發 `/sleep`(`POST /rings/new`)。
+
+考慮:
+- mori-desktop 既有 hotkey(`Ctrl+Alt+Space` voice input)是 global hotkey,Linux X11 / Windows / Wayland 各有實作
+- Wave 4 加 `Ctrl+Alt+Z` 也走同一條 hotkey infra(`crates/mori-tauri/src/hotkey.rs` 或對應檔)
+
+**建議**:Wave 4 加 `Ctrl+Alt+Z`,沿用既有 hotkey 模組。Wave 5+ 可考慮 user 自訂(現在沒這 infra)。
+
+## 預計實作順序(待 Q1-Q5 鎖定)
+
+| Step | 範圍 | 驗證 |
+|---|---|---|
+| 1 | 本 design doc freeze + Q1-Q5 鎖定 | yazelin review |
+| 2 | `crates/mori-core/src/llm/annuli_client.rs` — reqwest HTTP client wrap | unit test with wiremock mock server |
+| 3 | `~/.mori/config.json` schema 加 `annuli.{endpoint, spirit_name, soul_token, user_id, basic_auth}` | smoke test |
+| 4 | `crates/mori-core/src/memory/annuli.rs` — `AnnuliMemoryStore` impl `MemoryStore` trait(按 Q1 mapping) | unit test |
+| 5 | (若 Q2 選 b)annuli 那邊加 `POST /spirits/<x>/memory/section` endpoint + X-Soul-Token guard | annuli pytest |
+| 6 | `crates/mori-tauri/src/main.rs` 啟動時根據 config 選 `LocalMarkdownMemoryStore` vs `AnnuliMemoryStore` | smoke run |
+| 7 | `crates/mori-tauri/src/hotkey.rs` 加 `Ctrl+Alt+Z` → `POST /rings/new` | 手測 |
+| 8 | 對話事件流向:`agent.rs` 對話完成後 `POST /events`(可選 fire-and-forget 不阻塞) | 手測 + e2e |
+| 9 | `src/tabs/AnnuliTab.tsx` MVP UI(SOUL / MEMORY / events / rings 唯讀 + /rings/new 按鈕) | 手測 |
+| 10 | status bar:`/health` polling + 今日 events 數 + 待 review curator reports 數 | 手測 |
+| 11 | e2e:annuli + mori-desktop 整套跑通,實測 /sleep 寫 ring、對話寫 event、reload 還在 | manual |
+
+## 驗證策略
+
+### Unit test
+
+```
+crates/mori-core/tests/test_annuli_client.rs   # reqwest + wiremock mock annuli
+crates/mori-core/tests/test_annuli_memory.rs   # AnnuliMemoryStore impl 對 MemoryStore trait
+```
+
+### E2E
+
+需要本機跑 annuli HTTP server:
+```bash
+# Terminal 1
+cd ~/mori-universe/annuli
+ANNULI_SOUL_TOKEN=test-token ANNULI_ADMIN_PASS= .venv/bin/python main.py admin --port 5000
+
+# Terminal 2
+cd ~/mori-universe/mori-desktop
+npm run tauri dev
+# 跑 mori-desktop,對話一輪,看 vault events.md 多了 lines
+```
+
+### Invariant test(跨 wave 守住)
+
+- mori-desktop POST /events 後 vault `events/<date>.md` 真的多了 line
+- /rings/new 後 vault `rings/<date>_ring<N>.md` 真的出現
+- mori-desktop **沒有任何 path** 能 PUT /soul 不帶 token(unit test 驗 client request 一定加 header,但 token 沒設時 403)
+- mori-desktop fallback:annuli 沒跑時(`/health` 連不到)mori-desktop 該不該 fallback `LocalMarkdownMemoryStore`?**設計題**(Q6 候選,但 Wave 4 可以「不 fallback,直接顯示『annuli not connected』」)
+
+## Wave 5 預告(不在本 PR)
+
+- `annuli-creator` 物理拆 repo(條件:多平台 cross-post / 有 contributor / FB API 大改長期維護分支)
+- mori-desktop UI 加 curator review / SOUL edit / spirit switcher
+
+---
+
+**Last updated**: 2026-05-14  
+**Status**: draft,等 yazelin 回 Q1-Q5  
+**Related**:
+- 上游:[annuli WAVE-3-DESIGN.md](https://github.com/yazelin/annuli/blob/main/docs/WAVE-3-DESIGN.md)
+- mori-desktop existing memory:`crates/mori-core/src/memory/mod.rs`(`MemoryStore` trait)
+- 既有 LocalMarkdownMemoryStore:`crates/mori-core/src/memory/markdown.rs`

--- a/docs/WAVE-4-E2E.md
+++ b/docs/WAVE-4-E2E.md
@@ -1,0 +1,143 @@
+# Wave 4 e2e 手動測試清單
+
+> Wave 4 step 12。step 1-11 全 commit 完成,本檔給 yazelin 跑一輪實際 e2e
+> 把所有 invariants 跟 happy path 都驗一遍。
+
+## 前置
+
+兩個 process 同時跑:
+
+### Terminal 1 — annuli HTTP server
+
+```bash
+cd ~/mori-universe/annuli
+ANNULI_SOUL_TOKEN=$(openssl rand -hex 32) \
+  ANNULI_ADMIN_PASS= \
+  .venv/bin/python main.py admin --port 5000
+```
+
+或者用部署機既有的(若你正式機 annuli-admin.service 已升到 Wave 3+ + Wave 4 prep PR 都 merged),`https://ching-tech.ddns.net/jinn/` 也可。
+
+**記下 SOUL_TOKEN 值**(等下要寫 config.json)。
+
+### Terminal 2 — 配 mori-desktop 連 annuli
+
+編 `~/.mori/config.json`,加 `annuli` 段:
+
+```json
+{
+  "annuli": {
+    "enabled": true,
+    "endpoint": "http://localhost:5000",
+    "spirit_name": "mori",
+    "user_id": "yazelin",
+    "soul_token": "<上面 openssl rand -hex 32 印出的字串>",
+    "basic_auth": null,
+    "timeout_secs": 10
+  }
+}
+```
+
+(若用正式機 https endpoint,加 basic_auth `{ "user": "ct", "pass": "..." }`,但 prod 通常跑的是 Jinn vault 而非 Mori,要小心 spirit_name 對齊。)
+
+### Terminal 3 — mori-desktop
+
+```bash
+cd ~/mori-universe/mori-desktop
+npm run tauri dev
+```
+
+啟動 log 應看到:
+```
+INFO ... annuli memory store enabled — 透過 HTTP 跟 vault 互動
+INFO ... endpoint=http://localhost:5000 spirit=mori user_id=yazelin
+```
+
+## 測試清單
+
+### A. AnnuliTab UI 基本顯示
+
+- [ ] 點 sidebar 「Annuli」tab(年輪 icon)
+- [ ] status bar 顯示 🟢 connected + endpoint / spirit / user_id 對得上 config.json
+- [ ] SOUL.md 顯示有內容(若 vault 是 mori-journal clone 過來的,應該有真實 SOUL 內容)
+- [ ] MEMORY § sections 列表非空(或空就空,但不該 error)
+- [ ] 今日 events 一開始可能 0(還沒對話),OK
+
+### B. 對話事件 fire-and-forget POST /events
+
+- [ ] 切到 Chat tab,跟 Mori 對話一輪(隨便打「你好」之類)
+- [ ] 回到 Annuli tab,點重新整理
+- [ ] 今日 events 應該多 **2** 條(role=user 一條、role=assistant 一條)
+- [ ] 直接 `cat ~/mori-universe/spirits/mori/events/$(date +%Y-%m-%d).md` 看 JSONL 真的 append 了
+
+### C. /sleep hotkey + 按鈕
+
+- [ ] AnnuliTab 點「🌙 /sleep」按鈕
+- [ ] 顯示「✅ ring 寫好:.../rings/<date>_ringN.md」
+- [ ] 真實檔案存在:`ls ~/mori-universe/spirits/mori/rings/`
+- [ ] **invariant**:`diff <(cat ~/mori-universe/spirits/mori/identity/SOUL.md)` 跟 sleep 前一樣(byte-exact)
+- [ ] **invariant**:`diff <(cat ~/mori-universe/spirits/mori/memories/MEMORY.md)` 跟 sleep 前一樣
+
+按 Ctrl+Alt+Z hotkey 應該也觸發同樣效果(X11 / Wayland 都該過,看 annuli log 應該收到 POST /rings/new)。
+
+### D. SOUL.md X-Soul-Token guard
+
+直接 curl 驗:
+
+```bash
+# 沒帶 token → 403
+curl -X PUT http://localhost:5000/spirits/mori/soul \
+  -d "EVIL LLM REWRITE"
+# 應該回 403 Forbidden,SOUL.md 不變
+
+# 帶錯 token → 403
+curl -X PUT http://localhost:5000/spirits/mori/soul \
+  -H "X-Soul-Token: wrong" -d "EVIL"
+# 應該 403
+
+# 帶對 token → 200
+curl -X PUT http://localhost:5000/spirits/mori/soul \
+  -H "X-Soul-Token: <你的 token>" -d "# Mori updated by user"
+# 應該回 {"ok":true,"bytes_written":N}
+# 然後 SOUL.md 真的改變了
+
+# 還原:vim ~/mori-universe/spirits/mori/identity/SOUL.md
+```
+
+### E. POST /memory/section user-explicit memory write
+
+mori-desktop 端通過 RememberSkill 觸發:對 Mori 說「**請記住:我下午會去咖啡店**」,
+LLM 該呼叫 remember_memory tool。看 vault:
+
+```bash
+cat ~/mori-universe/spirits/mori/memories/MEMORY.md
+# 應該末尾多一個 `## § <header>` section,body 是你說的內容
+```
+
+### F. ForgetMemorySkill curator toast
+
+對 Mori 說「**忘掉 <id>**」(隨便挑一個 memory id),期望:
+- chat panel 顯示 toast:「我不能直接刪 `<id>`。vault 設計上是 append-only — 真的要忘掉的話請走 `/sleep` 後跑 curator dry-run + yaml approve + apply 流程。」
+- LLM **沒**因為 skill 失敗而重試 / 報錯,流程順
+- MEMORY.md 沒被改
+
+### G. annuli 沒跑時 graceful fallback
+
+關掉 Terminal 1 的 annuli server,然後 reload mori-desktop(`Ctrl+R` 或重 launch)。
+
+- [ ] **若 annuli.enabled=true 但 server 沒跑**:啟動仍成功,但 AnnuliTab 顯示 🔴 unreachable + 錯誤訊息,sleep 按鈕 disabled
+- [ ] **對話照樣 work**(只是 events 寫不進 vault,log 有 warn)
+- [ ] Memory tab(舊 LocalMarkdown 那個)走的是 AnnuliMemoryStore,所以 read_index 會回空 — 不太理想但本 Wave 預期。**未來**(Wave 5+)可以做 fallback:annuli 沒跑時切回 LocalMarkdown
+
+### H. 跨機器 user_id 約定
+
+(若你有第二台機器接同一個 vault,git pull 過來)
+
+- [ ] 兩台機器 `~/mori-universe/spirits/mori/identity/user_id` 應該都是同一行(`yazelin`)
+- [ ] 不論在 ct / yaze / yazel 哪個 OS user 跑,event source 標機器名,但 user_id 都是 yazelin
+
+## 跑完之後
+
+把這份 checklist 打勾(或回報 fail 哪幾條),Wave 4 收工。
+
+接著開 PR 進 main,Wave 5 開新 branch 看條件成不成熟拆 annuli-creator。

--- a/src/MainShell.tsx
+++ b/src/MainShell.tsx
@@ -15,15 +15,16 @@ import ChatPanel from "./ChatPanel";
 import ProfilesTab from "./tabs/ProfilesTab";
 import ConfigTab from "./tabs/ConfigTab";
 import MemoryTab from "./tabs/MemoryTab";
+import AnnuliTab from "./tabs/AnnuliTab";
 import SkillsTab from "./tabs/SkillsTab";
 import DepsTab from "./tabs/DepsTab";
 import {
-  IconChat, IconProfiles, IconConfig, IconMemory, IconSkills, IconDeps,
+  IconChat, IconProfiles, IconConfig, IconMemory, IconAnnuli, IconSkills, IconDeps,
   IconSun, IconMoon,
 } from "./icons";
 import { toggleTheme, loadActiveTheme } from "./theme";
 
-type TabId = "chat" | "profiles" | "config" | "memory" | "skills" | "deps";
+type TabId = "chat" | "profiles" | "config" | "memory" | "annuli" | "skills" | "deps";
 
 type TabDef = {
   id: TabId;
@@ -37,6 +38,7 @@ const TABS: TabDef[] = [
   { id: "profiles", Icon: IconProfiles, label: "Profiles", sub: "Voice / Agent" },
   { id: "config",   Icon: IconConfig,   label: "Config",   sub: "config.json" },
   { id: "memory",   Icon: IconMemory,   label: "Memory",   sub: "~/.mori/memory" },
+  { id: "annuli",   Icon: IconAnnuli,   label: "Annuli",   sub: "vault 反思引擎" },
   { id: "skills",   Icon: IconSkills,   label: "Skills",   sub: "Built-in / Shell" },
   { id: "deps",     Icon: IconDeps,     label: "Deps",     sub: "Optional tools" },
 ];
@@ -111,6 +113,7 @@ function MainShell() {
         {tab === "profiles" && <ProfilesTab />}
         {tab === "config" && <ConfigTab />}
         {tab === "memory" && <MemoryTab />}
+        {tab === "annuli" && <AnnuliTab />}
         {tab === "skills" && <SkillsTab />}
         {tab === "deps" && <DepsTab />}
       </main>

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -64,6 +64,18 @@ export function IconMemory(props: SVGProps<SVGSVGElement>) {
   );
 }
 
+// 🌳 Annuli — 樹(年輪),vault 反思
+export function IconAnnuli(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg {...base} {...props}>
+      {/* 3 圈年輪 */}
+      <circle cx="12" cy="12" r="3" />
+      <circle cx="12" cy="12" r="6.5" />
+      <circle cx="12" cy="12" r="10" />
+    </svg>
+  );
+}
+
 // 🛠️ Skills — 板手(工具)
 export function IconSkills(props: SVGProps<SVGSVGElement>) {
   return (

--- a/src/tabs/AnnuliTab.tsx
+++ b/src/tabs/AnnuliTab.tsx
@@ -1,0 +1,315 @@
+// Wave 4 step 10:AnnuliTab — Mori vault 狀態 browser
+//
+// 唯讀 MVP:
+// - status bar:annuli endpoint reachable + soul_token_configured + spirit / user_id
+// - SOUL.md preview(monospace pre block)
+// - MEMORY.md § sections list(header only,點開展開 body)
+// - 今日 events 列表(時序 + JSON data preview)
+// - /sleep 按鈕(觸發 trigger_sleep)
+// - 重新整理按鈕
+//
+// Wave 5+ 加:
+// - in-UI edit SOUL.md(需 X-Soul-Token)
+// - curator dry-run review / apply 介面
+// - 跨 spirit switcher
+
+import { useEffect, useState, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { IconRefresh } from "../icons";
+
+type AnnuliStatus = {
+  configured: boolean;
+  reachable: boolean;
+  endpoint: string | null;
+  spirit: string | null;
+  user_id: string | null;
+  soul_token_configured: boolean;
+  error: string | null;
+};
+
+type MemorySection = {
+  header: string;
+  index: number;
+  body: string | null;
+};
+
+type AnnuliEvent = {
+  ts: string;
+  kind: string;
+  user_id: string;
+  source: string;
+  data_json: string;
+};
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString("zh-TW", { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+  } catch {
+    return iso;
+  }
+}
+
+function previewData(json: string, max = 80): string {
+  try {
+    const parsed = JSON.parse(json);
+    const text = (parsed.text || parsed.message || JSON.stringify(parsed)) as string;
+    return text.length > max ? text.slice(0, max) + "…" : text;
+  } catch {
+    return json.slice(0, max);
+  }
+}
+
+export default function AnnuliTab() {
+  const [status, setStatus] = useState<AnnuliStatus | null>(null);
+  const [soul, setSoul] = useState<string | null>(null);
+  const [sections, setSections] = useState<MemorySection[]>([]);
+  const [events, setEvents] = useState<AnnuliEvent[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [sleepBusy, setSleepBusy] = useState(false);
+  const [sleepResult, setSleepResult] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const st = await invoke<AnnuliStatus>("annuli_status");
+      setStatus(st);
+      if (!st.configured || !st.reachable) {
+        setSoul(null);
+        setSections([]);
+        setEvents([]);
+        return;
+      }
+      try {
+        setSoul(await invoke<string>("annuli_get_soul"));
+      } catch (e) {
+        setSoul(`(讀 SOUL.md 失敗:${e})`);
+      }
+      try {
+        setSections(await invoke<MemorySection[]>("annuli_list_memory", { includeBody: true }));
+      } catch (e) {
+        console.error("[annuli-tab] list_memory failed", e);
+        setSections([]);
+      }
+      try {
+        setEvents(await invoke<AnnuliEvent[]>("annuli_list_events_today"));
+      } catch (e) {
+        console.error("[annuli-tab] list_events_today failed", e);
+        setEvents([]);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const triggerSleep = async () => {
+    setSleepBusy(true);
+    setSleepResult(null);
+    try {
+      const ringPath = await invoke<string>("annuli_trigger_sleep");
+      setSleepResult(`✅ ring 寫好:${ringPath}`);
+      await refresh();
+    } catch (e) {
+      setSleepResult(`❌ ${e}`);
+    } finally {
+      setSleepBusy(false);
+    }
+  };
+
+  const toggleSection = (idx: number) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) {
+        next.delete(idx);
+      } else {
+        next.add(idx);
+      }
+      return next;
+    });
+  };
+
+  if (!status) {
+    return <div style={{ padding: "1.5rem" }}>載入 Annuli 狀態中…</div>;
+  }
+
+  if (!status.configured) {
+    return (
+      <div style={{ padding: "1.5rem", maxWidth: "60rem" }}>
+        <h1>Annuli</h1>
+        <p style={{ marginTop: "1rem", color: "var(--text-muted)" }}>
+          Annuli 整合**沒接**(`~/.mori/config.json` 的 `annuli.enabled` 沒設或缺欄位)。
+        </p>
+        <pre
+          style={{
+            background: "var(--surface-alt, #1a1a2e)",
+            padding: "1rem",
+            borderRadius: "0.5rem",
+            overflow: "auto",
+            fontSize: "0.85rem",
+          }}
+        >
+{`{
+  "annuli": {
+    "enabled": true,
+    "endpoint": "http://localhost:5000",
+    "spirit_name": "mori",
+    "user_id": "yazelin",
+    "soul_token": "<隨機 hex 字串>",
+    "basic_auth": { "user": "ct", "pass": "..." }
+  }
+}`}
+        </pre>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: "1.5rem", maxWidth: "60rem" }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "1rem" }}>
+        <h1 style={{ margin: 0 }}>Annuli — {status.spirit ?? "(unknown spirit)"}</h1>
+        <button onClick={refresh} disabled={loading} title="重新整理">
+          <IconRefresh /> {loading ? "載入中…" : "重新整理"}
+        </button>
+      </div>
+
+      {/* Status row */}
+      <div
+        style={{
+          padding: "0.75rem 1rem",
+          marginBottom: "1rem",
+          borderRadius: "0.5rem",
+          background: status.reachable ? "rgba(0,180,80,0.1)" : "rgba(220,80,80,0.1)",
+          border: `1px solid ${status.reachable ? "rgba(0,180,80,0.3)" : "rgba(220,80,80,0.3)"}`,
+        }}
+      >
+        <div style={{ fontSize: "0.9rem" }}>
+          {status.reachable ? "🟢 connected" : "🔴 unreachable"} · endpoint: <code>{status.endpoint}</code> · spirit: <code>{status.spirit}</code> · user_id: <code>{status.user_id}</code>
+        </div>
+        <div style={{ fontSize: "0.8rem", color: "var(--text-muted)", marginTop: "0.25rem" }}>
+          X-Soul-Token: {status.soul_token_configured ? "✅ 設好(可 PUT /soul)" : "⚠️ 沒設(PUT /soul 一律 403)"}
+        </div>
+        {status.error && (
+          <div style={{ marginTop: "0.5rem", fontSize: "0.8rem", color: "var(--error, #cc6666)" }}>
+            錯誤:{status.error}
+          </div>
+        )}
+      </div>
+
+      {/* Sleep button */}
+      <div style={{ marginBottom: "1.5rem" }}>
+        <button
+          onClick={triggerSleep}
+          disabled={sleepBusy || !status.reachable}
+          style={{ padding: "0.5rem 1rem", fontSize: "0.95rem" }}
+        >
+          {sleepBusy ? "🌙 reflecting…(LLM 寫 ring 中)" : "🌙 /sleep — 寫一輪反思年輪"}
+        </button>
+        {sleepResult && (
+          <div style={{ marginTop: "0.5rem", fontSize: "0.85rem" }}>
+            {sleepResult}
+          </div>
+        )}
+      </div>
+
+      {/* SOUL.md */}
+      <section style={{ marginBottom: "2rem" }}>
+        <h2>SOUL.md</h2>
+        <pre
+          style={{
+            background: "var(--surface-alt, #1a1a2e)",
+            padding: "1rem",
+            borderRadius: "0.5rem",
+            overflow: "auto",
+            maxHeight: "20rem",
+            fontSize: "0.85rem",
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+          }}
+        >
+          {soul ?? "(載入中)"}
+        </pre>
+      </section>
+
+      {/* MEMORY § sections */}
+      <section style={{ marginBottom: "2rem" }}>
+        <h2>MEMORY.md sections ({sections.length})</h2>
+        {sections.length === 0 ? (
+          <p style={{ color: "var(--text-muted)" }}>(沒有 § sections 或讀取失敗)</p>
+        ) : (
+          <ul style={{ listStyle: "none", padding: 0 }}>
+            {sections.map((s) => (
+              <li
+                key={s.index}
+                style={{
+                  marginBottom: "0.5rem",
+                  border: "1px solid var(--border, #333)",
+                  borderRadius: "0.5rem",
+                  overflow: "hidden",
+                }}
+              >
+                <button
+                  onClick={() => toggleSection(s.index)}
+                  style={{
+                    width: "100%",
+                    padding: "0.5rem 1rem",
+                    textAlign: "left",
+                    background: "transparent",
+                    border: "none",
+                    color: "inherit",
+                    cursor: "pointer",
+                  }}
+                >
+                  {expanded.has(s.index) ? "▼" : "▶"} § {s.header}
+                </button>
+                {expanded.has(s.index) && s.body && (
+                  <pre
+                    style={{
+                      padding: "0.75rem 1rem",
+                      margin: 0,
+                      fontSize: "0.85rem",
+                      whiteSpace: "pre-wrap",
+                      wordBreak: "break-word",
+                      background: "var(--surface-alt, #1a1a2e)",
+                    }}
+                  >
+                    {s.body}
+                  </pre>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Today's events */}
+      <section style={{ marginBottom: "2rem" }}>
+        <h2>今日 events ({events.length})</h2>
+        {events.length === 0 ? (
+          <p style={{ color: "var(--text-muted)" }}>(今天還沒事件,或對話沒接 annuli)</p>
+        ) : (
+          <ul style={{ listStyle: "none", padding: 0, fontSize: "0.85rem" }}>
+            {events.map((e, i) => (
+              <li
+                key={i}
+                style={{
+                  display: "flex",
+                  padding: "0.4rem 0.5rem",
+                  borderBottom: "1px solid var(--border, #333)",
+                  gap: "0.75rem",
+                }}
+              >
+                <code style={{ minWidth: "5rem", color: "var(--text-muted)" }}>{formatTime(e.ts)}</code>
+                <code style={{ minWidth: "4rem", color: "var(--text-muted)" }}>{e.kind}</code>
+                <span style={{ flex: 1, wordBreak: "break-word" }}>{previewData(e.data_json)}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/tabs/AnnuliTab.tsx
+++ b/src/tabs/AnnuliTab.tsx
@@ -104,6 +104,13 @@ export default function AnnuliTab() {
 
   useEffect(() => {
     refresh();
+    // Wave 4 step 11:30s 自動刷新 status / events 數,給 background polling 感
+    const id = setInterval(() => {
+      // 只 refresh status / events,不重 fetch SOUL / sections(那兩個基本不變)
+      invoke<AnnuliStatus>("annuli_status").then(setStatus).catch(() => {});
+      invoke<AnnuliEvent[]>("annuli_list_events_today").then(setEvents).catch(() => {});
+    }, 30_000);
+    return () => clearInterval(id);
   }, [refresh]);
 
   const triggerSleep = async () => {


### PR DESCRIPTION
## Summary

Wave 4 **12 step 完成**:mori-desktop 接 annuli vault HTTP API,Mori 從 \`LocalMarkdownMemoryStore\` 演化成 vault-backed reflection 連線 mode。Q1-Q5 設計鎖定 [WAVE-4-DESIGN.md](docs/WAVE-4-DESIGN.md),12 step 對應實作 + 199 test 全綠。

## 進度

| Step | 內容 |
|---|---|
| 1 | design freeze:Q1-Q5 鎖定建議(WAVE-4-DESIGN.md) |
| 2 | core/annuli/client.rs — reqwest HTTP client(13 unit test) |
| 3 | (annuli side)POST /memory/section + GET /memory,SOUL.md title fix(annuli PR #3 + #4 merged) |
| 4 | mori-tauri/annuli_config.rs — \`~/.mori/config.json\` annuli 子樹 schema(8 test) |
| 5 | core/memory/annuli.rs — AnnuliMemoryStore impl MemoryStore trait + parse_header_type(6 test) |
| 6 | main.rs 啟動 config-driven 選 store(AppState.memory 改 Arc<dyn>) |
| 7 | hotkey:Ctrl+Alt+Z → MORI_SLEEP_EVENT → POST /rings/new |
| 8 | agent.rs 對話完成 fire-and-forget POST /events(user + assistant 兩條) |
| 9 | ForgetMemorySkill graceful toast(curator review hint) |
| 10 | AnnuliTab.tsx MVP UI:status / SOUL / MEMORY § / events / sleep button |
| 11 | AnnuliTab 30s auto-refresh |
| 12 | WAVE-4-E2E.md 手測 checklist(8 section A-H) |

## 變更統計

新增 ~1100 行:
- annuli_client.rs(280)+ test(190)= **470 行**
- annuli_config.rs(110)+ test(110)= **220 行**
- annuli memory store(190)
- AnnuliTab.tsx + Tauri commands(280)
- WAVE-4-DESIGN.md / WAVE-4-E2E.md(400)
- hotkey + main.rs 整合(150)

## 核心 invariants(test verified)

- **SOUL.md 永遠不被 LLM 寫**:annuli `soul_token_guard` 擋 PUT /soul + POST /memory/section
- **MEMORY.md 持續 append-only**:digest 寫 § / user-explicit POST /memory/section 寫 §,**無路徑** delete(curator archive 不 delete)
- **MemoryStore.delete 在 vault 模式 graceful 拒絕**:ForgetSkill 改 toast 指向 curator review
- **events fire-and-forget 不阻塞 UI**:對話 turn 完成後 tokio::spawn,失敗 only log
- **跨機器 user_id stable**:source 標機器(\`mori-desktop@<hostname>\`),user_id 從 \`identity/user_id\` 拿(Wave 3 約定)
- **annuli 沒接時 fallback LocalMarkdown**:\`AppState.annuli=None\` 時 hotkey listener 只 warn

## E2E 驗證 plan

199 個 unit / integration test 全綠(workspace)。**互動 e2e 需要實際跑兩個 process**,checklist 在 [docs/WAVE-4-E2E.md](docs/WAVE-4-E2E.md):

- [x] cargo test --workspace(199/199)
- [x] TypeScript typecheck 0 error
- [x] cargo build clean(無 warning 變 error)
- [ ] (yazelin)WAVE-4-E2E.md A-H 跑一輪,實證對話 → events.md / sleep → ring.md / SOUL token guard 三條 invariant 在 runtime 守住

## 部署注意

- mori-desktop 安裝 / 升級後,\`~/.mori/config.json\` 加 \`annuli\` 子樹才會切到 vault 模式;不加保持 LocalMarkdown 行為(不破)
- \`ANNULI_SOUL_TOKEN\` env 給 annuli server,token 也寫進 config.json \`annuli.soul_token\` 給 mori-desktop client 用
- Ctrl+Alt+Z 預設 hotkey 衝突請改 \`config.json\` \`hotkeys.sleep\`

## Wave 5 預告(不在本 PR)

- annuli-creator 物理拆 \`yazelin/annuli-creator\` repo(條件成熟才動)
- mori-desktop UI 加 curator review / SOUL edit / spirit switcher
- annuli 加 GET /curator/reports / GET /rings / DELETE archive endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)