### PR TITLE
feat(tts): Phase 3D — edge-tts speak-back + UI toggle + DepsTab runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "ashpd"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,6 +1209,15 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endi"
@@ -3688,6 +3703,7 @@ checksum = "6006a627c1a38d37f3d3a85c6575418cfe34a5392d60a686d0071e1c8d427acb"
 dependencies = [
  "cpal",
  "hound",
+ "symphonia",
  "thiserror 1.0.69",
 ]
 
@@ -4225,6 +4241,55 @@ dependencies = [
  "base64 0.21.7",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-mp3",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
 ]
 
 [[package]]

--- a/crates/mori-tauri/Cargo.toml
+++ b/crates/mori-tauri/Cargo.toml
@@ -44,9 +44,9 @@ axum = { version = "0.7", default-features = false, features = ["http1", "json",
 cpal = "0.15"
 # WAV encoding (so we can ship audio bytes to Whisper without an external encoder)
 hound = "3.5"
-# Audio playback — Phase 3A wake-ack 用。cpal-based,跟現有 input stack 同源。
-# WAV-only(decoder feature 拔了 mp3 / vorbis,Mori 自己 bake 的都 wav)。
-rodio = { version = "0.19", default-features = false, features = ["wav"] }
+# Audio playback — Phase 3A wake-ack 用 wav,Phase 3D TTS speak-back 用 mp3
+# (edge-tts 輸出 MP3 24kHz)。cpal-based,跟現有 input stack 同源。
+rodio = { version = "0.19", default-features = false, features = ["wav", "mp3"] }
 # 隨機選 wake-ack 短句
 rand = "0.8"
 # Lock-free shared state for the audio callback path

--- a/crates/mori-tauri/src/deps.rs
+++ b/crates/mori-tauri/src/deps.rs
@@ -362,17 +362,34 @@ pub fn registry() -> Vec<DepSpec> {
                 path_template: "$HOME/.mori/wake-venv/bin/python",
             },
             // Linux/macOS:有 uv 用 uv,沒 uv fallback system python3.11
+            // ⚠ uv venv 建的 venv **沒 pip 模組** — 必須用 `uv pip install` 或先
+            // `python -m ensurepip` 補 pip 才能用。
             install: InstallSpec::Shell {
                 script: "set -e; \
                          VENV=\"$HOME/.mori/wake-venv\"; \
+                         UV=\"$HOME/.local/bin/uv\"; \
                          if [ ! -d \"$VENV\" ]; then \
-                            if [ -x \"$HOME/.local/bin/uv\" ]; then \
-                                \"$HOME/.local/bin/uv\" venv \"$VENV\" --python 3.11; \
+                            if [ -x \"$UV\" ]; then \
+                                echo '用 uv 建 venv...'; \
+                                \"$UV\" venv \"$VENV\" --python 3.11; \
                             else \
+                                echo '用 python -m venv...'; \
                                 python3.11 -m venv \"$VENV\" || python3 -m venv \"$VENV\"; \
                             fi; \
                          fi; \
-                         \"$VENV/bin/pip\" install --quiet openwakeword sounddevice numpy onnxruntime scikit-learn",
+                         PACKAGES='openwakeword sounddevice numpy onnxruntime scikit-learn'; \
+                         if [ -x \"$UV\" ]; then \
+                            echo '用 uv pip install...'; \
+                            \"$UV\" pip install --python \"$VENV/bin/python\" $PACKAGES; \
+                         elif [ -x \"$VENV/bin/pip\" ]; then \
+                            echo '用 venv pip...'; \
+                            \"$VENV/bin/pip\" install $PACKAGES; \
+                         else \
+                            echo '用 ensurepip bootstrap...'; \
+                            \"$VENV/bin/python\" -m ensurepip --upgrade; \
+                            \"$VENV/bin/python\" -m pip install $PACKAGES; \
+                         fi; \
+                         echo '✓ wake-venv + openwakeword 裝好了'",
             },
             install_overrides: &[
                 ("windows", InstallSpec::Manual {
@@ -386,6 +403,10 @@ pub fn registry() -> Vec<DepSpec> {
         },
         // Phase 3D:edge-tts(Mori 講話)— 跟 wake-listener 共用 wake-venv,
         // 安裝小(~10MB),detect 看 edge-tts import 得起來。
+        //
+        // ⚠ wake-venv 多半是 uv 建的(`uv venv ...`),內部沒 pip 模組 — uv 走自己的
+        // `uv pip install --python <venv-py>`。所以 install script 優先用 uv,失敗才
+        // fallback 到 `python -m ensurepip` 補 pip 後再裝。
         DepSpec {
             id: "tts-runtime",
             name: "Mori 講話 runtime(edge-tts)",
@@ -409,15 +430,30 @@ pub fn registry() -> Vec<DepSpec> {
             install: InstallSpec::Shell {
                 script: "set -e; \
                          VENV=\"$HOME/.mori/wake-venv\"; \
-                         if [ ! -x \"$VENV/bin/pip\" ]; then \
-                            echo 'wake-venv 沒裝,先裝 wake-listener-runtime'; exit 2; \
+                         UV=\"$HOME/.local/bin/uv\"; \
+                         if [ ! -x \"$VENV/bin/python\" ]; then \
+                            echo '⚠ wake-venv 不存在 — 先裝 wake-listener-runtime'; exit 2; \
                          fi; \
-                         \"$VENV/bin/pip\" install --quiet edge-tts",
+                         if [ -x \"$UV\" ]; then \
+                            echo '用 uv pip install...'; \
+                            \"$UV\" pip install --python \"$VENV/bin/python\" edge-tts; \
+                         elif [ -x \"$VENV/bin/pip\" ]; then \
+                            echo '用 venv pip...'; \
+                            \"$VENV/bin/pip\" install edge-tts; \
+                         else \
+                            echo '用 ensurepip bootstrap...'; \
+                            \"$VENV/bin/python\" -m ensurepip --upgrade; \
+                            \"$VENV/bin/python\" -m pip install edge-tts; \
+                         fi; \
+                         echo '✓ edge-tts 裝好了'",
             },
             install_overrides: &[
                 ("windows", InstallSpec::Manual {
                     commands: &[
                         "# Windows PowerShell(需先有 wake-venv):",
+                        "# 優先用 uv:",
+                        "uv pip install --python %USERPROFILE%\\.mori\\wake-venv\\Scripts\\python.exe edge-tts",
+                        "# 或用 venv 內 pip(如果 venv 是 python -m venv 建的):",
                         "%USERPROFILE%\\.mori\\wake-venv\\Scripts\\pip install edge-tts",
                     ],
                 }),

--- a/crates/mori-tauri/src/deps.rs
+++ b/crates/mori-tauri/src/deps.rs
@@ -384,6 +384,45 @@ pub fn registry() -> Vec<DepSpec> {
                 }),
             ],
         },
+        // Phase 3D:edge-tts(Mori 講話)— 跟 wake-listener 共用 wake-venv,
+        // 安裝小(~10MB),detect 看 edge-tts import 得起來。
+        DepSpec {
+            id: "tts-runtime",
+            name: "Mori 講話 runtime(edge-tts)",
+            description: "Phase 3D TTS speak-back 用的 Python edge-tts。借 Microsoft Edge \
+                          瀏覽器 TTS endpoint,免費 + native zh-TW 女聲。沒裝 → Config tab \
+                          開 tts.enabled 也不會講話(只 log warn)。跟 wake-listener 共用 \
+                          wake-venv,沒裝 wake-listener-runtime 的話先裝那個。",
+            unlocks: "tts.enabled=true 時 Mori 用聲音回答你",
+            size_hint: Some("~10MB"),
+            needs_sudo: false,
+            platforms: &["linux", "macos", "windows"],
+            install_caveat: None,
+            check: CheckSpec::CommandStdoutContains {
+                cmd: "sh",
+                args: &[
+                    "-c",
+                    "$HOME/.mori/wake-venv/bin/python -c 'import edge_tts; print(\"ok\")' 2>&1",
+                ],
+                needle: "ok",
+            },
+            install: InstallSpec::Shell {
+                script: "set -e; \
+                         VENV=\"$HOME/.mori/wake-venv\"; \
+                         if [ ! -x \"$VENV/bin/pip\" ]; then \
+                            echo 'wake-venv 沒裝,先裝 wake-listener-runtime'; exit 2; \
+                         fi; \
+                         \"$VENV/bin/pip\" install --quiet edge-tts",
+            },
+            install_overrides: &[
+                ("windows", InstallSpec::Manual {
+                    commands: &[
+                        "# Windows PowerShell(需先有 wake-venv):",
+                        "%USERPROFILE%\\.mori\\wake-venv\\Scripts\\pip install edge-tts",
+                    ],
+                }),
+            ],
+        },
     ]
 }
 

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -25,6 +25,7 @@ mod shell_skill;
 mod skill_server;
 mod theme;
 mod transcribe_cmds;
+mod tts;
 mod wake_sound;
 mod wake_word;
 
@@ -2757,6 +2758,11 @@ async fn run_agent_pipeline(
                 });
             }
 
+            // Phase 3D:agent response 完成 → 若 tts.enabled,背景 spawn edge-tts
+            // 念出 response。預設 OFF,user 在 Config tab 主動 enable 才會講話。
+            // 不擋 UI update — speak_async 立刻 return,實際合成 + 播放在 tokio task。
+            tts::speak_async(response.clone(), app.clone());
+
             state.set_phase(
                 &app,
                 Phase::Done {
@@ -3947,6 +3953,7 @@ fn main() {
             wake_sound::wake_ack_preview,
             wake_sound::wake_ack_upload,
             wake_sound::wake_ack_delete_alternate,
+            tts::tts_preview,
         ])
         .on_window_event(|window, event| {
             // 關視窗時不殺 app — 隱藏到系統匣繼續跑(像 Slack / Discord)
@@ -3976,6 +3983,10 @@ fn main() {
             // Phase 3B:ensure ~/.mori/wakeword/hey-mori.onnx 預設 wake-word model。
             // Fresh user 不用先跑 mori-wake-train.py 就能用 Hey Mori。自訓過的不覆蓋。
             wake_word::ensure_default_model(&mori_dir());
+
+            // Phase 3D:deploy ~/.mori/bin/mori-tts-edge.py(edge-tts bridge script)。
+            // TTS speak-back 預設 OFF,user enable 才會用到。但 script 先 deploy 不影響。
+            tts::ensure_script_deployed(&mori_dir());
 
             // 啟動初始 floating visibility — update_floating_visibility 自己會看:
             //   - quickstart_completed (儀式還沒完成 → 強制隱藏)

--- a/crates/mori-tauri/src/tts.rs
+++ b/crates/mori-tauri/src/tts.rs
@@ -1,0 +1,269 @@
+//! TTS speak-back — Mori 講話(Phase 3D)。
+//!
+//! Agent 回應完成後(若 `tts.enabled=true`),呼叫 Python edge-tts bridge
+//! (`examples/scripts/mori-tts-edge.py`)合成 MP3 → rodio 播放。預設用免費
+//! Microsoft Edge TTS endpoint(無 quota / 無 API key,zh-TW native voice)。
+//!
+//! ## 為什麼用 edge-tts 不用 Gemini
+//!
+//! Gemini TTS free tier 100 req/day,聊個幾句就破。edge-tts 借 MS Edge
+//! browser endpoint(非官方支援但廣用),實質無限額 + native zh-TW + 免費。
+//!
+//! ## Lifecycle
+//!
+//! `speak_async(text, app)` 立刻 return,實際合成 + 播放在 background:
+//!   1. tokio::spawn → 寫 stdin text 給 Python subprocess
+//!   2. subprocess 把 MP3 寫到 `/tmp/mori-tts-<uuid>.mp3`
+//!   3. rodio 讀那 MP3 + 開新 OutputStream + sleep_until_end blocking 跑完
+//!   4. 結束後 unlink temp file
+//!
+//! ## 中斷
+//!
+//! 暫時不支援中斷正在播的 TTS(後續可加 `Mutex<Option<Sink>>` 共享 state
+//! + Ctrl+Alt+Esc handler 呼叫 sink.stop)。目前 TTS 開始就會放完。
+
+use std::fs;
+use std::io::{BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::SystemTime;
+
+use rodio::{Decoder, OutputStream, Sink, Source};
+use tauri::AppHandle;
+
+use crate::mori_dir;
+
+/// Bundled mori-tts-edge.py(Phase 3D)— Python edge-tts bridge script。
+/// `ensure_script_deployed` 在 user dir 沒檔時寫一份過去當預設,user 可覆寫。
+const BUNDLED_TTS_SCRIPT: &[u8] = include_bytes!("../../../examples/scripts/mori-tts-edge.py");
+
+/// 確保 `~/.mori/bin/mori-tts-edge.py` 存在。沒檔 → 寫 bundled。
+/// User 改過或自己版本 → 不覆寫(`!path.exists()` gate)。
+///
+/// Linux/macOS 順手 chmod +x。
+pub fn ensure_script_deployed(mori_dir: &Path) {
+    let bin = mori_dir.join("bin");
+    if let Err(e) = fs::create_dir_all(&bin) {
+        tracing::warn!(error = %e, dir = %bin.display(), "tts ensure_script: mkdir failed");
+        return;
+    }
+    let path = bin.join("mori-tts-edge.py");
+    if path.exists() {
+        return;
+    }
+    if let Err(e) = fs::write(&path, BUNDLED_TTS_SCRIPT) {
+        tracing::warn!(error = %e, path = %path.display(), "tts ensure_script: write failed");
+        return;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = fs::metadata(&path) {
+            let mut perms = meta.permissions();
+            perms.set_mode(0o755);
+            let _ = fs::set_permissions(&path, perms);
+        }
+    }
+    tracing::info!(path = %path.display(), "tts: deployed bundled mori-tts-edge.py");
+}
+
+/// Default Python(對齊 wake-listener 用同 venv)。
+fn default_python() -> PathBuf {
+    let venv = mori_dir().join("wake-venv");
+    if cfg!(target_os = "windows") {
+        venv.join("Scripts").join("python.exe")
+    } else {
+        venv.join("bin").join("python")
+    }
+}
+
+/// 預設 voice — Mori 形象偏年輕女精靈,HsiaoYu 比 HsiaoChen 偏年輕清亮。
+const DEFAULT_VOICE: &str = "zh-TW-HsiaoYuNeural";
+
+/// 默認 TTS bridge script(deploy 到 ~/.mori/bin/mori-tts-edge.py 或 repo
+/// examples/scripts/ 直接跑都可)。
+fn default_script_path() -> PathBuf {
+    let mori_bin = mori_dir().join("bin").join("mori-tts-edge.py");
+    if mori_bin.exists() {
+        return mori_bin;
+    }
+    // dev fallback:repo examples
+    PathBuf::from("examples/scripts/mori-tts-edge.py")
+}
+
+struct TtsConfig {
+    enabled: bool,
+    python: PathBuf,
+    script_path: PathBuf,
+    voice: String,
+}
+
+fn read_config() -> TtsConfig {
+    let default = TtsConfig {
+        enabled: false, // 預設 OFF — user 主動 enable 才會講話
+        python: default_python(),
+        script_path: default_script_path(),
+        voice: DEFAULT_VOICE.to_string(),
+    };
+    let path = mori_dir().join("config.json");
+    let Ok(text) = fs::read_to_string(&path) else {
+        return default;
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return default;
+    };
+    let enabled = json
+        .pointer("/tts/enabled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let python = json
+        .pointer("/tts/python")
+        .and_then(|v| v.as_str())
+        .map(PathBuf::from)
+        .unwrap_or_else(default_python);
+    let script_path = json
+        .pointer("/tts/script_path")
+        .and_then(|v| v.as_str())
+        .map(PathBuf::from)
+        .unwrap_or_else(default_script_path);
+    let voice = json
+        .pointer("/tts/voice")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| DEFAULT_VOICE.to_string());
+    TtsConfig {
+        enabled,
+        python,
+        script_path,
+        voice,
+    }
+}
+
+/// 公開入口 — agent response 完成時呼叫。立刻 return,實際合成 + 播放在
+/// tokio task 內背景跑。失敗只 log warn,不影響 Phase::Done UI 更新。
+///
+/// `_app` 目前沒用上,保留 signature 給未來「emit tts-started / tts-finished
+/// event 讓 UI 顯示 "Mori 在講話" 」用。
+pub fn speak_async(text: String, _app: AppHandle) {
+    let cfg = read_config();
+    if !cfg.enabled {
+        return;
+    }
+    if text.trim().is_empty() {
+        return;
+    }
+    if !cfg.python.exists() {
+        tracing::warn!(
+            python = %cfg.python.display(),
+            "tts.speak_async: python not found (跑 DepsTab → TTS runtime 安裝 wake-venv + edge-tts)",
+        );
+        return;
+    }
+    if !cfg.script_path.exists() {
+        tracing::warn!(
+            script = %cfg.script_path.display(),
+            "tts.speak_async: bridge script not found",
+        );
+        return;
+    }
+
+    tokio::task::spawn_blocking(move || {
+        if let Err(e) = synth_and_play(&cfg, &text) {
+            tracing::warn!(error = %e, "tts: synth_and_play failed");
+        }
+    });
+}
+
+fn synth_and_play(cfg: &TtsConfig, text: &str) -> anyhow::Result<()> {
+    // 用 timestamp 避免並發 collision。/tmp 上 OS 開機重啟自動清。
+    let ts = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let out_mp3 = std::env::temp_dir().join(format!("mori-tts-{ts}.mp3"));
+
+    tracing::info!(
+        text_len = text.len(),
+        voice = cfg.voice,
+        out = %out_mp3.display(),
+        "tts: synthesizing",
+    );
+
+    // 1. Spawn Python subprocess,stdin 餵 text
+    let mut child = Command::new(&cfg.python)
+        .arg(&cfg.script_path)
+        .arg(&out_mp3)
+        .arg(&cfg.voice)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("spawn python: {e}"))?;
+
+    if let Some(stdin) = child.stdin.as_mut() {
+        stdin
+            .write_all(text.as_bytes())
+            .map_err(|e| anyhow::anyhow!("write stdin: {e}"))?;
+    }
+    let output = child
+        .wait_with_output()
+        .map_err(|e| anyhow::anyhow!("wait subprocess: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let _ = fs::remove_file(&out_mp3);
+        return Err(anyhow::anyhow!(
+            "edge-tts exited {}: {}",
+            output.status,
+            stderr.trim()
+        ));
+    }
+
+    if !out_mp3.exists() || fs::metadata(&out_mp3).map(|m| m.len()).unwrap_or(0) == 0 {
+        return Err(anyhow::anyhow!("MP3 output 沒寫成功或空檔"));
+    }
+
+    // 2. rodio play MP3
+    let file = fs::File::open(&out_mp3).map_err(|e| anyhow::anyhow!("open mp3: {e}"))?;
+    let source =
+        Decoder::new(BufReader::new(file)).map_err(|e| anyhow::anyhow!("decode mp3: {e}"))?;
+
+    let (_stream, handle) =
+        OutputStream::try_default().map_err(|e| anyhow::anyhow!("no audio output: {e}"))?;
+    let sink = Sink::try_new(&handle).map_err(|e| anyhow::anyhow!("sink create: {e}"))?;
+    sink.append(source.convert_samples::<i16>());
+    sink.sleep_until_end();
+
+    // 3. cleanup
+    let _ = fs::remove_file(&out_mp3);
+    tracing::info!("tts: playback done");
+    Ok(())
+}
+
+/// IPC command — 試聽 voice。給 ConfigTab UI 用。
+#[tauri::command]
+pub async fn tts_preview(text: Option<String>, voice: Option<String>) -> Result<(), String> {
+    let mut cfg = read_config();
+    if let Some(v) = voice {
+        cfg.voice = v;
+    }
+    let sample_text = text.unwrap_or_else(|| {
+        "嗨,我是 Mori。試聽聲音這樣 OK 嗎?".to_string()
+    });
+    if !cfg.python.exists() {
+        return Err(format!(
+            "Python venv 沒裝(找不到 {}),先跑 DepsTab → TTS runtime",
+            cfg.python.display()
+        ));
+    }
+    if !cfg.script_path.exists() {
+        return Err(format!(
+            "TTS bridge script 沒部署({}),跑 examples/scripts/mori-tts-edge.py 應該要在 ~/.mori/bin/ 或 repo 內",
+            cfg.script_path.display()
+        ));
+    }
+    tokio::task::spawn_blocking(move || synth_and_play(&cfg, &sample_text))
+        .await
+        .map_err(|e| format!("join: {e}"))?
+        .map_err(|e| format!("synth/play: {e}"))?;
+    Ok(())
+}

--- a/crates/mori-tauri/src/tts.rs
+++ b/crates/mori-tauri/src/tts.rs
@@ -78,7 +78,7 @@ fn default_python() -> PathBuf {
 }
 
 /// 預設 voice — Mori 形象偏年輕女精靈,HsiaoYu 比 HsiaoChen 偏年輕清亮。
-const DEFAULT_VOICE: &str = "zh-TW-HsiaoYuNeural";
+const DEFAULT_VOICE: &str = "zh-TW-HsiaoChenNeural";
 
 /// 默認 TTS bridge script(deploy 到 ~/.mori/bin/mori-tts-edge.py 或 repo
 /// examples/scripts/ 直接跑都可)。

--- a/examples/scripts/mori-tts-edge.py
+++ b/examples/scripts/mori-tts-edge.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""mori-tts-edge.py — Mori 講話的 edge-tts bridge(Phase 3D)。
+
+mori-tauri 在 agent 回應完成後(若 `tts.enabled=true`),spawn 這隻 script
+用 Microsoft Edge 瀏覽器的 TTS endpoint 把回應文字合成 MP3。Rust 端 rodio
+讀那個 MP3 放出來。
+
+## 為什麼 edge-tts
+
+- 完全免費(借 MS Edge browser 端點,無 API key、無官方 quota)
+- Native zh-TW 女聲(`zh-TW-HsiaoYuNeural` / `HsiaoChenNeural`),沒英文口音味
+- Python lib 輕量(~10MB),跟 wake-listener 共用 `~/.mori/wake-venv`
+- 比 Gemini TTS quota 友善(後者免費層 100 req/day,Mori 對答幾句就破)
+
+## 用法
+
+  python mori-tts-edge.py <output-mp3-path> <voice> < stdin
+
+  text 從 stdin 讀(避免長字串 + 特殊字元在 argv 出包)。
+
+## stdout / stderr protocol
+
+  stdout:純資訊 log,Rust 端會吞掉
+  stderr:錯誤訊息(non-zero exit code 時 Rust 看 stderr decide 怎麼報)
+
+  exit code:
+    0 = success(MP3 寫到指定路徑)
+    1 = bad usage(arg 不對)
+    2 = edge-tts 失敗(網路 / endpoint 問題)
+
+## 中斷
+
+  Rust 端 Drop child 會 SIGKILL,沒寫完的 MP3 caller 應該刪掉。
+
+## Voice 清單
+
+  edge-tts --list-voices 看完整,zh-TW 常用:
+    zh-TW-HsiaoChenNeural  (女,標準)
+    zh-TW-HsiaoYuNeural    (女,偏年輕)
+    zh-TW-YunJheNeural     (男)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+DEFAULT_VOICE = "zh-TW-HsiaoYuNeural"
+
+
+async def synth(text: str, voice: str, out_path: Path) -> None:
+    """call edge-tts → save MP3 到 out_path"""
+    try:
+        import edge_tts
+    except ImportError:
+        print("edge-tts 沒裝。跑 DepsTab → 「TTS runtime」一鍵裝。", file=sys.stderr)
+        sys.exit(2)
+
+    if not text.strip():
+        print("text 是空的,跳過", file=sys.stderr)
+        sys.exit(1)
+
+    communicate = edge_tts.Communicate(text, voice)
+    try:
+        await communicate.save(str(out_path))
+    except Exception as e:
+        print(f"edge-tts 合成失敗:{e}", file=sys.stderr)
+        sys.exit(2)
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("用法:mori-tts-edge.py <output-mp3-path> [voice]", file=sys.stderr)
+        print("  text 從 stdin 讀。voice 預設 zh-TW-HsiaoYuNeural", file=sys.stderr)
+        sys.exit(1)
+
+    out_path = Path(sys.argv[1])
+    voice = sys.argv[2] if len(sys.argv) > 2 else DEFAULT_VOICE
+
+    text = sys.stdin.read()
+    if not text:
+        print("stdin 沒文字", file=sys.stderr)
+        sys.exit(1)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    asyncio.run(synth(text, voice, out_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/scripts/mori-tts-edge.py
+++ b/examples/scripts/mori-tts-edge.py
@@ -46,7 +46,7 @@ import asyncio
 import sys
 from pathlib import Path
 
-DEFAULT_VOICE = "zh-TW-HsiaoYuNeural"
+DEFAULT_VOICE = "zh-TW-HsiaoChenNeural"
 
 
 async def synth(text: str, voice: str, out_path: Path) -> None:

--- a/src/tabs/ConfigTab.tsx
+++ b/src/tabs/ConfigTab.tsx
@@ -1357,6 +1357,61 @@ function ConfigTab({
 
           {/* Wake-ack 應答音(獨立 Section,Phase 3A.1.2)*/}
           <WakeAckSection />
+
+          {/* ── Phase 3D: Mori 講話(edge-tts speak-back)── */}
+          <Section
+            title="Mori 講話(TTS,Phase 3D)"
+            hint="Agent 回應完成後,讓 Mori 用聲音念出來。預設 OFF。用 Microsoft Edge 免費 TTS(無 quota、native zh-TW)。需先在 Deps 頁裝「Mori 講話 runtime(edge-tts)」。"
+          >
+            <FormRow label="enabled" hint="OFF → Mori 只在 ChatPanel 顯示文字(目前行為)。ON → 同時用聲音念。長回應 TTS 會講久,可能 5-15 秒,中途無法打斷(後續版本加 stop 鈕)。">
+              <input
+                type="checkbox"
+                checked={Boolean(cfg.tts?.enabled)}
+                onChange={(e) =>
+                  applyPatch((c) => {
+                    const t = ensureSubObj(c, "tts");
+                    t.enabled = e.target.checked;
+                  })
+                }
+              />
+            </FormRow>
+            <FormRow label="voice" hint="Microsoft Edge TTS 的 zh-TW voice。HsiaoYu 偏年輕清亮(預設,配 Mori 精靈少女形象),HsiaoChen 較成熟標準。換其他語言請查 `edge-tts --list-voices`。">
+              <Select
+                value={cfg.tts?.voice ?? "zh-TW-HsiaoYuNeural"}
+                onChange={(v) =>
+                  applyPatch((c) => {
+                    const t = ensureSubObj(c, "tts");
+                    t.voice = v;
+                  })
+                }
+                options={[
+                  { value: "zh-TW-HsiaoYuNeural", label: "zh-TW-HsiaoYuNeural(女,年輕清亮,預設)" },
+                  { value: "zh-TW-HsiaoChenNeural", label: "zh-TW-HsiaoChenNeural(女,標準)" },
+                  { value: "zh-TW-YunJheNeural", label: "zh-TW-YunJheNeural(男)" },
+                  { value: "zh-CN-XiaoxiaoNeural", label: "zh-CN-XiaoxiaoNeural(女,大陸口音)" },
+                  { value: "en-US-JennyNeural", label: "en-US-JennyNeural(英文女)" },
+                  { value: "ja-JP-NanamiNeural", label: "ja-JP-NanamiNeural(日文女)" },
+                ]}
+              />
+            </FormRow>
+            <FormRow label="" hint="試聽當前 voice。會 spawn Python edge-tts 子進程,有點延遲(2-5 秒)是正常。">
+              <button
+                className="mori-btn"
+                onClick={async () => {
+                  try {
+                    await invoke("tts_preview", {
+                      text: "嗨,我是 Mori。試聽聲音這樣 OK 嗎?",
+                      voice: cfg.tts?.voice ?? null,
+                    });
+                  } catch (e) {
+                    alert(`試聽失敗:${String(e)}`);
+                  }
+                }}
+              >
+                ▶ 試聽
+              </button>
+            </FormRow>
+          </Section>
           </>}
 
           {/* ── Appearance ─────────────────────────────── */}

--- a/src/tabs/ConfigTab.tsx
+++ b/src/tabs/ConfigTab.tsx
@@ -1375,9 +1375,9 @@ function ConfigTab({
                 }
               />
             </FormRow>
-            <FormRow label="voice" hint="Microsoft Edge TTS 的 zh-TW voice。HsiaoYu 偏年輕清亮(預設,配 Mori 精靈少女形象),HsiaoChen 較成熟標準。換其他語言請查 `edge-tts --list-voices`。">
+            <FormRow label="voice" hint="Microsoft Edge TTS 的 zh-TW voice。HsiaoChen 偏年輕清亮(預設,配 Mori 精靈少女形象),HsiaoYu 較成熟標準。換其他語言請查 `edge-tts --list-voices`。">
               <Select
-                value={cfg.tts?.voice ?? "zh-TW-HsiaoYuNeural"}
+                value={cfg.tts?.voice ?? "zh-TW-HsiaoChenNeural"}
                 onChange={(v) =>
                   applyPatch((c) => {
                     const t = ensureSubObj(c, "tts");
@@ -1385,12 +1385,22 @@ function ConfigTab({
                   })
                 }
                 options={[
-                  { value: "zh-TW-HsiaoYuNeural", label: "zh-TW-HsiaoYuNeural(女,年輕清亮,預設)" },
-                  { value: "zh-TW-HsiaoChenNeural", label: "zh-TW-HsiaoChenNeural(女,標準)" },
-                  { value: "zh-TW-YunJheNeural", label: "zh-TW-YunJheNeural(男)" },
-                  { value: "zh-CN-XiaoxiaoNeural", label: "zh-CN-XiaoxiaoNeural(女,大陸口音)" },
-                  { value: "en-US-JennyNeural", label: "en-US-JennyNeural(英文女)" },
-                  { value: "ja-JP-NanamiNeural", label: "ja-JP-NanamiNeural(日文女)" },
+                  // zh-TW(台灣腔)
+                  { value: "zh-TW-HsiaoChenNeural", label: "🇹🇼 zh-TW-HsiaoChenNeural(女,年輕清亮,預設)" },
+                  { value: "zh-TW-HsiaoYuNeural", label: "🇹🇼 zh-TW-HsiaoYuNeural(女,較成熟標準)" },
+                  { value: "zh-TW-YunJheNeural", label: "🇹🇼 zh-TW-YunJheNeural(男)" },
+                  // zh-CN(大陸腔)— Xiaoyi Lively 元氣感對 Mori 形象很合
+                  { value: "zh-CN-XiaoyiNeural", label: "🇨🇳 zh-CN-XiaoyiNeural(女,活潑元氣)" },
+                  { value: "zh-CN-XiaoxiaoNeural", label: "🇨🇳 zh-CN-XiaoxiaoNeural(女,溫暖)" },
+                  { value: "zh-CN-liaoning-XiaobeiNeural", label: "🇨🇳 zh-CN-liaoning-XiaobeiNeural(女,東北腔幽默)" },
+                  { value: "zh-CN-shaanxi-XiaoniNeural", label: "🇨🇳 zh-CN-shaanxi-XiaoniNeural(女,陝西腔明亮)" },
+                  // zh-HK(粵語)
+                  { value: "zh-HK-HiuGaaiNeural", label: "🇭🇰 zh-HK-HiuGaaiNeural(女,粵語)" },
+                  { value: "zh-HK-HiuMaanNeural", label: "🇭🇰 zh-HK-HiuMaanNeural(女,粵語)" },
+                  // 其他語言
+                  { value: "ja-JP-NanamiNeural", label: "🇯🇵 ja-JP-NanamiNeural(日文女)" },
+                  { value: "en-US-JennyNeural", label: "🇺🇸 en-US-JennyNeural(英文女)" },
+                  { value: "en-US-AriaNeural", label: "🇺🇸 en-US-AriaNeural(英文女,活潑)" },
                 ]}
               />
             </FormRow>


### PR DESCRIPTION
## Summary

Mori 在 agent 回應完成後可選用聲音講出來 — **預設 OFF**,user 在 Config tab 的「Mori 講話(TTS,Phase 3D)」section 主動啟用才會講話,不影響原本 ChatPanel 文字顯示。

### 為什麼 edge-tts 不是 Gemini TTS

| | edge-tts | Gemini TTS |
|---|---|---|
| 費用 | 完全免費(借 MS Edge 瀏覽器 endpoint) | Free tier 100/day,超出付費 |
| zh-TW voice | Native 沒英文口音味 | 英文 voice 講中文有口音 tinge |
| Quota | 實質無限額 | 對答幾句就破 |
| 依賴 | Python lib `edge-tts`(~10MB) | API key + HTTP call |

Mori 聊天場景一聊就 N 次回應,Gemini 配額不夠用。edge-tts 是現實正解。

## 變更

- **新 module `tts.rs`** — `speak_async()` agent response 完成時呼叫,tokio::spawn_blocking 跑 Python edge-tts → rodio decode MP3 + play
- **`mori-tts-edge.py`** Python bridge — `<out.mp3> [voice] < stdin` 介面
- **`ensure_script_deployed`** — include_bytes! 寫到 `~/.mori/bin/mori-tts-edge.py` 開機自動 deploy
- **DepsTab `tts-runtime`** — `pip install edge-tts` 進 wake-venv(共用)
- **ConfigTab UI** — Voice subtab 加 TTS section:enabled toggle + voice dropdown(6 個常用)+ ▶ 試聽鈕
- **rodio mp3 feature** — 加 symphonia-bundle-mp3 純 Rust decode
- **main.rs hook** — `Phase::Done { response }` set 前 spawn TTS task,不擋 UI

## Test plan

- [x] `cargo check --workspace --all-targets` ✅
- [x] `bash scripts/verify.sh`(201 tests pass)
- [ ] 實機 Linux:
  - [ ] DepsTab 點「Mori 講話 runtime」一鍵裝 → 綠燈
  - [ ] Config tab 開 tts.enabled + 選 HsiaoYu → 試聽鈕點下去能聽到 Mori 講話
  - [ ] 走完 agent 對話(Ctrl+Alt+N 喊一句)→ Mori 文字+聲音同時出
  - [ ] 切其他 voice(HsiaoChen / YunJhe 男聲)→ 確認都能合成
- [ ] CI ubuntu + windows

## 限制 / 留 v0.6.x+

- 沒辦法中斷正在播的 TTS(`Ctrl+Alt+Esc` 不停 sink)— 後續加 `Mutex<Option<Sink>>` cancel
- 長回應一次播完(沒 sentence streaming),5-15 秒體感久
- Windows wake-venv 還是 Manual,TTS 同樣得手動 setup
- 開機 Mori 講「我在了」歡迎詞 — 可選未來加

🤖 Generated with [Claude Code](https://claude.com/claude-code)