### PR TITLE
feat(listening): Phase 3A — Mode::Listening + openWakeWord wake-word plumbing

### DIFF
--- a/crates/mori-core/src/mode.rs
+++ b/crates/mori-core/src/mode.rs
@@ -10,11 +10,15 @@
 //!   → `PasteController` 直接貼到游標。對應 Alt+N profile。永遠單輪，
 //!   不做動作，只做「字」。
 //! - `Background` — 休眠：mic 硬關，UI 隱藏。privacy-first。
+//! - `Listening` — Hey Mori 待命（Phase 3A 起）：mic 常開但只跑 wake-word
+//!   detector，聽到「Hey Mori」才開始錄音（走當前 Agent profile 的 pipeline）。
+//!   免熱鍵、hands-free 啟動。對應 Ctrl+Alt+W toggle。
 //!
 //! ## 鍵盤直覺
 //! - Alt+N         → VoiceInput profile（「我要輸入字」）
 //! - Ctrl+Alt+N    → Agent profile（「我要叫 Mori 做事」）
-//! - Ctrl+Alt+Space → toggle 錄音（兩個 mode 共用）
+//! - Ctrl+Alt+Space → toggle 錄音（Agent / VoiceInput 共用）
+//! - Ctrl+Alt+W    → toggle Listening（進/退 Hey Mori 待命）
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -30,6 +34,10 @@ pub enum Mode {
     VoiceInput,
     /// 休眠：麥克風完全關閉。
     Background,
+    /// Hey Mori 待命：mic 常開,wake-word detector(openWakeWord python
+    /// subprocess)跑 idle 偵測。聽到「Hey Mori」→ 觸發跟主熱鍵相同的
+    /// recording → STT → agent 流程。免熱鍵 hands-free。
+    Listening,
 }
 
 impl Mode {
@@ -38,12 +46,14 @@ impl Mode {
             Mode::Agent => "agent",
             Mode::VoiceInput => "voice_input",
             Mode::Background => "background",
+            Mode::Listening => "listening",
         }
     }
 
-    /// 麥克風能不能在這個 mode 下開。Agent / VoiceInput 都需要;Background 才硬關。
+    /// 麥克風能不能在這個 mode 下開。Agent / VoiceInput / Listening 都需要;
+    /// Background 才硬關。
     pub fn allows_mic(&self) -> bool {
-        matches!(self, Mode::Agent | Mode::VoiceInput)
+        matches!(self, Mode::Agent | Mode::VoiceInput | Mode::Listening)
     }
 }
 

--- a/crates/mori-core/src/skill/set_mode.rs
+++ b/crates/mori-core/src/skill/set_mode.rs
@@ -69,6 +69,7 @@ impl Skill for SetModeSkill {
             "agent" | "active" => Mode::Agent, // "active" 為 5G 前的 alias
             "voice_input" => Mode::VoiceInput,
             "background" => Mode::Background,
+            "listening" => Mode::Listening,
             other => return Err(anyhow!("invalid mode: {other}")),
         };
 
