### PR TITLE
feat(evaluator): Phase 3C — wake-event intent filter (background noise gate)

### DIFF
--- a/crates/mori-core/src/evaluator.rs
+++ b/crates/mori-core/src/evaluator.rs
@@ -1,0 +1,190 @@
+//! Phase 3C — Wake event 後的 intent evaluator。
+//!
+//! Hey Mori 喚醒後 STT 拿到 transcript,**先過一輪 fast LLM 判斷意圖**,再
+//! 決定要不要進完整 agent loop。三種 outcome:
+//!
+//! - [`Intent::AddressMori`] — user 真的在跟 Mori 講話(指令 / 對話)。
+//!   → 走 agent pipeline(現有行為)
+//! - [`Intent::BackgroundNoise`] — wake-word false positive。user 不是在
+//!   叫 Mori,是自言自語 / 跟別人講話被 mic 收到。
+//!   → 直接 skip agent dispatch,emit `noise_rejected` event 給 UI 顯示
+//! - [`Intent::Unclear`] — 模糊,可能是斷句不完整 / 半截話。
+//!   → 走 agent 但加 hint 提示「user 句子不完整,可禮貌反問」
+//!
+//! ## 為什麼有這個
+//!
+//! Hey Mori wake threshold 設低(0.35-0.5)抓得到 user 聲線,但代價是
+//! false positive 多 — user 自言自語講到「Mori」之類關鍵字就觸發。讓
+//! 完整 agent loop(可能 spawn tool / call skill / 跑 1-3 LLM round)在
+//! noise 上跑很浪費 + 體感怪(Mori 對自己的影子回話)。
+//!
+//! Evaluator 是一個 **單一 fast LLM call**(Groq oss-120b ~200ms),擋
+//! 掉 noise 提升訊號比。
+//!
+//! ## 行為
+//!
+//! 預設 **OFF**(`evaluator.enabled = false`),既有行為不變。User 在
+//! Config tab 主動 enable + 設 provider(預設 groq)才會啟動。
+
+use std::sync::Arc;
+
+use anyhow::{anyhow, Context as _, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::llm::{ChatMessage, LlmProvider, ToolDefinition};
+
+/// Wake event STT 後 evaluator 判出的 user 意圖。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Intent {
+    /// User 真的在跟 Mori 講話(指令 / 對話 / 問問題)
+    AddressMori,
+    /// Wake-word false positive,user 不是在叫 Mori
+    BackgroundNoise,
+    /// 模糊 / 不完整,可能需要反問
+    Unclear,
+}
+
+/// Evaluator output。`intent` 必填,`reason` / `confidence` 可選。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluationResult {
+    pub intent: Intent,
+    /// LLM 給的判斷理由(debug / log 用,UI 可選擇顯示)
+    #[serde(default)]
+    pub reason: String,
+    /// 0.0..=1.0 信心值(LLM 自評,別太當真 — 主要看 intent)
+    #[serde(default)]
+    pub confidence: f32,
+}
+
+const EVALUATOR_SYSTEM_PROMPT: &str = r#"你是 Mori(桌面 AI 同伴)的 wake-word evaluator。每個 wake event 觸發後,user 的語音轉成 transcript 給你。你**只**判斷一件事:user 是不是在跟 Mori 講話?
+
+三種輸出:
+- `address_mori`:user 在跟 Mori 講話(指令 / 對話 / 問問題 / 閒聊)。明確或合理推斷都算。
+- `background_noise`:wake-word false positive — user 在跟別人講話、自言自語、看影片唸出來、隨口提到「Mori」這個詞。**不是**在跟 Mori 互動。
+- `unclear`:模糊 — 句子半截 / 內容空泛無上下文 / 像在思考但沒講完。
+
+判準:
+- 短指令「打開瀏覽器」「Mori 來幫我」「Hey Mori 查一下」→ address_mori
+- 完整對話「Mori 你今天好嗎」「我想問你一件事」→ address_mori
+- 自言自語「奇怪我剛剛在做什麼」「啊好煩」→ background_noise(沒提到 Mori 也沒指示)
+- 別人對話「他剛剛在玩什麼遊戲」「等下要吃什麼」→ background_noise
+- 半截話「然後...」「嗯...那個...」→ unclear
+- 看 YouTube 念稿「主持人說很多 AI 助手像 Siri 或 Mori」→ background_noise(只是提及)
+
+回 JSON,format:
+{"intent":"address_mori|background_noise|unclear","reason":"<10字內理由>","confidence":0.0-1.0}
+
+不要加 markdown fence,不要加說明,純 JSON。"#;
+
+/// 主入口 — 給 transcript + provider,回 EvaluationResult。
+///
+/// LLM 失敗(網路 / parse error)→ fallback 到 [`Intent::AddressMori`],
+/// 寧可 false positive 跑 agent 也不要 silent drop user 真的指令。
+pub async fn evaluate(
+    transcript: &str,
+    provider: Arc<dyn LlmProvider>,
+) -> Result<EvaluationResult> {
+    let messages = vec![
+        ChatMessage::system(EVALUATOR_SYSTEM_PROMPT.to_string()),
+        ChatMessage::user(format!("Transcript:「{transcript}」")),
+    ];
+    let tools: Vec<ToolDefinition> = Vec::new();
+    let chat = provider
+        .chat(messages, tools)
+        .await
+        .context("evaluator LLM call failed")?;
+    let raw = chat.content.unwrap_or_default();
+    if raw.trim().is_empty() {
+        return Err(anyhow!("evaluator returned empty response"));
+    }
+    match parse_evaluation(&raw) {
+        Ok(result) => Ok(result),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                raw = %raw,
+                "evaluator: parse failed, falling back to AddressMori",
+            );
+            Ok(EvaluationResult {
+                intent: Intent::AddressMori,
+                reason: "parse_failed".into(),
+                confidence: 0.0,
+            })
+        }
+    }
+}
+
+/// 從 LLM raw output parse JSON。寬容處理:
+/// - 純 JSON ✓
+/// - 包在 markdown fence(```json ... ```)→ 去 fence
+/// - 前後有解釋文字 → 找第一個 `{` 跟最後一個 `}` 取中間
+fn parse_evaluation(raw: &str) -> Result<EvaluationResult> {
+    let trimmed = raw.trim();
+    // 去 markdown fence
+    let cleaned = trimmed
+        .trim_start_matches("```json")
+        .trim_start_matches("```")
+        .trim_end_matches("```")
+        .trim();
+    // 嘗試直接 parse
+    if let Ok(result) = serde_json::from_str::<EvaluationResult>(cleaned) {
+        return Ok(result);
+    }
+    // 找第一個 `{` 跟最後一個 `}`(處理 LLM 加廢話的情況)
+    let start = cleaned
+        .find('{')
+        .ok_or_else(|| anyhow!("no '{{' in evaluator output: {cleaned}"))?;
+    let end = cleaned
+        .rfind('}')
+        .ok_or_else(|| anyhow!("no '}}' in evaluator output: {cleaned}"))?;
+    if end <= start {
+        return Err(anyhow!("malformed braces in evaluator output"));
+    }
+    let json_slice = &cleaned[start..=end];
+    serde_json::from_str::<EvaluationResult>(json_slice)
+        .with_context(|| format!("failed to parse evaluator JSON: {json_slice}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_pure_json() {
+        let raw = r#"{"intent":"address_mori","reason":"明確指令","confidence":0.95}"#;
+        let r = parse_evaluation(raw).unwrap();
+        assert_eq!(r.intent, Intent::AddressMori);
+        assert_eq!(r.reason, "明確指令");
+        assert!((r.confidence - 0.95).abs() < 0.001);
+    }
+
+    #[test]
+    fn parse_with_markdown_fence() {
+        let raw = "```json\n{\"intent\":\"background_noise\",\"reason\":\"自言自語\",\"confidence\":0.8}\n```";
+        let r = parse_evaluation(raw).unwrap();
+        assert_eq!(r.intent, Intent::BackgroundNoise);
+    }
+
+    #[test]
+    fn parse_with_extra_text() {
+        let raw = "Sure thing! Here's my analysis:\n{\"intent\":\"unclear\",\"reason\":\"半截話\",\"confidence\":0.5}\nLet me know if you need more.";
+        let r = parse_evaluation(raw).unwrap();
+        assert_eq!(r.intent, Intent::Unclear);
+    }
+
+    #[test]
+    fn parse_minimal_json() {
+        let raw = r#"{"intent":"address_mori"}"#;
+        let r = parse_evaluation(raw).unwrap();
+        assert_eq!(r.intent, Intent::AddressMori);
+        assert_eq!(r.reason, "");
+        assert_eq!(r.confidence, 0.0);
+    }
+
+    #[test]
+    fn parse_invalid_intent_fails() {
+        let raw = r#"{"intent":"foo","reason":"x","confidence":1.0}"#;
+        assert!(parse_evaluation(raw).is_err());
+    }
+}

--- a/crates/mori-core/src/lib.rs
+++ b/crates/mori-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod agent_profile;
 pub mod annuli;
 pub mod context;
 pub mod corrections;
+pub mod evaluator;
 pub mod event_log;
 pub mod installed_apps;
 pub mod llm;

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -2423,6 +2423,72 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
     *state_for_handle.pipeline_task.lock() = Some(task);
 }
 
