### PR TITLE
feat(phase3-polish): A1 evaluator confidence gate + A2 enrollment real-time progress

### DIFF
--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -2531,6 +2531,15 @@ async fn evaluator_gate(transcript: &str) -> Option<EvaluatorOutcome> {
         .and_then(|v| v.as_str())
         .unwrap_or("groq")
         .to_string();
+    // Phase 3C polish:confidence threshold gate。LLM intent 判 BackgroundNoise
+    // 但 confidence < threshold(預設 0.85)→ 不夠確定,不 skip user 可能真
+    // 講的指令,fallthrough 給 agent。反之 AddressMori 但 confidence 太低也
+    // 不確定 — 但這 case 已經 fallthrough,所以只 gate reject path。
+    let confidence_threshold = json
+        .pointer("/evaluator/confidence_threshold")
+        .and_then(|v| v.as_f64())
+        .map(|v| v.clamp(0.0, 1.0) as f32)
+        .unwrap_or(0.85);
 
     // Build provider
     let provider = match mori_core::llm::build_named_provider(&provider_name, None) {
@@ -2548,16 +2557,38 @@ async fn evaluator_gate(transcript: &str) -> Option<EvaluatorOutcome> {
     // Run evaluator
     match evaluate(transcript, provider).await {
         Ok(result) => {
+            // Confidence gate:reject 路徑(BackgroundNoise)在 confidence
+            // < threshold 時不 skip(LLM 不夠確定就不應該擋掉 user 真指令)。
+            let skip = if matches!(result.intent, Intent::BackgroundNoise) {
+                if result.confidence < confidence_threshold {
+                    tracing::info!(
+                        intent = ?result.intent,
+                        reason = %result.reason,
+                        confidence = result.confidence,
+                        threshold = confidence_threshold,
+                        "evaluator: confidence too low to skip — fallthrough to agent",
+                    );
+                    false
+                } else {
+                    true
+                }
+            } else {
+                false
+            };
             tracing::info!(
                 intent = ?result.intent,
                 reason = %result.reason,
                 confidence = result.confidence,
+                skip,
                 "evaluator: result",
             );
-            let skip = matches!(result.intent, Intent::BackgroundNoise);
             Some(EvaluatorOutcome {
                 skip,
-                reason: result.reason,
+                reason: if skip {
+                    format!("{}(confidence {:.2})", result.reason, result.confidence)
+                } else {
+                    result.reason
+                },
             })
         }
         Err(e) => {

--- a/crates/mori-tauri/src/speaker_id.rs
+++ b/crates/mori-tauri/src/speaker_id.rs
@@ -244,9 +244,18 @@ pub fn speaker_id_status() -> EnrollmentStatus {
 /// IPC command — UI 點「錄音註冊我的聲音」觸發。Blocking ~30s。
 ///
 /// 跑 Python enrollment script,output 寫到 `~/.mori/voiceid/user_embedding.npy`。
-/// 失敗回 Err,UI 顯示錯誤訊息。
+///
+/// **Phase 3 polish A2**:讀 Python stdout line-by-line,JSON event 用
+/// Tauri `app.emit("speaker-id-enroll-progress", json)` forward 到前端,
+/// modal 用真實進度(non setInterval 估算)。
 #[tauri::command]
-pub async fn speaker_id_enroll(seconds: Option<f32>) -> Result<EnrollmentStatus, String> {
+pub async fn speaker_id_enroll(
+    app: tauri::AppHandle,
+    seconds: Option<f32>,
+) -> Result<EnrollmentStatus, String> {
+    use std::io::{BufRead, BufReader};
+    use tauri::Emitter;
+
     let cfg = read_config();
     let script = enroll_script_path();
     if !script.exists() {
@@ -268,8 +277,9 @@ pub async fn speaker_id_enroll(seconds: Option<f32>) -> Result<EnrollmentStatus,
     }
 
     let python = cfg.python.clone();
-    let result = tokio::task::spawn_blocking(move || {
-        Command::new(&python)
+    let app_for_thread = app.clone();
+    let exit_status = tokio::task::spawn_blocking(move || -> Result<std::process::ExitStatus, String> {
+        let mut child = Command::new(&python)
             .arg(&script)
             .arg(&out_path)
             .arg("--seconds")
@@ -277,21 +287,40 @@ pub async fn speaker_id_enroll(seconds: Option<f32>) -> Result<EnrollmentStatus,
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .output()
+            .spawn()
+            .map_err(|e| format!("spawn python: {e}"))?;
+
+        // Stream stdout — 每行解析 JSON,有 event 欄位就 emit 給前端
+        if let Some(stdout) = child.stdout.take() {
+            let reader = BufReader::new(stdout);
+            for line in reader.lines() {
+                let Ok(line) = line else { continue };
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                if let Ok(value) = serde_json::from_str::<serde_json::Value>(line) {
+                    if value.get("event").is_some() {
+                        let _ = app_for_thread.emit("speaker-id-enroll-progress", &value);
+                    }
+                } else {
+                    tracing::debug!(line, "enroll: non-JSON stdout line");
+                }
+            }
+        }
+
+        // Stream done — wait for exit
+        let status = child
+            .wait()
+            .map_err(|e| format!("wait python: {e}"))?;
+        Ok(status)
     })
     .await
     .map_err(|e| format!("join: {e}"))?
-    .map_err(|e| format!("spawn python: {e}"))?;
+    .map_err(|e| e)?;
 
-    if !result.status.success() {
-        let stderr = String::from_utf8_lossy(&result.stderr).into_owned();
-        let stdout = String::from_utf8_lossy(&result.stdout).into_owned();
-        return Err(format!(
-            "enrollment exit {}: stderr={} stdout-tail={}",
-            result.status,
-            stderr.trim(),
-            stdout.lines().last().unwrap_or("").trim()
-        ));
+    if !exit_status.success() {
+        return Err(format!("enrollment exited with {exit_status}"));
     }
 
     Ok(speaker_id_status())

--- a/src/tabs/ConfigTab.tsx
+++ b/src/tabs/ConfigTab.tsx
@@ -11,7 +11,7 @@
 import React, { useEffect, useMemo, useState, type SVGProps } from "react";
 import { createPortal } from "react-dom";
 import { invoke } from "@tauri-apps/api/core";
-import { emit } from "@tauri-apps/api/event";
+import { emit, listen } from "@tauri-apps/api/event";
 import { useTranslation } from "react-i18next";
 import { listThemes, setActiveTheme, themesDir, loadActiveTheme, type ThemeEntry } from "../theme";
 import { Select } from "../Select";
@@ -858,19 +858,47 @@ function EnrollmentModal({
   onCancel?: () => void;
 }) {
   const [elapsed, setElapsed] = useState(0);
+  // Phase 3 polish A2:接 Python script 真實 JSON event 給 modal 走精確進度,
+  // setInterval 只當 fallback(Python 還沒開錄就先有畫面)。
+  const [phase, setPhase] = useState<"recording" | "embedding" | "done">("recording");
+
   useEffect(() => {
     if (!open) {
       setElapsed(0);
+      setPhase("recording");
       return;
     }
     const start = Date.now();
+    // Fallback 計時器:Python event 還沒來時,先用秒數估
     const t = setInterval(() => {
-      setElapsed(Math.min(ENROLL_SECONDS, (Date.now() - start) / 1000));
-    }, 100);
-    return () => clearInterval(t);
+      setElapsed((prev) => {
+        const tick = (Date.now() - start) / 1000;
+        // 若 event 已經給了較高 elapsed,don't regress
+        return Math.max(prev, Math.min(ENROLL_SECONDS, tick));
+      });
+    }, 200);
+    // 接 Tauri event:Python script 真實 progress
+    const unlistenPromise = listen<{ event?: string; elapsed?: number }>(
+      "speaker-id-enroll-progress",
+      (e) => {
+        const ev = e.payload.event;
+        if (ev === "recording_progress" && typeof e.payload.elapsed === "number") {
+          setElapsed(Math.min(ENROLL_SECONDS, e.payload.elapsed));
+        } else if (ev === "recording_done") {
+          setElapsed(ENROLL_SECONDS);
+          setPhase("embedding");
+        } else if (ev === "embedding_done") {
+          setPhase("done");
+        }
+      },
+    );
+    return () => {
+      clearInterval(t);
+      unlistenPromise.then((fn) => fn()).catch(() => {});
+    };
   }, [open]);
   if (!open) return null;
-  const pct = (elapsed / ENROLL_SECONDS) * 100;
+  const pct = phase === "embedding" ? 100 : (elapsed / ENROLL_SECONDS) * 100;
   const remaining = Math.max(0, ENROLL_SECONDS - elapsed);
   return createPortal(
     <div className="mori-modal-backdrop">
@@ -937,7 +965,11 @@ function EnrollmentModal({
       <div className="mori-enroll-modal">
         <div className="mori-enroll-header">
           <div className="mori-enroll-rec-dot" />
-          <h3 className="mori-enroll-title">錄音中 — 請念出下方文字</h3>
+          <h3 className="mori-enroll-title">
+            {phase === "recording" && "錄音中 — 請念出下方文字"}
+            {phase === "embedding" && "錄音完成 — 計算聲紋中..."}
+            {phase === "done" && "✓ 聲紋註冊完成"}
+          </h3>
         </div>
 
         <div className="mori-enroll-script">{ENROLL_SAMPLE_TEXT}</div>
@@ -1695,6 +1727,22 @@ function ConfigTab({
                   { value: "gemini", label: "gemini API(會吃 Gemini quota)" },
                   { value: "ollama", label: "ollama(本地,需自架)" },
                 ]}
+              />
+            </FormRow>
+            <FormRow label="confidence_threshold" hint="LLM 判 background_noise 但 confidence 低於這值 → 不擋(避免 LLM 不確定時誤殺 user 真指令)。預設 0.85。設高 → 寬鬆,只擋 LLM 很確定的雜訊;設低 → 嚴格,LLM 略有懷疑就擋。0.5-0.95 都合理。">
+              <input
+                type="number"
+                min={0.0}
+                max={1.0}
+                step={0.05}
+                value={Number(cfg.evaluator?.confidence_threshold ?? 0.85)}
+                onChange={(e) =>
+                  applyPatch((c) => {
+                    const ev = ensureSubObj(c, "evaluator");
+                    const n = Number(e.target.value);
+                    ev.confidence_threshold = Number.isFinite(n) ? Math.max(0, Math.min(1, n)) : 0.85;
+                  })
+                }
               />
             </FormRow>
           </Section>


### PR DESCRIPTION
## Summary

Phase 3 收尾 polish:evaluator 更穩定的判斷 + speaker enrollment 用真實進度而非估算。

### A1 — Evaluator confidence threshold gate

User 反映:evaluator 偶爾 confidence 偏低(0.7)還是判 BackgroundNoise 擋掉 user 真指令。加 confidence gate:LLM 判 reject 但 confidence < threshold(預設 **0.85**)→ **不擋,fallthrough 給 agent**。

寧可 false positive 浪費一輪 LLM(免費)也不要 silent drop user 真指令。

- Config:`evaluator.confidence_threshold`(clamp 0..1,預設 0.85)
- UI:ConfigTab Voice subtab → 「Wake-event 過濾」section 新 number input

### A2 — Speaker enrollment real-time progress

之前 modal 用純 JS setInterval 估算進度(`Date.now() - start / 30000 * 100`),Python script 其實已 emit line-delimited JSON event 但 Rust 沒 forward。

Changes:
- `speaker_id::speaker_id_enroll`:`.output()` → `spawn` + `BufReader::lines` 即時讀 stdout
- 每行 parse JSON → `app.emit("speaker-id-enroll-progress", value)`
- 前端 `EnrollmentModal` `listen("speaker-id-enroll-progress")` 接 3 個 event:
  - `recording_progress { elapsed }` → 校正進度條
  - `recording_done` → 切 phase "embedding"(顯示「計算聲紋中...」)
  - `embedding_done` → 切 phase "done"
- setInterval fallback 保留(Python 還沒 emit 前 0.5s 有畫面)
- Modal title 動態:「錄音中」/「錄音完成 — 計算聲紋中...」/「✓ 完成」

### Skipped: A3 i18n keys(留 follow-up PR)

WakeAckSection / SpeakerIdSection / TTS Section / Evaluator Section 內中文 hint 全部硬寫。i18n 要把 ~120 strings 抽進 zh.json + en.json,純 busy work不影響功能。留下一條獨立 PR 做。

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `npm run build`
- [ ] CI ubuntu + windows
- [ ] 實機 Linux:
  - [ ] Config tab → evaluator.confidence_threshold 拉到 0.95 → 講含糊的話應該 fallthrough 給 agent(LLM 不確定就放行)
  - [ ] 重 enroll → modal 進度條跟 Python 真實秒數一致(不是預估)
  - [ ] 錄完後 modal 短暫顯示「計算聲紋中...」(embedding ~1-2s)
  - [ ] 完成顯示 ✓ 後自動關
- [ ] 拉到 0.0 → reject 永遠不擋(等於 evaluator 完全 disabled 在 reject path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)