### PR TITLE
feat(speaker-id): Phase 3E — voice biometric gate(只認 enrolled user)+ WakeAck UI bug fix

### DIFF
--- a/crates/mori-tauri/src/deps.rs
+++ b/crates/mori-tauri/src/deps.rs
@@ -459,6 +459,56 @@ pub fn registry() -> Vec<DepSpec> {
                 }),
             ],
         },
+        // Phase 3E:resemblyzer 聲紋辨識 — 共用 wake-venv,~100MB(含 80MB pretrained
+        // VoiceEncoder + librosa + numpy deps)。預設 OFF,user 開啟才會 gate。
+        DepSpec {
+            id: "speaker-id-runtime",
+            name: "聲紋辨識 runtime(resemblyzer)",
+            description: "Phase 3E speaker verification 用的 Python resemblyzer(VoxCeleb \
+                          pretrained voice encoder)。沒裝 → Config 開 speaker_id.enabled \
+                          也不會 gate(只 log)。跟 wake-listener / edge-tts 共用 wake-venv。",
+            unlocks: "speaker_id.enabled=true 時擋下別人聲音,只有 enrolled user 能叫 Mori",
+            size_hint: Some("~100MB(含 pretrained model)"),
+            needs_sudo: false,
+            platforms: &["linux", "macos", "windows"],
+            install_caveat: None,
+            check: CheckSpec::CommandStdoutContains {
+                cmd: "sh",
+                args: &[
+                    "-c",
+                    "$HOME/.mori/wake-venv/bin/python -c 'import resemblyzer; print(\"ok\")' 2>&1",
+                ],
+                needle: "ok",
+            },
+            install: InstallSpec::Shell {
+                script: "set -e; \
+                         VENV=\"$HOME/.mori/wake-venv\"; \
+                         UV=\"$HOME/.local/bin/uv\"; \
+                         if [ ! -x \"$VENV/bin/python\" ]; then \
+                            echo '⚠ wake-venv 不存在 — 先裝 wake-listener-runtime'; exit 2; \
+                         fi; \
+                         if [ -x \"$UV\" ]; then \
+                            echo '用 uv pip install resemblyzer...'; \
+                            \"$UV\" pip install --python \"$VENV/bin/python\" resemblyzer; \
+                         elif [ -x \"$VENV/bin/pip\" ]; then \
+                            echo '用 venv pip...'; \
+                            \"$VENV/bin/pip\" install resemblyzer; \
+                         else \
+                            echo '用 ensurepip bootstrap...'; \
+                            \"$VENV/bin/python\" -m ensurepip --upgrade; \
+                            \"$VENV/bin/python\" -m pip install resemblyzer; \
+                         fi; \
+                         echo '✓ resemblyzer 裝好了。第一次跑 enrollment 會自動下載 80MB pretrained model。'",
+            },
+            install_overrides: &[
+                ("windows", InstallSpec::Manual {
+                    commands: &[
+                        "# Windows PowerShell(需先有 wake-venv):",
+                        "uv pip install --python %USERPROFILE%\\.mori\\wake-venv\\Scripts\\python.exe resemblyzer",
+                    ],
+                }),
+            ],
+        },
     ]
 }
 

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -2225,6 +2225,61 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
         // provider 就 100% Groq-free)。
         let transcribe_result: anyhow::Result<String> = async {
             let mut audio = recorder.stop().context("stop recorder")?;
+
+            // Phase 3E:speaker verification 用 **raw audio**(silence-trim 前)。
+            // resemblyzer 內建 VAD 會自己抓有聲段,我們不該 double-trim — 之前
+            // 用 trimmed audio 把 4.65s 砍到 0.39s,resemblyzer 在 < 1 秒上
+            // embedding 不穩(同一人 score 從 0.75 掉到 0.55 誤拒)。
+            //
+            // 先寫一份 raw WAV 給 speaker_id 用,後面再 trim + STT。
+            let raw_wav = audio.to_wav_bytes().context("encode raw WAV")?;
+            let raw_path = std::env::temp_dir().join("mori-last-recording-raw.wav");
+            let _ = std::fs::write(&raw_path, &raw_wav);
+            let verify_path = raw_path.clone();
+            let outcome = tokio::task::spawn_blocking(move || {
+                speaker_id::verify_audio_file(&verify_path)
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("speaker_id join: {e}"))?;
+            match &outcome {
+                speaker_id::VerifyOutcome::Verified(r) if !r.pass => {
+                    tracing::info!(
+                        score = r.score,
+                        threshold = r.threshold,
+                        raw_duration_secs = audio.duration_secs(),
+                        "speaker_id: rejected — not enrolled user"
+                    );
+                    mori_core::event_log::append(serde_json::json!({
+                        "kind": "speaker_id_rejected",
+                        "score": r.score,
+                        "threshold": r.threshold,
+                    }));
+                    let _ = app_for_provider.emit(
+                        "speaker-id-rejected",
+                        serde_json::json!({
+                            "score": r.score,
+                            "threshold": r.threshold,
+                        }),
+                    );
+                    return Ok(String::new());
+                }
+                speaker_id::VerifyOutcome::Verified(r) => {
+                    tracing::info!(
+                        score = r.score,
+                        threshold = r.threshold,
+                        raw_duration_secs = audio.duration_secs(),
+                        "speaker_id: pass"
+                    );
+                }
+                speaker_id::VerifyOutcome::NotEnrolled => {
+                    tracing::info!("speaker_id: skipped (user not enrolled)");
+                }
+                speaker_id::VerifyOutcome::Disabled => {}
+                speaker_id::VerifyOutcome::Error(e) => {
+                    tracing::warn!(error = %e, "speaker_id: error — passing through");
+                }
+            }
+
             if read_voice_trim_silence_enabled() {
                 let before_samples = audio.samples.len();
                 let before_secs = audio.duration_secs();
@@ -2341,52 +2396,9 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
             let _ = std::fs::write(&debug_path, &wav);
             tracing::info!(path = %debug_path.display(), "wrote debug WAV");
 
-            // Phase 3E:speaker verification gate(config 開啟才跑)。
-            // 把 WAV 路徑丟給 Python resemblyzer 算 embedding + cosine 比對,
-            // score < threshold(預設 0.7)→ 別人聲音,silent reject。
-            // spawn_blocking 包 Python subprocess,~100-500ms。
-            let verify_path = debug_path.clone();
-            let outcome = tokio::task::spawn_blocking(move || {
-                speaker_id::verify_audio_file(&verify_path)
-            })
-            .await
-            .map_err(|e| anyhow::anyhow!("speaker_id join: {e}"))?;
-            match &outcome {
-                speaker_id::VerifyOutcome::Verified(r) if !r.pass => {
-                    tracing::info!(
-                        score = r.score,
-                        threshold = r.threshold,
-                        "speaker_id: rejected — not enrolled user"
-                    );
-                    mori_core::event_log::append(serde_json::json!({
-                        "kind": "speaker_id_rejected",
-                        "score": r.score,
-                        "threshold": r.threshold,
-                    }));
-                    let _ = app_for_provider.emit(
-                        "speaker-id-rejected",
-                        serde_json::json!({
-                            "score": r.score,
-                            "threshold": r.threshold,
-                        }),
-                    );
-                    return Ok(String::new());
-                }
-                speaker_id::VerifyOutcome::Verified(r) => {
-                    tracing::info!(
-                        score = r.score,
-                        threshold = r.threshold,
-                        "speaker_id: pass"
-                    );
-                }
-                speaker_id::VerifyOutcome::NotEnrolled => {
-                    tracing::info!("speaker_id: skipped (user not enrolled)");
-                }
-                speaker_id::VerifyOutcome::Disabled => {} // 沒 log 太吵
-                speaker_id::VerifyOutcome::Error(e) => {
-                    tracing::warn!(error = %e, "speaker_id: error — passing through");
-                }
-            }
+            // Phase 3E speaker verification 已在 silence-trim 前用 raw audio 跑完
+            // (見 fn 上方 transcribe_result 開頭)— 不再在此處跑,避免短 audio
+            // embedding 不穩誤拒 user 本人。
 
             // 5F: VoiceInput mode 時，profile 可用 stt_provider 覆蓋全域 STT 設定
             let stt_override: Option<String> = if matches!(*state.mode.lock(), Mode::VoiceInput) {

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -2435,6 +2435,24 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
             }
         };
 
+        // Phase 3E + STT-skip:空 transcript 一律不送下游。可能原因:
+        // 1. Speaker_id reject(別人聲音,silent skip)
+        // 2. STT gate skip(audio too quiet / too short)
+        // 3. Whisper 真的回空(理論上不該,但守一道)
+        // 直接 Phase::Done + return,不浪費 agent / LLM call。
+        if transcript.trim().is_empty() {
+            tracing::info!("empty transcript — skipping downstream agent pipeline");
+            state.set_phase(
+                &app,
+                Phase::Done {
+                    transcript: String::new(),
+                    response: String::new(),
+                    skill_calls: vec![],
+                },
+            );
+            return;
+        }
+
         // Stage 2: routing 拆 agent + per-skill provider(5A-3)。STT 一定走 Groq
         // Whisper(stage 1),但 chat 跟 skill 各自的 provider 由 routing 決定。
         let routing =

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -23,6 +23,7 @@ mod x11_shape;
 mod selection;
 mod shell_skill;
 mod skill_server;
+mod speaker_id;
 mod theme;
 mod transcribe_cmds;
 mod tts;
@@ -2340,6 +2341,53 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
             let _ = std::fs::write(&debug_path, &wav);
             tracing::info!(path = %debug_path.display(), "wrote debug WAV");
 
+            // Phase 3E:speaker verification gate(config 開啟才跑)。
+            // 把 WAV 路徑丟給 Python resemblyzer 算 embedding + cosine 比對,
+            // score < threshold(預設 0.7)→ 別人聲音,silent reject。
+            // spawn_blocking 包 Python subprocess,~100-500ms。
+            let verify_path = debug_path.clone();
+            let outcome = tokio::task::spawn_blocking(move || {
+                speaker_id::verify_audio_file(&verify_path)
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("speaker_id join: {e}"))?;
+            match &outcome {
+                speaker_id::VerifyOutcome::Verified(r) if !r.pass => {
+                    tracing::info!(
+                        score = r.score,
+                        threshold = r.threshold,
+                        "speaker_id: rejected — not enrolled user"
+                    );
+                    mori_core::event_log::append(serde_json::json!({
+                        "kind": "speaker_id_rejected",
+                        "score": r.score,
+                        "threshold": r.threshold,
+                    }));
+                    let _ = app_for_provider.emit(
+                        "speaker-id-rejected",
+                        serde_json::json!({
+                            "score": r.score,
+                            "threshold": r.threshold,
+                        }),
+                    );
+                    return Ok(String::new());
+                }
+                speaker_id::VerifyOutcome::Verified(r) => {
+                    tracing::info!(
+                        score = r.score,
+                        threshold = r.threshold,
+                        "speaker_id: pass"
+                    );
+                }
+                speaker_id::VerifyOutcome::NotEnrolled => {
+                    tracing::info!("speaker_id: skipped (user not enrolled)");
+                }
+                speaker_id::VerifyOutcome::Disabled => {} // 沒 log 太吵
+                speaker_id::VerifyOutcome::Error(e) => {
+                    tracing::warn!(error = %e, "speaker_id: error — passing through");
+                }
+            }
+
             // 5F: VoiceInput mode 時，profile 可用 stt_provider 覆蓋全域 STT 設定
             let stt_override: Option<String> = if matches!(*state.mode.lock(), Mode::VoiceInput) {
                 mori_core::voice_input_profile::load_active_profile()
@@ -4045,6 +4093,9 @@ fn main() {
             wake_sound::wake_ack_upload,
             wake_sound::wake_ack_delete_alternate,
             tts::tts_preview,
+            speaker_id::speaker_id_status,
+            speaker_id::speaker_id_enroll,
+            speaker_id::speaker_id_clear,
         ])
         .on_window_event(|window, event| {
             // 關視窗時不殺 app — 隱藏到系統匣繼續跑(像 Slack / Discord)
@@ -4078,6 +4129,10 @@ fn main() {
             // Phase 3D:deploy ~/.mori/bin/mori-tts-edge.py(edge-tts bridge script)。
             // TTS speak-back 預設 OFF,user enable 才會用到。但 script 先 deploy 不影響。
             tts::ensure_script_deployed(&mori_dir());
+
+            // Phase 3E:deploy ~/.mori/bin/mori-voice-enroll.py + mori-voice-verify.py。
+            // Speaker verification 預設 OFF。
+            speaker_id::ensure_scripts_deployed(&mori_dir());
 
             // 啟動初始 floating visibility — update_floating_visibility 自己會看:
             //   - quickstart_completed (儀式還沒完成 → 強制隱藏)

--- a/crates/mori-tauri/src/speaker_id.rs
+++ b/crates/mori-tauri/src/speaker_id.rs
@@ -1,0 +1,308 @@
+//! Speaker verification(聲紋辨識,Phase 3E)。
+//!
+//! Wake event 觸發 + user 講話完(VAD silence-stop 後),把 recording 音檔
+//! 跟 enrolled user embedding 比對 cosine similarity:
+//! - score >= threshold → 確認是 user 本人 → 走 agent
+//! - score < threshold → 別人聲音,silent reject
+//!
+//! 預設 OFF — config `speaker_id.enabled=true` 才會 gate。沒 enrolled
+//! (user 還沒錄聲紋)→ 直接 pass(避免 deadlock 鎖住所有人)。
+//!
+//! 兩個入口:
+//! - [`enroll_user_voice`] — 一次性 enrollment,~30s 錄音抽聲紋存到 .npy
+//! - [`verify_audio_file`] — 每次 wake 後驗 audio file 是不是 user
+//!
+//! 共用 wake-venv Python(`~/.mori/wake-venv/bin/python`),deps:resemblyzer。
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use serde::{Deserialize, Serialize};
+
+use crate::mori_dir;
+
+const DEFAULT_THRESHOLD: f32 = 0.7;
+const DEFAULT_ENROLL_SECONDS: f32 = 30.0;
+
+// ── Bundled Python scripts(deploy 到 ~/.mori/bin/)──────────────────────────
+
+const BUNDLED_ENROLL_SCRIPT: &[u8] =
+    include_bytes!("../../../examples/scripts/mori-voice-enroll.py");
+const BUNDLED_VERIFY_SCRIPT: &[u8] =
+    include_bytes!("../../../examples/scripts/mori-voice-verify.py");
+
+/// 開機呼叫:確保 enrollment + verify 兩個 Python script 在 user dir。
+pub fn ensure_scripts_deployed(mori_dir: &Path) {
+    let bin = mori_dir.join("bin");
+    if let Err(e) = fs::create_dir_all(&bin) {
+        tracing::warn!(error = %e, dir = %bin.display(), "speaker_id: mkdir bin failed");
+        return;
+    }
+    for (name, bytes) in &[
+        ("mori-voice-enroll.py", BUNDLED_ENROLL_SCRIPT),
+        ("mori-voice-verify.py", BUNDLED_VERIFY_SCRIPT),
+    ] {
+        let path = bin.join(name);
+        if path.exists() {
+            continue;
+        }
+        if let Err(e) = fs::write(&path, *bytes) {
+            tracing::warn!(error = %e, path = %path.display(), "speaker_id: write script failed");
+            continue;
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Ok(meta) = fs::metadata(&path) {
+                let mut perms = meta.permissions();
+                perms.set_mode(0o755);
+                let _ = fs::set_permissions(&path, perms);
+            }
+        }
+        tracing::info!(name, "speaker_id: deployed bundled script");
+    }
+}
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+fn default_python() -> PathBuf {
+    let venv = mori_dir().join("wake-venv");
+    if cfg!(target_os = "windows") {
+        venv.join("Scripts").join("python.exe")
+    } else {
+        venv.join("bin").join("python")
+    }
+}
+
+fn enrollment_path() -> PathBuf {
+    mori_dir().join("voiceid").join("user_embedding.npy")
+}
+
+fn enroll_script_path() -> PathBuf {
+    mori_dir().join("bin").join("mori-voice-enroll.py")
+}
+
+fn verify_script_path() -> PathBuf {
+    mori_dir().join("bin").join("mori-voice-verify.py")
+}
+
+#[derive(Debug, Clone)]
+struct SpeakerIdConfig {
+    enabled: bool,
+    threshold: f32,
+    python: PathBuf,
+}
+
+fn read_config() -> SpeakerIdConfig {
+    let default = SpeakerIdConfig {
+        enabled: false,
+        threshold: DEFAULT_THRESHOLD,
+        python: default_python(),
+    };
+    let path = mori_dir().join("config.json");
+    let Ok(text) = fs::read_to_string(&path) else {
+        return default;
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return default;
+    };
+    let enabled = json
+        .pointer("/speaker_id/enabled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let threshold = json
+        .pointer("/speaker_id/threshold")
+        .and_then(|v| v.as_f64())
+        .map(|v| v.clamp(0.3, 0.99) as f32)
+        .unwrap_or(DEFAULT_THRESHOLD);
+    let python = json
+        .pointer("/speaker_id/python")
+        .and_then(|v| v.as_str())
+        .map(PathBuf::from)
+        .unwrap_or_else(default_python);
+    SpeakerIdConfig {
+        enabled,
+        threshold,
+        python,
+    }
+}
+
+// ── Verify(每次 wake 後跑)──────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerifyResult {
+    pub score: f32,
+    pub pass: bool,
+    pub threshold: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum VerifyOutcome {
+    /// 不在 enabled 狀態 → 不 gate,直接放行
+    Disabled,
+    /// User 還沒 enroll → 不 gate(避免鎖死),只 log 提示
+    NotEnrolled,
+    /// 驗證跑了 + 結果
+    Verified(VerifyResult),
+    /// Python 跑失敗 → log 但放行(寧可 false positive 也不要 user 用不了)
+    Error(String),
+}
+
+/// 驗 audio file 是不是 enrolled user。
+///
+/// **Blocking** — 內部 spawn Python subprocess + wait。run from `spawn_blocking`
+/// task,別在 async runtime 直接 call。
+pub fn verify_audio_file(audio_path: &Path) -> VerifyOutcome {
+    let cfg = read_config();
+    if !cfg.enabled {
+        return VerifyOutcome::Disabled;
+    }
+    let user_emb = enrollment_path();
+    if !user_emb.exists() {
+        tracing::info!(
+            path = %user_emb.display(),
+            "speaker_id enabled but user not enrolled — skipping gate",
+        );
+        return VerifyOutcome::NotEnrolled;
+    }
+    let script = verify_script_path();
+    if !script.exists() {
+        return VerifyOutcome::Error(format!(
+            "verify script not found: {}",
+            script.display()
+        ));
+    }
+    if !cfg.python.exists() {
+        return VerifyOutcome::Error(format!(
+            "python not found: {}(跑 DepsTab → 聲紋辨識 runtime 一鍵裝)",
+            cfg.python.display()
+        ));
+    }
+
+    let output = match Command::new(&cfg.python)
+        .arg(&script)
+        .arg(&user_emb)
+        .arg(audio_path)
+        .arg("--threshold")
+        .arg(cfg.threshold.to_string())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => return VerifyOutcome::Error(format!("spawn python: {e}")),
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return VerifyOutcome::Error(format!(
+            "verify exited {}: {}",
+            output.status,
+            stderr.trim()
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let last_line = stdout.lines().last().unwrap_or("").trim();
+    match serde_json::from_str::<VerifyResult>(last_line) {
+        Ok(r) => VerifyOutcome::Verified(r),
+        Err(e) => VerifyOutcome::Error(format!("parse verify output: {e} — got: {last_line}")),
+    }
+}
+
+// ── Enrollment(IPC command,UI 觸發)────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EnrollmentStatus {
+    pub enrolled: bool,
+    pub path: String,
+    pub size_bytes: u64,
+    pub enabled: bool,
+    pub threshold: f32,
+}
+
+/// IPC command — UI 開啟時 / 每次操作後查狀態。
+#[tauri::command]
+pub fn speaker_id_status() -> EnrollmentStatus {
+    let cfg = read_config();
+    let path = enrollment_path();
+    let (enrolled, size_bytes) = match fs::metadata(&path) {
+        Ok(m) => (true, m.len()),
+        Err(_) => (false, 0),
+    };
+    EnrollmentStatus {
+        enrolled,
+        path: path.to_string_lossy().into_owned(),
+        size_bytes,
+        enabled: cfg.enabled,
+        threshold: cfg.threshold,
+    }
+}
+
+/// IPC command — UI 點「錄音註冊我的聲音」觸發。Blocking ~30s。
+///
+/// 跑 Python enrollment script,output 寫到 `~/.mori/voiceid/user_embedding.npy`。
+/// 失敗回 Err,UI 顯示錯誤訊息。
+#[tauri::command]
+pub async fn speaker_id_enroll(seconds: Option<f32>) -> Result<EnrollmentStatus, String> {
+    let cfg = read_config();
+    let script = enroll_script_path();
+    if !script.exists() {
+        return Err(format!(
+            "enroll script not found: {} — 重啟 mori-tauri 自動 deploy",
+            script.display()
+        ));
+    }
+    if !cfg.python.exists() {
+        return Err(format!(
+            "Python venv 沒裝(找不到 {}),先跑 DepsTab → 聲紋辨識 runtime",
+            cfg.python.display()
+        ));
+    }
+    let secs = seconds.unwrap_or(DEFAULT_ENROLL_SECONDS).clamp(5.0, 120.0);
+    let out_path = enrollment_path();
+    if let Some(parent) = out_path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    let python = cfg.python.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        Command::new(&python)
+            .arg(&script)
+            .arg(&out_path)
+            .arg("--seconds")
+            .arg(secs.to_string())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+    })
+    .await
+    .map_err(|e| format!("join: {e}"))?
+    .map_err(|e| format!("spawn python: {e}"))?;
+
+    if !result.status.success() {
+        let stderr = String::from_utf8_lossy(&result.stderr).into_owned();
+        let stdout = String::from_utf8_lossy(&result.stdout).into_owned();
+        return Err(format!(
+            "enrollment exit {}: stderr={} stdout-tail={}",
+            result.status,
+            stderr.trim(),
+            stdout.lines().last().unwrap_or("").trim()
+        ));
+    }
+
+    Ok(speaker_id_status())
+}
+
+/// IPC command — 清掉 enrollment(刪 .npy),user 想重 enroll 前用。
+#[tauri::command]
+pub fn speaker_id_clear() -> Result<EnrollmentStatus, String> {
+    let path = enrollment_path();
+    if path.exists() {
+        fs::remove_file(&path).map_err(|e| format!("remove enrollment: {e}"))?;
+    }
+    Ok(speaker_id_status())
+}

--- a/crates/mori-tauri/src/wake_word.rs
+++ b/crates/mori-tauri/src/wake_word.rs
@@ -253,7 +253,11 @@ impl Drop for WakeWordListener {
 // ─── Config readers ────────────────────────────────────────────────────
 
 /// 從 `~/.mori/config.json` `listening_mode.*` 區塊讀 WakeWordConfig。
-/// 預設值對齊 Phase 3A 設計 — phrase = Hey Mori, threshold 0.5。
+/// 預設值對齊 Phase 3E pipeline 設計 — phrase = Hey Mori, threshold **0.7**。
+///
+/// 為什麼 0.7 不是更高(0.9+):下游有 Phase 3E speaker verification + Phase 3C
+/// evaluator 兩層 filter,wake 可以放寬;反而要避免 0.9+ 漏掉 user 輕聲 /
+/// 不完整發音的「Hey Mori」(recall ↓)。0.7 是 wake-word 主流 operating point。
 pub fn config_from_disk(mori_dir: &Path) -> WakeWordConfig {
     let cfg_text = std::fs::read_to_string(mori_dir.join("config.json")).ok();
     let json: serde_json::Value = cfg_text
@@ -283,7 +287,7 @@ pub fn config_from_disk(mori_dir: &Path) -> WakeWordConfig {
         .pointer("/listening_mode/threshold")
         .and_then(|v| v.as_f64())
         .map(|v| v.clamp(0.05, 0.95) as f32)
-        .unwrap_or(0.5);
+        .unwrap_or(0.7);
 
     let verifier_path = json
         .pointer("/listening_mode/verifier_path")
@@ -339,7 +343,7 @@ mod tests {
         std::fs::create_dir_all(&tmp).unwrap();
         let cfg = config_from_disk(&tmp);
         assert_eq!(cfg.python, PathBuf::from("python3"));
-        assert_eq!(cfg.threshold, 0.5);
+        assert_eq!(cfg.threshold, 0.7);
         assert!(cfg.model_path.ends_with("wakeword/hey-mori.onnx"));
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/examples/scripts/mori-voice-enroll.py
+++ b/examples/scripts/mori-voice-enroll.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""mori-voice-enroll.py — 註冊使用者聲紋(Phase 3E)。
+
+用 resemblyzer 抽 30 秒語音的 256-dim 聲紋向量,存到 user 指定路徑。
+mori-tauri 之後在每次 wake event 後比對 incoming 聲音是不是同一個人。
+
+## 用法
+
+  python mori-voice-enroll.py <output-embedding.npy> [--seconds 30]
+
+  錄音從預設 input device 抓,sample_rate 16kHz mono(resemblyzer 內部會
+  preprocess,但給標準格式比較穩)。
+
+## stdout / stderr protocol
+
+  stdout: JSON 進度事件,line-delimited
+    {"event":"recording_start", "seconds": 30}
+    {"event":"recording_progress", "elapsed": 5.0}
+    {"event":"recording_done"}
+    {"event":"embedding_start"}
+    {"event":"embedding_done", "path": "/path/to/embedding.npy", "dim": 256}
+    {"event":"error", "msg": "..."}
+
+  Rust 端讀 stdout JSON 給 UI 顯示「錄音中... 25 秒剩」。
+
+## 為什麼 30 秒
+
+resemblyzer encoder 在 5-10s 已能抽穩定 embedding,但越長越穩定,30 秒涵蓋
+不同 prosody / 停頓 / 音高範圍,提高 day-to-day 辨識穩定度。建議錄各種句子
+(短/長、平靜/興奮、Hey Mori 變體)。
+
+## 為什麼用 resemblyzer 不用 speechbrain / pyannote
+
+resemblyzer:
+  - 純 Python,純 PyTorch,沒外部 C++ dep
+  - Pretrained on VoxCeleb,~80MB 模型
+  - API 一行:`VoiceEncoder().embed_utterance(audio)`
+  - 安裝 1 個 pip,2-3 分鐘
+
+speechbrain / pyannote 準度高但裝起來重,Phase 3E MVP 用 resemblyzer 即可。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+
+def emit(obj: dict) -> None:
+    print(json.dumps(obj), flush=True)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Enroll user voice for Mori speaker verification")
+    ap.add_argument("output", type=Path, help="輸出 .npy 路徑,例 ~/.mori/voiceid/user_embedding.npy")
+    ap.add_argument("--seconds", type=float, default=30.0, help="錄音秒數(預設 30,建議 ≥15)")
+    ap.add_argument("--sample-rate", type=int, default=16000)
+    args = ap.parse_args()
+
+    try:
+        import numpy as np
+        import sounddevice as sd
+        from resemblyzer import VoiceEncoder, preprocess_wav
+    except ImportError as e:
+        emit({"event": "error", "msg": f"missing dep: {e}. 跑 DepsTab → 「聲紋辨識 runtime」一鍵裝"})
+        sys.exit(2)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    # ── 錄音 ────────────────────────────────────────────────────────────────
+    emit({"event": "recording_start", "seconds": args.seconds})
+    total_frames = int(args.seconds * args.sample_rate)
+    recording = np.zeros((total_frames,), dtype=np.float32)
+
+    # 用 InputStream 邊錄邊報進度(每 0.5s emit 一次)
+    written = [0]
+    last_progress_emit = [time.time()]
+
+    def callback(indata, frames, time_info, status):
+        if status:
+            print(f"[enroll] stream status: {status}", file=sys.stderr)
+        n = min(frames, total_frames - written[0])
+        if n <= 0:
+            return
+        recording[written[0]:written[0] + n] = indata[:n, 0]
+        written[0] += n
+        now = time.time()
+        if now - last_progress_emit[0] >= 0.5:
+            elapsed = written[0] / args.sample_rate
+            emit({"event": "recording_progress", "elapsed": round(elapsed, 1)})
+            last_progress_emit[0] = now
+
+    stream = sd.InputStream(
+        samplerate=args.sample_rate,
+        channels=1,
+        dtype="float32",
+        callback=callback,
+    )
+    stream.start()
+    # Block 直到錄滿
+    start = time.time()
+    while written[0] < total_frames:
+        elapsed = time.time() - start
+        if elapsed > args.seconds + 2:  # safety:超過預期 +2s 還沒滿就斷
+            break
+        time.sleep(0.05)
+    stream.stop()
+    stream.close()
+
+    if written[0] < total_frames * 0.5:
+        emit({"event": "error", "msg": f"錄音不足({written[0]}/{total_frames} samples)"})
+        sys.exit(3)
+
+    actual_audio = recording[:written[0]]
+    emit({"event": "recording_done"})
+
+    # ── 抽聲紋 ──────────────────────────────────────────────────────────────
+    emit({"event": "embedding_start"})
+    try:
+        # resemblyzer preprocess_wav 需 16kHz mono float32 numpy。Vad-trim 自動做。
+        wav_preprocessed = preprocess_wav(actual_audio, source_sr=args.sample_rate)
+        encoder = VoiceEncoder(verbose=False)
+        embedding = encoder.embed_utterance(wav_preprocessed)
+    except Exception as e:
+        emit({"event": "error", "msg": f"embedding 失敗:{e}"})
+        sys.exit(4)
+
+    # ── 存檔 ────────────────────────────────────────────────────────────────
+    np.save(args.output, embedding)
+    emit({
+        "event": "embedding_done",
+        "path": str(args.output),
+        "dim": int(embedding.shape[0]),
+    })
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/scripts/mori-voice-verify.py
+++ b/examples/scripts/mori-voice-verify.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""mori-voice-verify.py — 驗證 incoming 聲音是不是 enrolled user(Phase 3E)。
+
+mori-tauri 在每次 wake event 後,user 講完 + STT 之前(或之後)呼叫這個 script:
+- 給 enrolled embedding `.npy` + recording `.wav`
+- 回 cosine similarity score(0-1)+ pass/fail 判定
+
+## 用法
+
+  python mori-voice-verify.py <user-embedding.npy> <audio.wav> [--threshold 0.7]
+
+## stdout protocol(JSON,單行)
+
+  {"score": 0.85, "pass": true, "threshold": 0.7}
+  {"error": "..."}
+
+  Rust 端 parse → score < threshold 就 silent reject 不送 agent。
+
+## 為什麼用 audio file 不用 stdin pipe raw audio
+
+WAV file API 跨 Python/Rust 最穩,沒 byte-order / endianness / sample-rate
+誤判風險。recording.rs 已會寫 WAV,直接把暫存路徑 passthrough 即可。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def emit(obj: dict) -> None:
+    print(json.dumps(obj), flush=True)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Verify incoming voice matches enrolled user")
+    ap.add_argument("user_embedding", type=Path, help="enrolled user .npy(從 mori-voice-enroll.py 產出)")
+    ap.add_argument("audio", type=Path, help="incoming recording .wav")
+    ap.add_argument("--threshold", type=float, default=0.7, help="cosine threshold(0~1,預設 0.7)")
+    args = ap.parse_args()
+
+    if not args.user_embedding.exists():
+        emit({"error": f"user embedding 不存在:{args.user_embedding}(先跑 enrollment)"})
+        sys.exit(2)
+    if not args.audio.exists():
+        emit({"error": f"audio file 不存在:{args.audio}"})
+        sys.exit(2)
+
+    try:
+        import numpy as np
+        from resemblyzer import VoiceEncoder, preprocess_wav
+    except ImportError as e:
+        emit({"error": f"missing dep: {e}. 跑 DepsTab → 「聲紋辨識 runtime」"})
+        sys.exit(3)
+
+    try:
+        user_emb = np.load(args.user_embedding)
+    except Exception as e:
+        emit({"error": f"讀 embedding 失敗:{e}"})
+        sys.exit(4)
+
+    try:
+        # preprocess_wav 接 wav file path 或 numpy array;會自動 resample 到 16kHz mono +
+        # VAD trim silence(對短錄音很有幫助)
+        wav = preprocess_wav(args.audio)
+        encoder = VoiceEncoder(verbose=False)
+        incoming_emb = encoder.embed_utterance(wav)
+    except Exception as e:
+        emit({"error": f"embedding 失敗:{e}"})
+        sys.exit(5)
+
+    # resemblyzer embeddings 已 L2-normalized,dot product = cosine similarity
+    score = float(np.dot(user_emb, incoming_emb))
+    passed = score >= args.threshold
+
+    emit({
+        "score": round(score, 4),
+        "pass": passed,
+        "threshold": args.threshold,
+    })
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tabs/ConfigTab.tsx
+++ b/src/tabs/ConfigTab.tsx
@@ -840,6 +840,140 @@ type SpeakerIdSectionProps = {
   applyPatch: (mutator: (c: AnyObj) => void) => void;
 };
 
+const ENROLL_SAMPLE_TEXT = `嗨,我是 Mori 的使用者,我在錄音註冊我的聲音,讓 Mori 認得我。
+Hey Mori,你今天好嗎?今天天氣不錯,陽光很好,我喜歡咖啡跟茶。
+我來念幾種不同語氣的句子:這是平常講話,這是問句嗎?還有強調的時候!
+最後 Hey Mori,我念完了。如果還沒到 30 秒,我就繼續隨便聊一下今天做了什麼,
+工作如何,有沒有遇到什麼好玩的事,或者就重複念剛剛那段都可以,重點是別停。`;
+const ENROLL_SECONDS = 30;
+
+/** Recording modal with pulsing red dot + countdown + progress bar.
+ *  純 JS 計時(SetInterval),不依賴後端 event。recording 實際在 Python 子進程
+ *  跑,30 秒固定,modal 跟著計時一起跑,結束關閉。 */
+function EnrollmentModal({
+  open,
+  onCancel,
+}: {
+  open: boolean;
+  onCancel?: () => void;
+}) {
+  const [elapsed, setElapsed] = useState(0);
+  useEffect(() => {
+    if (!open) {
+      setElapsed(0);
+      return;
+    }
+    const start = Date.now();
+    const t = setInterval(() => {
+      setElapsed(Math.min(ENROLL_SECONDS, (Date.now() - start) / 1000));
+    }, 100);
+    return () => clearInterval(t);
+  }, [open]);
+  if (!open) return null;
+  const pct = (elapsed / ENROLL_SECONDS) * 100;
+  const remaining = Math.max(0, ENROLL_SECONDS - elapsed);
+  return createPortal(
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.55)",
+        zIndex: 10000,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <style>{`
+        @keyframes mori-rec-pulse {
+          0%, 100% { transform: scale(1); opacity: 0.95; box-shadow: 0 0 0 0 rgba(220,60,60,0.7); }
+          50% { transform: scale(1.18); opacity: 1; box-shadow: 0 0 0 16px rgba(220,60,60,0); }
+        }
+      `}</style>
+      <div
+        style={{
+          background: "var(--mori-bg, #fff)",
+          padding: 28,
+          borderRadius: 12,
+          maxWidth: 600,
+          width: "92%",
+          boxShadow: "0 20px 60px rgba(0,0,0,0.4)",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 16 }}>
+          <div
+            style={{
+              width: 18,
+              height: 18,
+              background: "#dc3c3c",
+              borderRadius: "50%",
+              animation: "mori-rec-pulse 1.2s ease-in-out infinite",
+            }}
+          />
+          <h3 style={{ margin: 0, fontSize: 18 }}>錄音中 — 請念出下方文字</h3>
+        </div>
+
+        <div
+          style={{
+            padding: 14,
+            background: "rgba(0,0,0,0.04)",
+            borderRadius: 6,
+            fontSize: 14,
+            lineHeight: 1.85,
+            whiteSpace: "pre-wrap",
+            marginBottom: 18,
+            maxHeight: 200,
+            overflowY: "auto",
+          }}
+        >
+          {ENROLL_SAMPLE_TEXT}
+        </div>
+
+        <div style={{ marginBottom: 8, display: "flex", justifyContent: "space-between", fontSize: 13 }}>
+          <span>已錄 <strong>{elapsed.toFixed(1)}s</strong> / {ENROLL_SECONDS}s</span>
+          <span>剩餘 <strong>{remaining.toFixed(1)}s</strong></span>
+        </div>
+        <div
+          style={{
+            height: 8,
+            background: "rgba(0,0,0,0.08)",
+            borderRadius: 4,
+            overflow: "hidden",
+            marginBottom: 14,
+          }}
+        >
+          <div
+            style={{
+              width: `${pct}%`,
+              height: "100%",
+              background: "linear-gradient(90deg, #6a8c5a 0%, #8db077 100%)",
+              transition: "width 0.1s linear",
+            }}
+          />
+        </div>
+
+        <p style={{ fontSize: 12, opacity: 0.7, lineHeight: 1.6, margin: "0 0 14px 0" }}>
+          💡 念完還沒滿就<strong>繼續隨意聊</strong>(今天 / 工作 / 任何)或重複範本。
+          <strong>別停</strong>。中間靜音會被 VAD 砍掉,降低 embedding 品質。
+        </p>
+
+        {onCancel && elapsed < ENROLL_SECONDS && (
+          <div style={{ textAlign: "right" }}>
+            <button
+              className="mori-btn small ghost"
+              onClick={onCancel}
+              style={{ color: "var(--mori-danger, #c66)" }}
+            >
+              取消(放棄這次)
+            </button>
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
 function SpeakerIdSection({ cfg, applyPatch }: SpeakerIdSectionProps) {
   const [status, setStatus] = useState<SpeakerIdStatus | null>(null);
   const [enrolling, setEnrolling] = useState(false);
@@ -864,18 +998,13 @@ function SpeakerIdSection({ cfg, applyPatch }: SpeakerIdSectionProps) {
   };
 
   const onEnroll = async () => {
-    const sample = `嗨,我是 Mori 的使用者,我在錄音註冊我的聲音。
-Hey Mori,你好嗎?今天天氣不錯,我喜歡咖啡跟茶。
-我來念幾種不同語氣的句子:這是平常講話,這是問句嗎?
-還有強調的時候!Hey Mori,辨識完成。`;
     if (
       !confirm(
-        `錄音 30 秒註冊聲紋。\n\n按下確定後,請以「自然語氣」念以下內容(或自由發揮類似長度):\n\n${sample}\n\n要點:\n• 自然語速,不要朗讀腔\n• 中間不要長停頓\n• 跟實際叫 Mori 時同麥克風距離\n• 多種語氣(平淡 / 問句 / 強調)`
+        `準備錄音 30 秒註冊聲紋。\n\n按下確定後會跳出讀稿視窗,跟著念就好。\n\n要點:\n• 自然語速,不要朗讀腔\n• 念完還沒 30 秒 → 繼續隨意聊或重複範本(別停)\n• 跟實際叫 Mori 時同麥克風距離\n• 多種語氣(平淡 / 問句 / 強調)`
       )
     )
       return;
     setEnrolling(true);
-    setMsg("錄音中... 30 秒(請按上方提示連續講話)");
     try {
       await invoke("speaker_id_enroll", { seconds: 30 });
       await refresh();
@@ -899,6 +1028,8 @@ Hey Mori,你好嗎?今天天氣不錯,我喜歡咖啡跟茶。
   };
 
   return (
+    <>
+    <EnrollmentModal open={enrolling} />
     <Section
       title="聲紋辨識(只認你,Phase 3E)"
       hint="啟用後 wake event 觸發、user 講完之後,先用 resemblyzer 比對聲紋。只有 enrolled user 的聲音通過,別人 silent reject。需先在 Deps 頁裝「聲紋辨識 runtime」(~100MB)+ 點下方錄音註冊一次。預設 OFF。"
@@ -992,6 +1123,7 @@ Hey Mori,你好嗎?今天天氣不錯,我喜歡咖啡跟茶。
         </p>
       )}
     </Section>
+    </>
   );
 }
 

--- a/src/tabs/ConfigTab.tsx
+++ b/src/tabs/ConfigTab.tsx
@@ -607,7 +607,15 @@ type WakeAckStatus = {
   alternates: WakeAckAlternate[];
 };
 
-function WakeAckSection() {
+// WakeAckSection 需要 cfg + applyPatch 才能讓「啟用」toggle 走 form 的 dirty
+// tracking(不然 toggle 不會 enable 儲存按鈕)。其他檔案操作(set_active /
+// upload / delete)仍走 IPC,因為它們牽涉檔案系統。
+type WakeAckSectionProps = {
+  cfg: AnyObj;
+  applyPatch: (mutator: (c: AnyObj) => void) => void;
+};
+
+function WakeAckSection({ cfg, applyPatch }: WakeAckSectionProps) {
   // i18n keys 之後補,目前 hardcode 中文(跟其他 hardcode 的 hint 一樣)
   const [status, setStatus] = useState<WakeAckStatus | null>(null);
   const [busy, setBusy] = useState(false);
@@ -668,16 +676,13 @@ function WakeAckSection() {
     }
   };
 
-  const onToggleEnabled = async (enabled: boolean) => {
-    setBusy(true);
-    try {
-      await invoke("wake_ack_set_enabled", { enabled });
-      await refresh();
-    } catch (e) {
-      flashMsg(`儲存失敗:${String(e)}`);
-    } finally {
-      setBusy(false);
-    }
+  // 「啟用」改走 applyPatch — 跟其他 form 欄位一致,動到會 enable 儲存按鈕。
+  // (不再 call wake_ack_set_enabled IPC,Save 統一寫 config.json)
+  const onToggleEnabled = (enabled: boolean) => {
+    applyPatch((c) => {
+      const lm = ensureSubObj(c, "listening_mode");
+      lm.wake_ack_enabled = enabled;
+    });
   };
 
   const onUpload = async (file: File) => {
@@ -713,11 +718,10 @@ function WakeAckSection() {
       title="Wake-ack 應答音"
       hint="Listening mode 下,Hey Mori 被偵測到後播這個音檔(讓你知道可以開始說話)。先放完再開麥克風,避免被 mic 收回去污染 STT。"
     >
-      <FormRow label="啟用" hint="關掉就完全靜音(只看 floating Mori 動畫提示)">
+      <FormRow label="啟用" hint="關掉就完全靜音(只看 floating Mori 動畫提示)。改動後按上方「儲存」才寫入 config.json。">
         <input
           type="checkbox"
-          checked={status.enabled}
-          disabled={busy}
+          checked={Boolean((cfg.listening_mode?.wake_ack_enabled) ?? true)}
           onChange={(e) => onToggleEnabled(e.target.checked)}
         />
       </FormRow>
@@ -814,6 +818,138 @@ function WakeAckSection() {
           {msg && <span style={{ fontSize: 12, opacity: 0.8 }}>{msg}</span>}
         </div>
       </FormRow>
+    </Section>
+  );
+}
+
+// ── Phase 3E:聲紋辨識(Speaker verification)──────────────────────────
+//
+// 啟用後 wake event 觸發 + STT 前先過 voice embedding 比對,別人聲音 silent
+// reject。需先「錄音註冊我的聲音」(~30s) + DepsTab 裝 resemblyzer。
+
+type SpeakerIdStatus = {
+  enrolled: boolean;
+  path: string;
+  size_bytes: number;
+  enabled: boolean;
+  threshold: number;
+};
+
+type SpeakerIdSectionProps = {
+  cfg: AnyObj;
+  applyPatch: (mutator: (c: AnyObj) => void) => void;
+};
+
+function SpeakerIdSection({ cfg, applyPatch }: SpeakerIdSectionProps) {
+  const [status, setStatus] = useState<SpeakerIdStatus | null>(null);
+  const [enrolling, setEnrolling] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const refresh = async () => {
+    try {
+      const s = await invoke<SpeakerIdStatus>("speaker_id_status");
+      setStatus(s);
+    } catch (e) {
+      console.error("speaker_id_status", e);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const flashMsg = (m: string) => {
+    setMsg(m);
+    setTimeout(() => setMsg(null), 4000);
+  };
+
+  const onEnroll = async () => {
+    if (!confirm("錄音 30 秒註冊聲紋。請在安靜環境連續講話(讀文章 / 自我介紹 / 多句不同 prosody)。按確定開始。")) return;
+    setEnrolling(true);
+    setMsg("錄音中... 30 秒(請持續講話)");
+    try {
+      await invoke("speaker_id_enroll", { seconds: 30 });
+      await refresh();
+      flashMsg("✓ 聲紋註冊完成");
+    } catch (e) {
+      flashMsg(`註冊失敗:${String(e)}`);
+    } finally {
+      setEnrolling(false);
+    }
+  };
+
+  const onClear = async () => {
+    if (!confirm("清除已註冊的聲紋?清除後 wake event 不會 gate(任何人都能叫 Mori)。")) return;
+    try {
+      await invoke("speaker_id_clear");
+      await refresh();
+      flashMsg("✓ 已清除");
+    } catch (e) {
+      flashMsg(`清除失敗:${String(e)}`);
+    }
+  };
+
+  return (
+    <Section
+      title="聲紋辨識(只認你,Phase 3E)"
+      hint="啟用後 wake event 觸發、user 講完之後,先用 resemblyzer 比對聲紋。只有 enrolled user 的聲音通過,別人 silent reject。需先在 Deps 頁裝「聲紋辨識 runtime」(~100MB)+ 點下方錄音註冊一次。預設 OFF。"
+    >
+      <FormRow label="enabled" hint="OFF → 任何人都能叫 Mori(現有行為)。ON → 只認你。沒 enrolled 就 ON 也不會 gate(避免鎖死)。每次 wake 多 ~200-500ms 延遲跑 embedding 比對。">
+        <input
+          type="checkbox"
+          checked={Boolean(cfg.speaker_id?.enabled)}
+          onChange={(e) =>
+            applyPatch((c) => {
+              const s = ensureSubObj(c, "speaker_id");
+              s.enabled = e.target.checked;
+            })
+          }
+        />
+      </FormRow>
+      <FormRow label="threshold" hint="Cosine similarity 0~1,越高越嚴(只認跟 enrollment 高度相似的聲音)。預設 0.7。同一人不同日 / 感冒 / 距離 mic 不同會掉到 0.65-0.75,設太高容易擋掉自己。設太低(<0.55)別人也通過。建議從 0.7 開始,實測微調。">
+        <input
+          type="number"
+          min={0.3}
+          max={0.99}
+          step={0.05}
+          value={Number(cfg.speaker_id?.threshold ?? 0.7)}
+          onChange={(e) =>
+            applyPatch((c) => {
+              const s = ensureSubObj(c, "speaker_id");
+              const n = Number(e.target.value);
+              s.threshold = Number.isFinite(n) ? Math.max(0.3, Math.min(0.99, n)) : 0.7;
+            })
+          }
+        />
+      </FormRow>
+      <FormRow label="" hint={status?.enrolled ? `已註冊:${status.path}(${status.size_bytes} bytes)` : "尚未註冊 — 按下方錄音 30 秒"}>
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          <button
+            className="mori-btn"
+            onClick={onEnroll}
+            disabled={enrolling}
+            title="錄 30 秒講話,抽聲紋當作識別基準"
+          >
+            {enrolling ? "錄音中..." : status?.enrolled ? "🎙 重新註冊" : "🎙 錄音註冊我的聲音"}
+          </button>
+          {status?.enrolled && (
+            <button
+              className="mori-btn small ghost"
+              onClick={onClear}
+              disabled={enrolling}
+              style={{ color: "var(--mori-danger, #c66)" }}
+            >
+              ✕ 清除
+            </button>
+          )}
+          {msg && <span style={{ fontSize: 12, opacity: 0.8 }}>{msg}</span>}
+        </div>
+      </FormRow>
+      {!status?.enrolled && cfg.speaker_id?.enabled && (
+        <p style={{ fontSize: 12, opacity: 0.7, padding: "4px 12px", color: "var(--mori-warn, #d80)" }}>
+          ⚠ enabled 但還沒 enrolled — wake event 不會 gate(任何人都能用)。先按上方錄音註冊。
+        </p>
+      )}
     </Section>
   );
 }
@@ -1356,7 +1492,10 @@ function ConfigTab({
           </Section>
 
           {/* Wake-ack 應答音(獨立 Section,Phase 3A.1.2)*/}
-          <WakeAckSection />
+          <WakeAckSection cfg={cfg} applyPatch={applyPatch} />
+
+          {/* ── Phase 3E: 聲紋辨識(Speaker verification)── */}
+          <SpeakerIdSection cfg={cfg} applyPatch={applyPatch} />
 
           {/* ── Phase 3C: Wake-event evaluator(背景噪音過濾)── */}
           <Section

--- a/src/tabs/ConfigTab.tsx
+++ b/src/tabs/ConfigTab.tsx
@@ -864,9 +864,18 @@ function SpeakerIdSection({ cfg, applyPatch }: SpeakerIdSectionProps) {
   };
 
   const onEnroll = async () => {
-    if (!confirm("錄音 30 秒註冊聲紋。請在安靜環境連續講話(讀文章 / 自我介紹 / 多句不同 prosody)。按確定開始。")) return;
+    const sample = `嗨,我是 Mori 的使用者,我在錄音註冊我的聲音。
+Hey Mori,你好嗎?今天天氣不錯,我喜歡咖啡跟茶。
+我來念幾種不同語氣的句子:這是平常講話,這是問句嗎?
+還有強調的時候!Hey Mori,辨識完成。`;
+    if (
+      !confirm(
+        `錄音 30 秒註冊聲紋。\n\n按下確定後,請以「自然語氣」念以下內容(或自由發揮類似長度):\n\n${sample}\n\n要點:\n• 自然語速,不要朗讀腔\n• 中間不要長停頓\n• 跟實際叫 Mori 時同麥克風距離\n• 多種語氣(平淡 / 問句 / 強調)`
+      )
+    )
+      return;
     setEnrolling(true);
-    setMsg("錄音中... 30 秒(請持續講話)");
+    setMsg("錄音中... 30 秒(請按上方提示連續講話)");
     try {
       await invoke("speaker_id_enroll", { seconds: 30 });
       await refresh();
@@ -922,6 +931,38 @@ function SpeakerIdSection({ cfg, applyPatch }: SpeakerIdSectionProps) {
           }
         />
       </FormRow>
+      {!status?.enrolled && (
+        <div
+          style={{
+            margin: "8px 12px",
+            padding: 10,
+            background: "var(--mori-accent-bg, rgba(120,180,140,0.08))",
+            borderLeft: "3px solid var(--mori-forest, #6a8c5a)",
+            borderRadius: 4,
+            fontSize: 12,
+            lineHeight: 1.6,
+          }}
+        >
+          <strong>📖 30 秒讀稿範本</strong>(按開始後唸這段,或自由發揮類似長度):
+          <pre
+            style={{
+              margin: "6px 0 4px 0",
+              padding: 8,
+              background: "rgba(0,0,0,0.05)",
+              borderRadius: 3,
+              whiteSpace: "pre-wrap",
+              fontFamily: "inherit",
+              fontSize: 12,
+            }}
+          >
+{`嗨,我是 Mori 的使用者,我在錄音註冊我的聲音。
+Hey Mori,你好嗎?今天天氣不錯,我喜歡咖啡跟茶。
+我來念幾種不同語氣的句子:這是平常講話,這是問句嗎?
+還有強調的時候!Hey Mori,辨識完成。`}
+          </pre>
+          <strong>準確訣竅:</strong>自然語速 / 中間別長停頓 / 跟實際叫 Mori 同麥克風距離 / 含「平淡 + 問句 + 強調」多種語氣。
+        </div>
+      )}
       <FormRow label="" hint={status?.enrolled ? `已註冊:${status.path}(${status.size_bytes} bytes)` : "尚未註冊 — 按下方錄音 30 秒"}>
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
           <button

--- a/src/tabs/ConfigTab.tsx
+++ b/src/tabs/ConfigTab.tsx
@@ -873,97 +873,91 @@ function EnrollmentModal({
   const pct = (elapsed / ENROLL_SECONDS) * 100;
   const remaining = Math.max(0, ENROLL_SECONDS - elapsed);
   return createPortal(
-    <div
-      style={{
-        position: "fixed",
-        inset: 0,
-        background: "rgba(0,0,0,0.55)",
-        zIndex: 10000,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-    >
+    <div className="mori-modal-backdrop">
       <style>{`
         @keyframes mori-rec-pulse {
           0%, 100% { transform: scale(1); opacity: 0.95; box-shadow: 0 0 0 0 rgba(220,60,60,0.7); }
           50% { transform: scale(1.18); opacity: 1; box-shadow: 0 0 0 16px rgba(220,60,60,0); }
         }
+        .mori-enroll-modal {
+          width: min(92%, 640px);
+          background: var(--c-surface-bg);
+          color: var(--c-text);
+          border: 1px solid var(--c-border-strong);
+          border-radius: 12px;
+          padding: 22px 24px;
+          box-shadow: 0 12px 40px rgba(0,0,0,0.55);
+        }
+        .mori-enroll-header {
+          display: flex; align-items: center; gap: 12px; margin-bottom: 14px;
+        }
+        .mori-enroll-rec-dot {
+          width: 16px; height: 16px; background: #dc3c3c; border-radius: 50%;
+          animation: mori-rec-pulse 1.2s ease-in-out infinite;
+        }
+        .mori-enroll-title { margin: 0; font-size: 17px; color: var(--c-text); }
+        .mori-enroll-script {
+          padding: 12px 14px;
+          background: var(--c-input-bg);
+          color: var(--c-text);
+          border: 1px solid var(--c-border);
+          border-radius: 6px;
+          font-size: 14px;
+          line-height: 1.85;
+          white-space: pre-wrap;
+          margin-bottom: 14px;
+          max-height: 220px;
+          overflow-y: auto;
+        }
+        .mori-enroll-progress-text {
+          display: flex; justify-content: space-between;
+          font-size: 13px; color: var(--c-text); margin-bottom: 6px;
+        }
+        .mori-enroll-progress-track {
+          height: 8px;
+          background: var(--c-input-bg);
+          border: 1px solid var(--c-border);
+          border-radius: 4px;
+          overflow: hidden;
+          margin-bottom: 12px;
+        }
+        .mori-enroll-progress-fill {
+          height: 100%;
+          background: linear-gradient(90deg, var(--c-forest, #6a8c5a) 0%, var(--c-forest-light, #8db077) 100%);
+          transition: width 0.1s linear;
+        }
+        .mori-enroll-hint {
+          font-size: 12px;
+          color: var(--c-text-muted);
+          line-height: 1.6;
+          margin: 0 0 12px 0;
+        }
+        .mori-enroll-footer { text-align: right; }
       `}</style>
-      <div
-        style={{
-          background: "var(--mori-bg, #fff)",
-          padding: 28,
-          borderRadius: 12,
-          maxWidth: 600,
-          width: "92%",
-          boxShadow: "0 20px 60px rgba(0,0,0,0.4)",
-        }}
-      >
-        <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 16 }}>
-          <div
-            style={{
-              width: 18,
-              height: 18,
-              background: "#dc3c3c",
-              borderRadius: "50%",
-              animation: "mori-rec-pulse 1.2s ease-in-out infinite",
-            }}
-          />
-          <h3 style={{ margin: 0, fontSize: 18 }}>錄音中 — 請念出下方文字</h3>
+      <div className="mori-enroll-modal">
+        <div className="mori-enroll-header">
+          <div className="mori-enroll-rec-dot" />
+          <h3 className="mori-enroll-title">錄音中 — 請念出下方文字</h3>
         </div>
 
-        <div
-          style={{
-            padding: 14,
-            background: "rgba(0,0,0,0.04)",
-            borderRadius: 6,
-            fontSize: 14,
-            lineHeight: 1.85,
-            whiteSpace: "pre-wrap",
-            marginBottom: 18,
-            maxHeight: 200,
-            overflowY: "auto",
-          }}
-        >
-          {ENROLL_SAMPLE_TEXT}
-        </div>
+        <div className="mori-enroll-script">{ENROLL_SAMPLE_TEXT}</div>
 
-        <div style={{ marginBottom: 8, display: "flex", justifyContent: "space-between", fontSize: 13 }}>
+        <div className="mori-enroll-progress-text">
           <span>已錄 <strong>{elapsed.toFixed(1)}s</strong> / {ENROLL_SECONDS}s</span>
           <span>剩餘 <strong>{remaining.toFixed(1)}s</strong></span>
         </div>
-        <div
-          style={{
-            height: 8,
-            background: "rgba(0,0,0,0.08)",
-            borderRadius: 4,
-            overflow: "hidden",
-            marginBottom: 14,
-          }}
-        >
-          <div
-            style={{
-              width: `${pct}%`,
-              height: "100%",
-              background: "linear-gradient(90deg, #6a8c5a 0%, #8db077 100%)",
-              transition: "width 0.1s linear",
-            }}
-          />
+        <div className="mori-enroll-progress-track">
+          <div className="mori-enroll-progress-fill" style={{ width: `${pct}%` }} />
         </div>
 
-        <p style={{ fontSize: 12, opacity: 0.7, lineHeight: 1.6, margin: "0 0 14px 0" }}>
+        <p className="mori-enroll-hint">
           💡 念完還沒滿就<strong>繼續隨意聊</strong>(今天 / 工作 / 任何)或重複範本。
           <strong>別停</strong>。中間靜音會被 VAD 砍掉,降低 embedding 品質。
         </p>
 
         {onCancel && elapsed < ENROLL_SECONDS && (
-          <div style={{ textAlign: "right" }}>
-            <button
-              className="mori-btn small ghost"
-              onClick={onCancel}
-              style={{ color: "var(--mori-danger, #c66)" }}
-            >
+          <div className="mori-enroll-footer">
+            <button className="mori-btn small ghost" onClick={onCancel}>
               取消(放棄這次)
             </button>
           </div>

--- a/src/tabs/ConfigTab.tsx
+++ b/src/tabs/ConfigTab.tsx
@@ -1582,19 +1582,19 @@ function ConfigTab({
           >
             <FormRow
               label="threshold"
-              hint="偵測門檻(0.05~0.95)。越高越嚴格(必須完整「Hey Mori」才觸發),越低越敏感(誤觸多)。預設 0.5。建議從 0.65 試起。"
+              hint="偵測門檻(0.05~0.95)。越高越嚴格,越低越敏感(誤觸多)。預設 0.7。下游有 speaker_id + evaluator 兩層 filter 擋誤觸,wake 不必設太嚴(0.9+ 會漏掉輕聲 / 不清楚的「Hey Mori」)。"
             >
               <input
                 type="number"
                 min={0.05}
                 max={0.95}
                 step={0.05}
-                value={Number(cfg.listening_mode?.threshold ?? 0.5)}
+                value={Number(cfg.listening_mode?.threshold ?? 0.7)}
                 onChange={(e) =>
                   applyPatch((c) => {
                     const lm = ensureSubObj(c, "listening_mode");
                     const n = Number(e.target.value);
-                    lm.threshold = Number.isFinite(n) ? Math.max(0.05, Math.min(0.95, n)) : 0.5;
+                    lm.threshold = Number.isFinite(n) ? Math.max(0.05, Math.min(0.95, n)) : 0.7;
                   })
                 }
               />


### PR DESCRIPTION
## Summary

User 反映「不同人都能叫 Mori」— 因為 wake-word / verifier / evaluator 都不是聲紋識別:
- Wake-word ONNX 只認 phoneme 像不像「Hey Mori」
- Verifier 訓 negative 是 user 自己的話,不是別人的「Hey Mori」
- Evaluator 只看 transcript 文字,聾的

這版加 **第 4 層 — 語音生物識別**:resemblyzer(VoxCeleb pretrained VoiceEncoder)抽 256-dim 聲紋向量,wake event 後比對 cosine similarity。**只有 enrolled user 的聲音能通過**。

預設 **OFF**,user 主動 enable + 錄音註冊一次才生效。沒 enroll 即使 enable 也不 gate(避免鎖死)。

## 工作流

```
Wake event → wake-ack 播 → VAD 錄音 → WAV 寫完
                                    ↓
                              speaker_id verify (~200-500ms)
                                    ↓
                       ┌────pass────┴────reject────┐
                       ↓                            ↓
                  Whisper STT                 silent skip
                       ↓                       Phase::Done
                  evaluator gate           emit "speaker-id-rejected"
                       ↓
                   agent loop
                       ↓
                  TTS speak-back
```

## 變更

- **`mori-voice-enroll.py`** — 錄 30s → resemblyzer encode → `.npy` 存檔
- **`mori-voice-verify.py`** — 讀 user `.npy` + incoming `.wav` → cosine → JSON 出 score/pass
- **`speaker_id.rs`(new)** — `verify_audio_file()` + 3 個 Tauri commands(status / enroll / clear)
- **`main.rs::stop_and_transcribe`** — WAV 寫完後 spawn_blocking 跑 verify,fail → return early skip STT
- **DepsTab `speaker-id-runtime`** — `pip install resemblyzer`(共用 wake-venv,~100MB 含 80MB pretrained model)
- **ConfigTab UI** — Voice subtab 新「聲紋辨識(只認你,Phase 3E)」section:enabled toggle + threshold number + 錄音註冊 button + 清除 button
- **Bonus fix**:WakeAckSection enabled toggle 改走 applyPatch(之前繞過 form dirty tracking 害儲存按鈕灰色)

## Config schema

```json
{
  "speaker_id": {
    "enabled": true,
    "threshold": 0.7
  }
}
```

User embedding 存 `~/.mori/voiceid/user_embedding.npy`(~1KB float32)。

## 試用流程

1. DepsTab → 「聲紋辨識 runtime」一鍵裝(~100MB)
2. Config tab → Voice subtab → 滑到底「聲紋辨識(只認你)」
3. 點「🎙 錄音註冊我的聲音」→ 30 秒持續講話(讀文章 / 多種句型 prosody)
4. 勾 enabled + 儲存
5. Tray「Hey Mori 待命」
6. 自己喊「Hey Mori 開瀏覽器」→ 通過,Mori 走 agent
7. 找別人喊一樣的話 → silent reject,沒任何反應(看 logs.tab 有 `speaker_id_rejected` 條目)
8. 調 threshold — 太嚴會擋掉自己感冒 / 距離 mic 不同的聲音,從 0.7 開始實測

## Test plan

- [x] `cargo check --workspace --all-targets` ✅
- [x] `bash scripts/verify.sh` 全綠
- [ ] CI ubuntu + windows
- [ ] 實機 Linux:enrollment 30s 跑完 + `.npy` 寫成
- [ ] 自己叫 Mori → score > 0.7 → pass
- [ ] 別人(或變聲)叫 → score < 0.7 → reject
- [ ] threshold 拉到 0.85 → 確認自己仍能通過(若不行 → enrollment 範本太窄)
- [ ] WakeAck enabled toggle 改完儲存按鈕變亮(bug fix 驗證)

## 限制 / 留 v0.6.x+

- Enrollment 沒 real-time progress bar(只有 "錄音中..." 字)。Python 已有 JSON event,Tauri forward 可後加
- 沒 anti-spoofing(錄音播放可繞)— 語音識別不該當 high-stakes auth
- 沒 multi-user(enroll 多個聲紋)
- 沒 threshold 自動校準

🤖 Generated with [Claude Code](https://claude.com/claude-code)