+/// Phase 3C — evaluator gate 的回傳。`skip=true` 代表判定 background noise,
+/// 呼叫端應跳過 agent;`skip=false` → 走正常 agent。`reason` 給 UI / log 用。
+struct EvaluatorOutcome {
+    skip: bool,
+    reason: String,
+}
+
+/// 讀 `~/.mori/config.json` `evaluator.*` config,跑 evaluator LLM,回 outcome。
+/// 任何環節失敗 → return None(等同 disabled,呼叫端走正常 agent flow)。
+async fn evaluator_gate(transcript: &str) -> Option<EvaluatorOutcome> {
+    use mori_core::evaluator::{evaluate, Intent};
+
+    // Read config
+    let path = mori_dir().join("config.json");
+    let json: serde_json::Value = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|t| serde_json::from_str(&t).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+    let enabled = json
+        .pointer("/evaluator/enabled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if !enabled {
+        return None;
+    }
+    let provider_name = json
+        .pointer("/evaluator/provider")
+        .and_then(|v| v.as_str())
+        .unwrap_or("groq")
+        .to_string();
+
+    // Build provider
+    let provider = match mori_core::llm::build_named_provider(&provider_name, None) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                provider = provider_name,
+                "evaluator: build_named_provider failed — skipping gate",
+            );
+            return None;
+        }
+    };
+
+    // Run evaluator
+    match evaluate(transcript, provider).await {
+        Ok(result) => {
+            tracing::info!(
+                intent = ?result.intent,
+                reason = %result.reason,
+                confidence = result.confidence,
+                "evaluator: result",
+            );
+            let skip = matches!(result.intent, Intent::BackgroundNoise);
+            Some(EvaluatorOutcome {
+                skip,
+                reason: result.reason,
+            })
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "evaluator: evaluate() failed — skipping gate");
+            None
+        }
+    }
+}
+
 /// 共用的 chat pipeline:給定 transcript + provider,進 Phase::Responding,
 /// 呼叫 Agent,把結果回 UI、append 進 conversation history。
 ///