@@ -79,6 +80,7 @@ impl Skill for SetModeSkill {
                     Mode::Agent => "我醒著呢。".to_string(),
                     Mode::VoiceInput => "已經在輸入模式了。".to_string(),
                     Mode::Background => "我已經在休眠了。".to_string(),
+                    Mode::Listening => "已經在待命,等你喊我。".to_string(),
                 },
                 data: Some(serde_json::json!({
                     "mode": target.as_str(),
@@ -96,6 +98,7 @@ impl Skill for SetModeSkill {
             Mode::Agent => "醒了,我在這。".to_string(),
             Mode::VoiceInput => "切到輸入模式 — 接下來的話會直接貼到游標位置。".to_string(),
             Mode::Background => "好,我先閉眼,叫我就回來。".to_string(),
+            Mode::Listening => "我待命著,喊「Hey Mori」就找我。".to_string(),
         };
 
         Ok(SkillOutput {

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -25,6 +25,7 @@ mod shell_skill;
 mod skill_server;
 mod theme;
 mod transcribe_cmds;
+mod wake_word;
 
 use std::sync::Arc;
 
@@ -128,6 +129,9 @@ pub struct AppState {
     /// Ctrl+Alt+Esc 在 Phase::Transcribing / Responding 階段可以 abort 它,
     /// kill_on_drop 會把 claude / gemini / codex 子程序連帶 SIGKILL。
     pub pipeline_task: Mutex<Option<tauri::async_runtime::JoinHandle<()>>>,
+    /// Phase 3A:Hey Mori wake-word listener。在 Mode::Listening 時 Some(running),
+    /// 切到別 mode 時 None(Drop 會 kill python subprocess)。
+    pub wake_word: Mutex<Option<wake_word::WakeWordListener>>,
     /// 5T: Toggle chord 的當前語意 — `Toggle`(一按切換)或 `Hold`(按住錄、放開停)。
     /// 啟動時從 `hotkey_config.toggle_mode` 讀入,`config_write` 寫完 disk 後同步
     /// 重讀更新 → 改完即時生效不必重啟。Listener 永遠掛 PRESSED + RELEASED,在
@@ -168,6 +172,81 @@ impl AppState {
         tracing::info!(?prev, ?new_mode, "mode change");
         if let Err(e) = app.emit("mode-changed", &new_mode) {
             tracing::warn!(?e, "failed to emit mode-changed");
+        }
+        // Phase 3A:Listening mode 進/退時 spawn/kill openWakeWord listener。
+        // 抽出 helper 是因為這條會被「config 改了 phrase / threshold」之類的
+        // hot-reload 路徑也用到。
+        update_wake_word_listener(self, app, prev, new_mode);
+    }
+}
+
+/// Mode 換到 Listening 時 spawn wake-word listener;退出時 kill。
+///
+/// Drop 機制本身就會 kill subprocess,所以「退出 Listening」只要 take() slot
+/// 然後 drop 即可。Spawn 失敗給 user-visible 錯誤 + revert mode 回 Agent
+/// (避免 user 卡在「在 Listening 但沒 listener」的死狀態)。
+fn update_wake_word_listener(state: &AppState, app: &AppHandle, prev: Mode, new: Mode) {
+    use crate::wake_word::{config_from_disk, WakeEvent, WakeWordListener};
+
+    let entering = !matches!(prev, Mode::Listening) && matches!(new, Mode::Listening);
+    let leaving = matches!(prev, Mode::Listening) && !matches!(new, Mode::Listening);
+
+    if leaving {
+        // Drop kills subprocess
+        if state.wake_word.lock().take().is_some() {
+            tracing::info!("wake-word listener stopped (left Listening mode)");
+        }
+        return;
+    }
+
+    if entering {
+        let cfg = config_from_disk(&mori_dir());
+        let app_for_cb = app.clone();
+        let listener = WakeWordListener::spawn(cfg, move |ev| match ev {
+            WakeEvent::Wake { word, score } => {
+                tracing::info!(word, score, "wake-word detected — triggering recording");
+                let _ = app_for_cb.emit("wake-word-detected", serde_json::json!({
+                    "word": word,
+                    "score": score,
+                }));
+                // 觸發跟「user 按主熱鍵」相同的 recording 流程。透過 IPC 事件
+                // 而非直接呼叫,是因為 callback 跑在 reader thread,要 dispatch
+                // 回 tokio runtime。`wake-word-detected` 在 main setup 那邊被
+                // listen 到、轉成 handle_hotkey_pressed 呼叫。
+            }
+            WakeEvent::Ready { model } => {
+                tracing::info!(model, "wake-word listener ready");
+                let _ = app_for_cb.emit(
+                    "wake-word-status",
+                    serde_json::json!({ "kind": "ready", "model": model }),
+                );
+            }
+            WakeEvent::Error { msg } => {
+                tracing::error!(msg, "wake-word listener error");
+                let _ = app_for_cb.emit(
+                    "wake-word-status",
+                    serde_json::json!({ "kind": "error", "msg": msg }),
+                );
+            }
+        });
+
+        match listener {
+            Ok(l) => {
+                *state.wake_word.lock() = Some(l);
+                tracing::info!("wake-word listener spawned (entered Listening mode)");
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "failed to spawn wake-word listener");
+                let _ = app.emit(
+                    "wake-word-status",
+                    serde_json::json!({
+                        "kind": "spawn_failed",
+                        "msg": format!("{e:#}"),
+                    }),
+                );
+                // 不 revert mode — user 應該看到「我選了 Listening 但出錯」的
+                // 狀態,自己決定切回。silent revert 反而難 debug。
+            }
         }
     }
 }
@@ -805,6 +884,24 @@ fn read_voice_trim_silence_threshold() -> f32 {
         .and_then(|v| v.as_f64())
         .map(|v| v.clamp(0.001, 0.2) as f32)
         .unwrap_or(0.02)
+}
+
+/// Listening mode 下,wake-word 觸發錄音後最多錄多久(秒)。
+/// Phase 3A 沒做 VAD-based 自動停,固定時間 cap。預設 10s。
+/// 之後 Phase 3B 改成 silence-based stop。
+/// clamp 2~60 秒。
+fn read_listening_max_record_secs() -> u32 {
+    let path = mori_dir().join("config.json");
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return 10;
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return 10;
+    };
+    json.pointer("/listening_mode/max_record_secs")
+        .and_then(|v| v.as_u64())
+        .map(|v| v.clamp(2, 60) as u32)
+        .unwrap_or(10)
 }
 
 /// 啟動時的預設 mode。讀 `~/.mori/config.json` 的 `startup_mode`(`"voice_input"`
@@ -2284,7 +2381,9 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
             Mode::VoiceInput => {
                 run_voice_input_pipeline(app, state, transcript, routing).await;
             }
-            Mode::Agent | Mode::Background => {
+            // Listening 模式底下 wake 觸發後的 transcript 走 agent pipeline,
+            // 跟一般 agent 對話沒區別 — 唯一差別是「啟動」靠 wake word 不靠熱鍵。
+            Mode::Agent | Mode::Background | Mode::Listening => {
                 run_agent_pipeline(app, state, transcript, routing).await;
             }
         }
@@ -3565,11 +3664,12 @@ fn refresh_floating_toggle_label(item: &MenuItem<tauri::Wry>, show_mode: &str) {
     let _ = item.set_text(label);
 }
 
-/// 把 tray 三個 mode 選單上的 label 重畫,在當下 mode 那條前面打 ✓。
+/// 把 tray 四個 mode 選單上的 label 重畫,在當下 mode 那條前面打 ✓。
 fn refresh_mode_menu_labels(
     active: &MenuItem<tauri::Wry>,
     voice_input: &MenuItem<tauri::Wry>,
     background: &MenuItem<tauri::Wry>,
+    listening: &MenuItem<tauri::Wry>,
     current: Mode,
 ) {
     let mark = |is_current: bool, base: &str| -> String {
@@ -3582,6 +3682,7 @@ fn refresh_mode_menu_labels(
     let _ = active.set_text(mark(current == Mode::Agent, "對話模式"));
     let _ = voice_input.set_text(mark(current == Mode::VoiceInput, "語音輸入模式"));
     let _ = background.set_text(mark(current == Mode::Background, "休眠(關麥克風)"));
+    let _ = listening.set_text(mark(current == Mode::Listening, "Hey Mori 待命"));
 }
 
 // ─── main ───────────────────────────────────────────────────────────
@@ -3692,6 +3793,7 @@ fn main() {
         ollama_warmup: Mutex::new(None),
         hotkey_window_context: Mutex::new(HotkeyWindowContext::default()),
         pipeline_task: Mutex::new(None),
+        wake_word: Mutex::new(None),
         // 5T: 啟動先用 default(Toggle),setup 讀 ~/.mori/config.json 後覆寫成
         // 實際值(見下方 hotkey_config 載入處)。
         toggle_mode: Mutex::new(hotkey_config::ToggleMode::default()),
@@ -3851,6 +3953,8 @@ fn main() {
                 MenuItem::with_id(app, "mode_voice_input", "語音輸入模式", true, None::<&str>)?;
             let mode_background_item =
                 MenuItem::with_id(app, "mode_background", "休眠(關麥克風)", true, None::<&str>)?;
+            let mode_listening_item =
+                MenuItem::with_id(app, "mode_listening", "Hey Mori 待命", true, None::<&str>)?;
 
             // 5K-2: 掃 ~/.mori/voice_input + ~/.mori/agent 目錄,把所有 profile
             // 列成 tray 子選單(超過 Alt+0~9 / Ctrl+Alt+0~9 的也能點)。
@@ -3922,6 +4026,7 @@ fn main() {
                     &floating_toggle_item,
                     &mode_active_item,
                     &mode_voice_input_item,
+                    &mode_listening_item,
                     &mode_background_item,
                     &voice_submenu,
                     &agent_submenu,
@@ -3935,6 +4040,7 @@ fn main() {
                 mode_active_item.clone(),
                 mode_voice_input_item.clone(),
                 mode_background_item.clone(),
+                mode_listening_item.clone(),
             );
             let floating_toggle_item_for_handler = floating_toggle_item.clone();
             // 啟動時就把 ✓ 標到目前 mode 上
@@ -3942,6 +4048,7 @@ fn main() {
                 &mode_items_for_handler.0,
                 &mode_items_for_handler.1,
                 &mode_items_for_handler.2,
+                &mode_items_for_handler.3,
                 *state_for_tray.mode.lock(),
             );
             let _tray = TrayIconBuilder::new()
@@ -4014,6 +4121,7 @@ fn main() {
                     }
                     "mode_active" => state_for_tray.set_mode(app, Mode::Agent),
                     "mode_voice_input" => state_for_tray.set_mode(app, Mode::VoiceInput),
+                    "mode_listening" => state_for_tray.set_mode(app, Mode::Listening),
                     "mode_background" => state_for_tray.set_mode(app, Mode::Background),
                     id if id.starts_with("voice_profile:") => {
                         let stem = &id["voice_profile:".len()..];
@@ -4055,17 +4163,26 @@ fn main() {
 
             // tray labels 跟著 Mode 同步:任何來源(tray 點擊、IPC、skill)改了
             // Mode 都 emit "mode-changed",這裡統一接 → 把 ✓ 標到正確的 menu item。
-            let (active_item, voice_input_item, background_item) = mode_items_for_handler;
+            let (active_item, voice_input_item, background_item, listening_item) =
+                mode_items_for_handler;
             app.listen("mode-changed", move |event| {
                 let payload = event.payload();
                 let target = if payload.contains("\"voice_input\"") {
                     Mode::VoiceInput
                 } else if payload.contains("\"background\"") {
                     Mode::Background
+                } else if payload.contains("\"listening\"") {
+                    Mode::Listening
                 } else {
                     Mode::Agent
                 };
-                refresh_mode_menu_labels(&active_item, &voice_input_item, &background_item, target);
+                refresh_mode_menu_labels(
+                    &active_item,
+                    &voice_input_item,
+                    &background_item,
+                    &listening_item,
+                    target,
+                );
             });
 
             // ── Skill HTTP server(5D)─────────────────────────────
@@ -4335,6 +4452,34 @@ fn main() {
                 "hotkey toggle/hold listeners armed (mode={:?})",
                 *state_for_setup.toggle_mode.lock(),
             );
+
+            // Phase 3A: wake-word 觸發 → 跟主熱鍵 Hold-press 等效(start_recording)。
+            // 沒 release event 的問題用 max_record_secs 計時 cap 解 — 到時間自動
+            // stop_and_transcribe。Phase 3B 換成 VAD-based silence-stop。
+            let handle_wake = app.handle().clone();
+            let state_for_wake = state_for_setup.clone();
+            app.listen("wake-word-detected", move |_event| {
+                let handle = handle_wake.clone();
+                let state = state_for_wake.clone();
+                // 不在 listener thread 裡呼叫 handle_hotkey_pressed — 它會 lock
+                // state.phase 等等,跑長一點怕擋住 Tauri event 派發。spawn 走。
+                tauri::async_runtime::spawn(async move {
+                    handle_hotkey_pressed(handle.clone(), state.clone());
+                    let max_secs = read_listening_max_record_secs();
+                    tracing::info!(max_secs, "wake-triggered recording started, auto-stop timer armed");
+                    tokio::time::sleep(std::time::Duration::from_secs(max_secs as u64)).await;
+                    // 只有當 phase 還在 Recording 時 stop_and_transcribe — user 可能在
+                    // 這段期間自己手動取消(Ctrl+Alt+Esc)或熱鍵又 toggle 走了。
+                    let still_recording = matches!(
+                        *state.phase.lock(),
+                        Phase::Recording { .. }
+                    );
+                    if still_recording {
+                        tracing::info!("wake-triggered recording reached max duration, stopping");
+                        stop_and_transcribe(handle, state);
+                    }
+                });
+            });
 
             // 5J: Ctrl+Alt+Esc — 全域中斷
             // - Phase::Recording → 停錄音 + 丟掉音檔不送 STT

--- a/crates/mori-tauri/src/wake_word.rs
+++ b/crates/mori-tauri/src/wake_word.rs
@@ -1,0 +1,338 @@
+//! Wake-word listener — Hey Mori 待命的核心。
+//!
+//! ## 架構
+//!
+//! Mori-tauri spawn 一個 Python subprocess(`examples/scripts/mori-wake-listener.py`)
+//! 用 openWakeWord 監聽麥克風。偵測到 wake phrase → stdout 印 JSON event。
+//! Rust 端 background thread 讀 stdout、parse JSON、呼叫 callback 觸發
+//! recording pipeline。
+//!
+//! ```text
+//!   spawn python ──── stdin: <none>
+//!                ──── stdout: line-delimited JSON events
+//!                       {"event":"ready", "model":"..."}
+//!                       {"event":"wake", "word":"hey_mori", "score":0.81}
+//!                       {"event":"error", "msg":"..."}
+//!                ──── stderr: log diagnostic(吞掉,不污染 stdout protocol)
+//! ```
+//!
+//! ## 為什麼 shell-out 不是 in-process
+//!
+//! 跟 [`crate::wake_word`] 的 sibling [`whisper_local`](mori-core) 同樣理由:
+//! - openWakeWord 是 Python lib,要綁 onnxruntime / tflite / sounddevice
+//! - 在 Rust 端整 ONNX inference + ALSA stream 是大工程,純 Rust 替代品成熟度
+//!   不夠(`vosk` 太重、`whisper.cpp` mini 不適合 hot-word use case)
+//! - subprocess 隔離:crash 不會炸 mori-tauri,kill_on_drop 直接收回。
+//!
+//! ## Lifecycle
+//!
+//! `WakeWordListener::spawn(config, on_wake)` →
+//!   1. spawn python(uv tool run / 系統 python 都試)
+//!   2. background reader thread 讀 stdout、parse、把 wake event 給 on_wake 跑
+//!   3. Drop → kill child + thread cooperatively 結束
+//!
+//! ## Phase 3A 範圍
+//!
+//! 只做「偵測 wake → callback」。Callback 端決定怎麼接(目前接到 start_recording
+//! + 10s 後 stop_and_transcribe)。多輪 ask / confirm-before-act 在 Phase 3B+。
+
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+
+use anyhow::{anyhow, bail, Context as _, Result};
+use serde::Deserialize;
+
+/// 啟動 listener 的設定。從 `~/.mori/config.json` 的 `listening_mode` 區塊讀。
+#[derive(Debug, Clone)]
+pub struct WakeWordConfig {
+    /// Python 解譯器路徑 — 預設 "python3"(用 PATH 解析)。
+    /// 若 user 在 config 寫成 uv tool run 的環境路徑可直接覆蓋。
+    pub python: PathBuf,
+    /// `mori-wake-listener.py` 絕對路徑。預設 `~/.mori/bin/mori-wake-listener.py`。
+    pub script_path: PathBuf,
+    /// Wake-word model `.onnx` 檔。openWakeWord pre-trained 或 user 自訓。
+    pub model_path: PathBuf,
+    /// Detection threshold(0~1)— 越高越嚴格,越低越敏感(誤觸多)。
+    /// 預設 0.5。
+    pub threshold: f32,
+}
+
+/// 從 Python stdout 解出來的 event。
+#[derive(Debug, Deserialize)]
+#[serde(tag = "event", rename_all = "lowercase")]
+pub enum WakeEvent {
+    /// Python 啟動好了,wake-word model 載完。後續才會發 wake / error。
+    Ready { model: String },
+    /// 偵測到 wake-word。score 是 model confidence,可給 log。
+    Wake {
+        word: String,
+        score: f32,
+    },
+    /// Python 端錯誤(model 載不到 / mic 開不起來)。
+    Error { msg: String },
+}
+
+/// Spawn 著的 listener。Drop 會 kill 子程序 + 等 reader thread 收尾。
+pub struct WakeWordListener {
+    child: Option<Child>,
+    reader_thread: Option<JoinHandle<()>>,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl WakeWordListener {
+    /// 啟動 listener。`on_wake` 在 reader thread 上被呼叫(別在 callback 內做
+    /// blocking 工作 — 至少 spawn 一個 tokio task 把活帶走)。
+    ///
+    /// 失敗回 Err — 通常是 python / script / model 路徑壞。
+    pub fn spawn<F>(config: WakeWordConfig, on_wake: F) -> Result<Self>
+    where
+        F: Fn(WakeEvent) + Send + Sync + 'static,
+    {
+        // Defensive checks — Python 不存在的話 Command::spawn 才會失敗,
+        // 但 script / model 路徑我們先驗,給更精準的錯誤訊息。
+        if !config.script_path.exists() {
+            bail!(
+                "wake-word script not found: {}\n\
+                 從 examples/scripts/mori-wake-listener.py 複製過去:\n\
+                   cp examples/scripts/mori-wake-listener.py ~/.mori/bin/\n\
+                   chmod +x ~/.mori/bin/mori-wake-listener.py",
+                config.script_path.display()
+            );
+        }
+        if !config.model_path.exists() {
+            bail!(
+                "wake-word model not found: {}\n\
+                 從 openWakeWord pre-trained 抓一個放進去,或自訓 custom 「Hey Mori」\n\
+                 模型(見 https://github.com/dscripka/openWakeWord)。",
+                config.model_path.display()
+            );
+        }
+
+        let mut cmd = Command::new(&config.python);
+        cmd.arg(&config.script_path)
+            .arg(&config.model_path)
+            .arg(config.threshold.to_string())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null()); // stderr 吞掉避免污染 stdout protocol
+
+        let mut child = cmd.spawn().with_context(|| {
+            format!(
+                "spawn wake-word listener: python={} script={}\n\
+                 確認:\n\
+                 1. `python3 --version` 跑得起來\n\
+                 2. `pip show openwakeword` 有裝(或 uv tool 對應環境)\n\
+                 3. script 跟 model 路徑對\n",
+                config.python.display(),
+                config.script_path.display(),
+            )
+        })?;
+
+        tracing::info!(
+            pid = child.id(),
+            model = %config.model_path.display(),
+            threshold = config.threshold,
+            "wake-word listener spawned",
+        );
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("wake-word: child stdout missing"))?;
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_for_thread = shutdown.clone();
+        let on_wake = Arc::new(on_wake);
+
+        let reader_thread = std::thread::Builder::new()
+            .name("mori-wake-reader".into())
+            .spawn(move || {
+                let reader = BufReader::new(stdout);
+                for line in reader.lines() {
+                    if shutdown_for_thread.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    let line = match line {
+                        Ok(l) => l,
+                        Err(e) => {
+                            tracing::warn!(?e, "wake-word: stdout read error");
+                            break;
+                        }
+                    };
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    match serde_json::from_str::<WakeEvent>(trimmed) {
+                        Ok(ev) => {
+                            tracing::debug!(?ev, "wake-word event");
+                            on_wake(ev);
+                        }
+                        Err(e) => {
+                            tracing::warn!(?e, line = %trimmed, "wake-word: bad JSON line");
+                        }
+                    }
+                }
+                tracing::debug!("wake-word reader thread exiting");
+            })
+            .context("spawn wake-word reader thread")?;
+
+        Ok(Self {
+            child: Some(child),
+            reader_thread: Some(reader_thread),
+            shutdown,
+        })
+    }
+}
+
+impl Drop for WakeWordListener {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            tracing::debug!(pid = child.id(), "wake-word listener killed on drop");
+        }
+        // reader thread 因為 child.stdout 被 kill 後 EOF 自然會結束。
+        // join 等它,給 ~50ms 上限 — 不該等太久卡住 mode switch。
+        if let Some(handle) = self.reader_thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+// ─── Config readers ────────────────────────────────────────────────────
+
+/// 從 `~/.mori/config.json` `listening_mode.*` 區塊讀 WakeWordConfig。
+/// 預設值對齊 Phase 3A 設計 — phrase = Hey Mori, threshold 0.5。
+pub fn config_from_disk(mori_dir: &Path) -> WakeWordConfig {
+    let cfg_text = std::fs::read_to_string(mori_dir.join("config.json")).ok();
+    let json: serde_json::Value = cfg_text
+        .as_deref()
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or(serde_json::Value::Null);
+
+    let python = json
+        .pointer("/listening_mode/python")
+        .and_then(|v| v.as_str())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("python3"));
+
+    let script_path = json
+        .pointer("/listening_mode/script_path")
+        .and_then(|v| v.as_str())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| mori_dir.join("bin").join("mori-wake-listener.py"));
+
+    let model_path = json
+        .pointer("/listening_mode/model_path")
+        .and_then(|v| v.as_str())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| mori_dir.join("wakeword").join("hey-mori.onnx"));
+
+    let threshold = json
+        .pointer("/listening_mode/threshold")
+        .and_then(|v| v.as_f64())
+        .map(|v| v.clamp(0.05, 0.95) as f32)
+        .unwrap_or(0.5);
+
+    WakeWordConfig {
+        python,
+        script_path,
+        model_path,
+        threshold,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wake_event_parses_ready() {
+        let ev: WakeEvent =
+            serde_json::from_str(r#"{"event":"ready","model":"/tmp/hey-mori.onnx"}"#).unwrap();
+        assert!(matches!(ev, WakeEvent::Ready { .. }));
+    }
+
+    #[test]
+    fn wake_event_parses_wake() {
+        let ev: WakeEvent =
+            serde_json::from_str(r#"{"event":"wake","word":"hey_mori","score":0.81}"#).unwrap();
+        match ev {
+            WakeEvent::Wake { word, score } => {
+                assert_eq!(word, "hey_mori");
+                assert!((score - 0.81).abs() < 1e-5);
+            }
+            other => panic!("expected Wake, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wake_event_parses_error() {
+        let ev: WakeEvent =
+            serde_json::from_str(r#"{"event":"error","msg":"model load failed"}"#).unwrap();
+        assert!(matches!(ev, WakeEvent::Error { .. }));
+    }
+
+    #[test]
+    fn config_from_disk_defaults_when_no_file() {
+        let tmp = std::env::temp_dir().join(format!(
+            "mori-wake-test-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let cfg = config_from_disk(&tmp);
+        assert_eq!(cfg.python, PathBuf::from("python3"));
+        assert_eq!(cfg.threshold, 0.5);
+        assert!(cfg.model_path.ends_with("wakeword/hey-mori.onnx"));
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn config_from_disk_reads_overrides() {
+        let tmp = std::env::temp_dir().join(format!(
+            "mori-wake-test-overrides-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let cfg_path = tmp.join("config.json");
+        std::fs::write(
+            &cfg_path,
+            r#"{"listening_mode":{"python":"/usr/bin/python3.11","threshold":0.7,"model_path":"/x/custom.onnx"}}"#,
+        )
+        .unwrap();
+        let cfg = config_from_disk(&tmp);
+        assert_eq!(cfg.python, PathBuf::from("/usr/bin/python3.11"));
+        assert!((cfg.threshold - 0.7).abs() < 1e-5);
+        assert_eq!(cfg.model_path, PathBuf::from("/x/custom.onnx"));
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn config_threshold_clamps_out_of_range() {
+        let tmp = std::env::temp_dir().join(format!(
+            "mori-wake-test-clamp-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::write(
+            tmp.join("config.json"),
+            r#"{"listening_mode":{"threshold":5.0}}"#,
+        )
+        .unwrap();
+        let cfg = config_from_disk(&tmp);
+        assert!(cfg.threshold <= 0.95);
+        std::fs::write(
+            tmp.join("config.json"),
+            r#"{"listening_mode":{"threshold":-1.0}}"#,
+        )
+        .unwrap();
+        let cfg = config_from_disk(&tmp);
+        assert!(cfg.threshold >= 0.05);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/examples/scripts/mori-wake-listener.py
+++ b/examples/scripts/mori-wake-listener.py
@@ -65,7 +65,8 @@ def main():
         sys.exit(3)
 
     try:
-        model = Model(wakeword_models=[model_path])
+        # openWakeWord 0.4+ API:kwarg 是 wakeword_model_paths(複數 + _paths 後綴)
+        model = Model(wakeword_model_paths=[model_path])
     except Exception as e:
         emit({"event": "error", "msg": f"model load failed: {e}"})
         sys.exit(4)

--- a/examples/scripts/mori-wake-listener.py
+++ b/examples/scripts/mori-wake-listener.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""mori-wake-listener.py — Hey Mori wake-word detector(Phase 3A)。
+
+mori-tauri 在 Listening mode 下會 spawn 這隻 script,持續開麥克風跑
+openWakeWord 偵測 wake phrase。偵測到 → stdout 印 line-delimited JSON
+event,mori-tauri 端 background thread 讀取觸發 recording pipeline。
+
+## stdout protocol (Rust 端 wake_word.rs 對應 WakeEvent enum)
+
+  {"event":"ready", "model":"/path/to/model.onnx"}
+  {"event":"wake", "word":"hey_mori", "score":0.81}
+  {"event":"error", "msg":"<reason>"}
+
+stderr 給 diagnostic / openwakeword 內部 log。**永遠別印非 JSON 到 stdout**,
+會打破 Rust 端 parse。
+
+## CLI
+
+  mori-wake-listener.py <model_path> [threshold]
+
+  model_path  — openWakeWord `.onnx` 檔路徑(pre-trained 或自訓)
+  threshold   — detection threshold 0~1,預設 0.5
+
+## 安裝
+
+  cp examples/scripts/mori-wake-listener.py ~/.mori/bin/
+  chmod +x ~/.mori/bin/mori-wake-listener.py
+
+  # openwakeword 依賴 — 用 uv 管 isolated venv 避免污染系統
+  uv tool install openwakeword
+  # 或 pip install openwakeword
+
+  # Model — 自訓「Hey Mori」需 GPU + 數小時;先用 openWakeWord 內建的
+  # 「hey jarvis」之類 placeholder 驗 pipeline 通,後期再換 custom。
+  # https://github.com/dscripka/openWakeWord#pre-trained-models
+"""
+
+import json
+import sys
+import time
+from pathlib import Path
+
+# Import 失敗時要 emit error event 給 mori-tauri,不能直接 raise。
+def emit(obj):
+    print(json.dumps(obj), flush=True)
+
+
+def main():
+    if len(sys.argv) < 2:
+        emit({"event": "error", "msg": "missing model_path argument"})
+        sys.exit(1)
+    model_path = sys.argv[1]
+    threshold = float(sys.argv[2]) if len(sys.argv) > 2 else 0.5
+
+    if not Path(model_path).exists():
+        emit({"event": "error", "msg": f"model not found: {model_path}"})
+        sys.exit(2)
+
+    try:
+        from openwakeword import Model
+        import sounddevice as sd
+        import numpy as np
+    except ImportError as e:
+        emit({"event": "error", "msg": f"missing dep: {e}. Run: pip install openwakeword sounddevice"})
+        sys.exit(3)
+
+    try:
+        model = Model(wakeword_models=[model_path])
+    except Exception as e:
+        emit({"event": "error", "msg": f"model load failed: {e}"})
+        sys.exit(4)
+
+    emit({"event": "ready", "model": model_path})
+
+    # openWakeWord 接 16kHz mono int16,80ms 一塊(1280 samples)。
+    SAMPLE_RATE = 16000
+    CHUNK_SAMPLES = 1280
+
+    # 連續觸發抑制 — 一次偵測到 wake 後 1.5s 內不再 emit(避免「Hey Mori Hey
+    # Mori」連噴),由 Rust 端管 cooldown 更彈性,但 Python 端基本守一道。
+    last_wake_ts = 0.0
+    SUPPRESS_SECS = 1.5
+
+    def callback(indata, frames, time_info, status):
+        nonlocal last_wake_ts
+        # indata: shape (frames, 1) int16
+        audio = indata[:, 0]
+        predictions = model.predict(audio)
+        for word, score in predictions.items():
+            if score >= threshold:
+                now = time.time()
+                if now - last_wake_ts < SUPPRESS_SECS:
+                    continue  # 抑制連續觸發
+                last_wake_ts = now
+                emit({"event": "wake", "word": word, "score": float(score)})
+
+    try:
+        with sd.InputStream(
+            samplerate=SAMPLE_RATE,
+            channels=1,
+            dtype="int16",
+            blocksize=CHUNK_SAMPLES,
+            callback=callback,
+        ):
+            # 主執行緒 idle 等 keyboard interrupt / parent kill。
+            while True:
+                time.sleep(0.5)
+    except KeyboardInterrupt:
+        pass
+    except Exception as e:
+        emit({"event": "error", "msg": f"audio stream failed: {e}"})
+        sys.exit(5)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ChatPanel.tsx
+++ b/src/ChatPanel.tsx
@@ -41,7 +41,7 @@ type Phase =
     }
   | { kind: "error"; message: string };
 
-type Mode = "agent" | "voice_input" | "background";
+type Mode = "agent" | "voice_input" | "background" | "listening";
 
 type ChatTurn = {
   // voice_input = 語音 dictation 完成留下的紀錄(不送 LLM context),只是給 user 翻閱
@@ -95,6 +95,9 @@ const MODE_LABEL: Record<Mode, { Icon: ComponentType<SVGProps<SVGSVGElement>>; l
   agent: { Icon: IconBubble, label: "Agent" },
   voice_input: { Icon: IconKeyboard, label: "VoiceInput" },
   background: { Icon: IconSleep, label: "Sleep" },
+  // Listening:Hey Mori 待命中(Phase 3A)。用耳朵 icon 表示「在聽」 — 跟 mic 圖示
+  // 區分:mic 暗示「正在錄」,耳朵暗示「等被喚醒」
+  listening: { Icon: IconWave, label: "Listening" },
 };
 
 function ChatPanel() {

--- a/src/FloatingMori.tsx
+++ b/src/FloatingMori.tsx
@@ -23,7 +23,7 @@ type Phase =
     }
   | { kind: "error"; message: string };
 
-type Mode = "agent" | "voice_input" | "background";
+type Mode = "agent" | "voice_input" | "background" | "listening";
 
 type Visual =
   | "sleeping"


### PR DESCRIPTION
## Summary

Phase 3A of the Hey Mori always-on / proactive agent feature. Adds 4th top-level `Mode::Listening` (orthogonal to Alt+N / Ctrl+Alt+N profile slots) + Python subprocess (`openWakeWord`) wake-word detector + wake → recording trigger.

Phase 3B (LLM evaluate / ask-back), 3C (confirm-before-execute), 3D (TTS speak-back) follow in separate PRs.

## What's in

- `Mode::Listening` enum variant (mori-core)
- `wake_word.rs` module (338 lines) — manages Python subprocess + stdout JSON event reader thread, with cooperative drop / kill
- `examples/scripts/mori-wake-listener.py` (116 lines) — openWakeWord wrapper emitting line-JSON
- `main.rs` integration: AppState slot, mode-change hook, wake-word-detected Tauri event listener, auto-stop timer
- Tray menu \`Hey Mori 待命\` entry + ✓ checkmark
- Frontend Mode union update (ChatPanel + FloatingMori)

## What's deliberately NOT in (later phases)

- Ctrl+Alt+W global hotkey (portal_hotkey wiring deferred — tray works)
- LLM evaluate / ask-back (Phase 3B)
- TTS speak-back (Phase 3D)
- Deps tab openWakeWord installer UI
- Custom \"Hey Mori\" model training

## Tests

- mori-core: 201 pass
- mori-tauri: **59 → 65 pass** (+6 wake_word tests covering event parse, config read, default values, clamping)

## Manual test plan

1. \`pip install openwakeword sounddevice\` (or \`uv tool install\`)
2. \`cp examples/scripts/mori-wake-listener.py ~/.mori/bin/ && chmod +x ~/.mori/bin/mori-wake-listener.py\`
3. Grab any openWakeWord pre-trained model .onnx → \`~/.mori/wakeword/hey-mori.onnx\` (or set listening_mode.model_path in config.json)
4. Restart mori-tauri → tray menu → \"Hey Mori 待命\"
5. Speak wake phrase to mic → recording should fire → goes through agent pipeline
6. Verify auto-stop kicks in after 10s (config: \`listening_mode.max_record_secs\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)