### PR TITLE
feat(startup-mode): 預設 voice_input + config knob 可改

### DIFF
--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -807,6 +807,25 @@ fn read_voice_trim_silence_threshold() -> f32 {
         .unwrap_or(0.02)
 }
 
+/// 啟動時的預設 mode。讀 `~/.mori/config.json` 的 `startup_mode`(`"voice_input"`
+/// / `"agent"`)。預設 voice_input — dictation 是高頻路徑,啟動即可用對齊
+/// iOS / macOS 系統內建語音輸入直覺。
+fn read_startup_mode() -> Mode {
+    let path = mori_dir().join("config.json");
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return Mode::VoiceInput;
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return Mode::VoiceInput;
+    };
+    match json.pointer("/startup_mode").and_then(|v| v.as_str()) {
+        Some("agent") => Mode::Agent,
+        Some("voice_input") => Mode::VoiceInput,
+        Some("background") => Mode::Background,
+        _ => Mode::VoiceInput,
+    }
+}
+
 /// 整段 RMS 低於這個值 → 跳過 STT(視為純靜音/雜訊,Whisper 會幻覺)。
 /// 0.012 經驗值。clamp 0.001~0.2。
 fn read_voice_min_audio_rms() -> f64 {
@@ -3669,7 +3688,7 @@ fn main() {
         annuli: parking_lot::RwLock::new(annuli_client),
         annuli_supervisor: Mutex::new(None),
         conversation: Mutex::new(Vec::new()),
-        mode: Mutex::new(Mode::Agent),
+        mode: Mutex::new(read_startup_mode()),
         ollama_warmup: Mutex::new(None),
         hotkey_window_context: Mutex::new(HotkeyWindowContext::default()),
         pipeline_task: Mutex::new(None),

--- a/src/chat-panel.css
+++ b/src/chat-panel.css
@@ -113,16 +113,17 @@
 }
 .mori-bubble.user { align-self: flex-end; align-items: flex-end; }
 .mori-bubble.assistant { align-self: flex-start; align-items: flex-start; }
-/* voice_input = 語音輸入留下的紀錄(不是對話)— 置中、灰調、跟左右兩邊的對話 bubble 視覺區隔。
-   **寬度固定 90%** 不隨內容變 — log-style entry 對齊讓 user 一眼掃過去整齊,
-   不像 chat bubble 那種「短訊息窄、長訊息寬」shrink-wrap 排版。 */
+/* voice_input = 語音輸入留下的紀錄(不是對話)— 撐滿 thread 寬度,跟左右靠邊的對話 bubble
+   視覺區隔。改成 width: 100% 而非 align-self: stretch + width: auto — 後者在某些
+   browser 跟 base `.mori-bubble { max-width: 80% }` 互動有 quirk(stretch 沒生效),
+   100% explicit 最穩定。 */
 .mori-bubble.voice_input {
-  align-self: stretch;       /* 撐滿父層寬度(父層 .mori-thread 是 flex column) */
-  align-items: stretch;      /* bubble-body 也撐滿 */
-  width: auto;
-  max-width: none;
+  align-self: stretch;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  margin: 0;
   position: relative;        /* 子層 .bubble-copy-btn 用 absolute 定位 */
-  margin: 0 auto;
 }
 
 .mori-bubble .role-label {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -428,6 +428,7 @@
       "hint_llm_whisper_server": "v2: Mori no longer builds whisper.cpp itself; it now spawns the official whisper-server as a child process. Model + engine can both be installed in one click from the Deps tab — no manual config edits.",
       "hint_llm_routing_agent": "Which provider the agent loop uses (default = provider above)",
       "hint_llm_routing_skills": "skill_name → provider (empty = use agent / provider above)",
+      "hint_startup_mode": "Default mode on startup. voice_input = pure dictation, no agent; agent = chat with Mori; background = mic off. Restart to take effect.",
       "hint_voice_cleanup": "smart = LLM + programmatic / minimal = programmatic only / none = raw paste",
       "hint_voice_trim_silence": "Trim leading/trailing silence before sending audio to STT (recommended on)",
       "hint_voice_trim_silence_min_ms": "Minimum silence duration (ms) to trim, including pauses inside the recording",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -428,6 +428,7 @@
       "hint_llm_whisper_server": "v2:Mori 自己不編 whisper.cpp，改 spawn 官方 whisper-server 子程序。模型 + 引擎兩件事都可以從 Deps 頁一鍵裝完，不用手動改 config。",
       "hint_llm_routing_agent": "agent loop 用哪個 provider(預設 = provider)",
       "hint_llm_routing_skills": "skill_name → provider(空 = 用 agent / provider)",
+      "hint_startup_mode": "啟動時預設模式。voice_input = 純 dictation 不過 agent;agent = 跟 Mori 對話;background = 麥克風關。改完重啟生效",
       "hint_voice_cleanup": "smart=LLM+程式 / minimal=只程式 / none=raw 直貼",
       "hint_voice_trim_silence": "錄音送 STT 前先修剪首尾靜音（建議開啟）",
       "hint_voice_trim_silence_min_ms": "靜音連續至少幾毫秒才修剪（也會套用到中間停頓）",

--- a/src/tabs/ConfigTab.tsx
+++ b/src/tabs/ConfigTab.tsx
@@ -923,6 +923,21 @@ function ConfigTab({
             title={t("config_tab.sections.voice_input")}
             hint={t("config_tab.sections.voice_input_hint")}
           >
+            <FormRow label="startup_mode" hint={t("config_tab.rows.hint_startup_mode")}>
+              <Select
+                value={cfg.startup_mode ?? "voice_input"}
+                onChange={(v) =>
+                  applyPatch((c) => {
+                    c.startup_mode = v;
+                  })
+                }
+                options={[
+                  { value: "voice_input", label: "voice_input(dictation,啟動即可用)" },
+                  { value: "agent", label: "agent(對話模式,跟 Mori 互動)" },
+                  { value: "background", label: "background(假寐,麥克風關)" },
+                ]}
+              />
+            </FormRow>
             <FormRow label="cleanup_level" hint={t("config_tab.rows.hint_voice_cleanup")}>
               <Select
                 value={cfg.voice_input?.cleanup_level ?? "smart"}


### PR DESCRIPTION
預設啟動 mode 從 Agent 改成 VoiceInput,對齊 iOS/macOS 系統內建語音輸入直覺。

Config tab → Voice → startup_mode row 可隨時切回 agent / background。

## Test plan

- [x] cargo check
- [x] tsc
- [ ] 重啟 mori-tauri,確認 chat panel 左上顯示「VoiceInput」mode
- [ ] Config tab 改 startup_mode → agent → 重啟 → 顯示「Agent」

🤖 Generated with [Claude Code](https://claude.com/claude-code)