@@ -2435,6 +2501,31 @@ async fn run_agent_pipeline(
     transcript: String,
     routing: Arc<mori_core::llm::Routing>,
 ) {
+    // Phase 3C:evaluator pre-gate — config 開啟時,先過 fast LLM 判 user 是不是
+    // 在跟 Mori 講話。Background noise → 直接 skip agent + 進 Done(空 response)。
+    // AddressMori / Unclear → 走原本 agent flow。
+    if let Some(EvaluatorOutcome { skip, reason }) = evaluator_gate(&transcript).await {
+        if skip {
+            tracing::info!(reason, "evaluator: background noise — skipping agent");
+            let _ = app.emit(
+                "evaluator-rejected",
+                serde_json::json!({
+                    "transcript": transcript,
+                    "reason": reason,
+                }),
+            );
+            state.set_phase(
+                &app,
+                Phase::Done {
+                    transcript,
+                    response: format!("(背景噪音 — {reason})"),
+                    skill_calls: vec![],
+                },
+            );
+            return;
+        }
+    }
+
     state.set_phase(
         &app,
         Phase::Responding {

--- a/src/tabs/ConfigTab.tsx
+++ b/src/tabs/ConfigTab.tsx
@@ -1358,6 +1358,41 @@ function ConfigTab({
           {/* Wake-ack 應答音(獨立 Section,Phase 3A.1.2)*/}
           <WakeAckSection />
 
+          {/* ── Phase 3C: Wake-event evaluator(背景噪音過濾)── */}
+          <Section
+            title="Wake-event 過濾(Evaluator,Phase 3C)"
+            hint="Hey Mori 觸發後,STT 出來的 transcript 先過一輪 fast LLM 判斷:user 是不是真的在跟 Mori 講話?是 → 走正常 agent。否(自言自語 / 跟別人講話 / 念稿提到「Mori」)→ skip,不浪費 agent 跑無關內容。每次 wake 多 1 個 LLM call(~200ms,Groq 免費)。預設 OFF。"
+          >
+            <FormRow label="enabled" hint="OFF → 既有行為(直接進 agent)。ON → 多一層意圖判斷,過濾 wake-word false positive。建議 threshold 設低(0.35-0.5)但 evaluator ON,捕捉率 + 訊號比都高。">
+              <input
+                type="checkbox"
+                checked={Boolean(cfg.evaluator?.enabled)}
+                onChange={(e) =>
+                  applyPatch((c) => {
+                    const ev = ensureSubObj(c, "evaluator");
+                    ev.enabled = e.target.checked;
+                  })
+                }
+              />
+            </FormRow>
+            <FormRow label="provider" hint="跑 evaluator 用的 LLM provider。預設 groq(快、便宜、免費 quota 大)。模型走該 provider 的 model 設定(`providers.groq.model`)。Gemini API key 有的話也行,但 quota 更精貴不推薦。">
+              <Select
+                value={cfg.evaluator?.provider ?? "groq"}
+                onChange={(v) =>
+                  applyPatch((c) => {
+                    const ev = ensureSubObj(c, "evaluator");
+                    ev.provider = v;
+                  })
+                }
+                options={[
+                  { value: "groq", label: "groq(預設,gpt-oss-120b 快又便宜)" },
+                  { value: "gemini", label: "gemini API(會吃 Gemini quota)" },
+                  { value: "ollama", label: "ollama(本地,需自架)" },
+                ]}
+              />
+            </FormRow>
+          </Section>
+
           {/* ── Phase 3D: Mori 講話(edge-tts speak-back)── */}
           <Section
             title="Mori 講話(TTS,Phase 3D)"


### PR DESCRIPTION
## Summary

Hey Mori wake threshold 設低抓得到 user 聲線,但代價是 false positive 多。讓完整 agent loop 在 noise 上跑很浪費 + 體感怪(Mori 對自己的影子回話)。

這版加 **單一 fast LLM 預判**(Groq oss-120b ~200ms,免費)擋掉 background noise。預設 **OFF**,user 在 Config tab 主動 enable 才會 gate。

## 三分支 intent

| Intent | 對應行為 |
|---|---|
| `address_mori` | user 真的在跟 Mori 講話 → 走正常 agent(no change) |
| `background_noise` | wake false positive → skip agent + emit `evaluator-rejected` event + Phase::Done 顯示「(背景噪音)」 |
| `unclear` | 模糊半截話 → 暫時當 address_mori,走 agent(ask-back UI 延後 Phase 3C.2) |

## 為什麼有用

- Wake threshold 0.35 抓得到輕聲喊「Hey Mori」,但容易誤觸
- 自言自語 / 跟別人講話 / 看 YT 念到「Mori」都會中
- 沒 evaluator → agent loop 跑 1-3 round LLM + 可能 spawn skill,浪費 quota + 體感怪
- 有 evaluator → 1 個 LLM call(Groq 免費)擋下來,silent ignore

## 變更

- **`crates/mori-core/src/evaluator.rs`(new)** — `Intent` enum + `evaluate()` async + 5 unit tests
- **`main.rs::run_agent_pipeline`** — Phase::Responding 前先過 `evaluator_gate()`
- **ConfigTab Voice subtab** — 新「Wake-event 過濾(Evaluator,Phase 3C)」section(toggle + provider Select)

## Config schema

```json
{
  "evaluator": {
    "enabled": true,
    "provider": "groq"
  }
}
```

## Test plan

- [x] `cargo test -p mori-core --lib evaluator` 5 tests pass ✅
- [x] `bash scripts/verify.sh`(206 tests pass)
- [ ] CI ubuntu + windows
- [ ] 實機 Linux:Config tab 開 evaluator.enabled → 對 mic 自言自語(不講「Mori」)→ 確認 wake 觸發後被 evaluator gate 擋,Phase::Done 顯示「(背景噪音 — 自言自語)」
- [ ] 對 mic 真的喊「Hey Mori 開瀏覽器」 → 確認走正常 agent flow,open_url 有觸發
- [ ] 看 ChatPanel / Logs 有沒看到 evaluator log 「intent=address_mori reason=明確指令」

## 留 v0.6.x+

- Phase 3C.2:ask-back UI — `Intent::Unclear` 時 Mori 反問 user(用 TTS 講)+ 自動重進 Listening 等回答
- Confidence threshold(目前只看 intent,不看 confidence)
- Per-profile evaluator on/off
- Evaluator 結果寫進 ChatPanel(像 skill_call chip)讓 user 看 LLM 判斷理由

🤖 Generated with [Claude Code](https://claude.com/claude-code)