### PR TITLE
feat(cli-detect): DepsTab 偵測 claude / gemini / codex CLI + default profile 不寫死 claude-bash

### DIFF
--- a/crates/mori-core/src/agent_profile.rs
+++ b/crates/mori-core/src/agent_profile.rs
@@ -612,9 +612,19 @@ fn read_inline(
 
 pub const DEFAULT_AGENT_MD: &str = r#"---
 # 預設 Mori — Ctrl+Alt+0 啟動
-# 5I 起 claude-bash / gemini-bash / codex-bash 也都看得到 action_skill 和
-# shell_skill（skill_server 已動態化）。可改成任何支援工具呼叫的 provider。
-provider: claude-bash
+#
+# provider 留空 → 跟 config.json 的 `provider` 走(Quickstart 時 user 設的)。
+# 純 API(gemini / groq / ollama)即可,fresh install 只要設一個 API key 就能跑,
+# 不需要先裝 CLI。
+#
+# 進階 user 想用「外部 AI CLI 當 agent loop」(更強的 tool use):
+#   - 裝 Claude Code:`npm i -g @anthropic-ai/claude-code` → provider: claude-bash
+#   - 裝 Gemini CLI:`npm i -g @google/generative-ai-cli` → provider: gemini-bash
+#   - 裝 Codex CLI:`npm i -g @openai/codex` → provider: codex-bash
+# Phase 3I 起 claude-bash / gemini-bash / codex-bash 都看得到 action_skill 跟
+# shell_skill(skill_server 已動態化)。
+
+# provider: claude-bash    # 進階:有裝 Claude Code 才打開
 enable_read: true   # 啟用 #file: 預處理（讓 body 能引用 ~/.mori/corrections.md）
 
 # enabled_skills 留空 = 全 built-in skill 都可用（包含 open_url / open_app

--- a/crates/mori-tauri/src/deps.rs
+++ b/crates/mori-tauri/src/deps.rs
@@ -292,6 +292,81 @@ pub fn registry() -> Vec<DepSpec> {
                 }),
             ],
         },
+        // Phase 3 polish B:三個 AI CLI 偵測 — claude-bash / gemini-bash / codex-bash
+        // 這幾個 provider 需要對應 binary 在 PATH 才能跑。fresh install 沒裝
+        // 時 agent profile 用了會炸 spawn,DepsTab 顯示 ✗ 提示去裝。
+        //
+        // 全部用 Manual install — 各家 CLI 官方安裝都很多步(npm / brew / installer),
+        // 我們不冒險跑自動腳本。
+        DepSpec {
+            id: "claude-code-cli",
+            name: "Claude Code CLI",
+            description: "Anthropic 官方 AI coding CLI。Mori provider `claude-bash` / \
+                          `claude-cli` 需要這個 binary。",
+            unlocks: "provider=claude-bash / claude-cli 啟動 Claude Code 當 agent loop",
+            size_hint: Some("~100MB(Node.js based)"),
+            needs_sudo: false,
+            platforms: &["linux", "macos", "windows"],
+            install_caveat: None,
+            check: CheckSpec::Which { bin: "claude" },
+            install: InstallSpec::Manual {
+                commands: &[
+                    "# 官方安裝(需先有 Node.js 18+):",
+                    "npm install -g @anthropic-ai/claude-code",
+                    "# 安裝完跑 `claude login` 完成 OAuth 認證(用 Anthropic 帳號)",
+                    "# 詳見 https://docs.anthropic.com/claude/docs/claude-code",
+                ],
+            },
+            install_overrides: &[],
+        },
+        DepSpec {
+            id: "gemini-cli",
+            name: "Gemini CLI",
+            description: "Google 官方 Gemini CLI。Mori provider `gemini-bash` / \
+                          `gemini-cli` 需要這個 binary。\
+                          \n\n注意:**只用 Gemini API**(`provider: gemini`)的話 \
+                          **不需要**這個 CLI,直接設 API key 就能跑。",
+            unlocks: "provider=gemini-bash / gemini-cli 啟動 Gemini CLI 當 agent loop",
+            size_hint: Some("~50MB(Node.js based)"),
+            needs_sudo: false,
+            platforms: &["linux", "macos", "windows"],
+            install_caveat: None,
+            check: CheckSpec::Which { bin: "gemini" },
+            install: InstallSpec::Manual {
+                commands: &[
+                    "# 官方安裝(需先有 Node.js 18+):",
+                    "npm install -g @google/gemini-cli",
+                    "# 安裝完跑 `gemini config set api_key <your-key>` 或 GEMINI_API_KEY env",
+                    "# 詳見 https://github.com/google-gemini/gemini-cli",
+                ],
+            },
+            install_overrides: &[],
+        },
+        DepSpec {
+            id: "codex-cli",
+            name: "OpenAI Codex CLI",
+            description: "OpenAI 官方 Codex CLI(AI coding helper)。Mori provider \
+                          `codex-bash` / `codex-cli` 需要這個 binary。\
+                          \n\nWindows 注意:v0.130 起才有純 JS 版,native variant 不支援 Win。",
+            unlocks: "provider=codex-bash / codex-cli 啟動 Codex 當 agent loop",
+            size_hint: Some("~30MB(Node.js based)"),
+            needs_sudo: false,
+            platforms: &["linux", "macos", "windows"],
+            install_caveat: Some(
+                "Windows 需要 v0.130+(JS 版),舊 native variant 不支援。",
+            ),
+            check: CheckSpec::Which { bin: "codex" },
+            install: InstallSpec::Manual {
+                commands: &[
+                    "# 官方安裝(需先有 Node.js 18+):",
+                    "npm install -g @openai/codex",
+                    "# 安裝完跑 `codex login` 完成 OAuth 認證(用 ChatGPT 帳號)",
+                    "# 或 `OPENAI_API_KEY` env",
+                    "# 詳見 https://github.com/openai/codex",
+                ],
+            },
+            install_overrides: &[],
+        },
         DepSpec {
             id: "ollama",
             name: "ollama",

--- a/examples/agent/AGENT-05.聽我指令.md
+++ b/examples/agent/AGENT-05.聽我指令.md
@@ -16,9 +16,14 @@
 # - 鍵盤動作 → send_keys
 # - 把東西貼到當前游標 → paste_selection_back
 #
-# 用 claude-bash 因為 multi-step 推理(該開哪個 + 怎麼包 args)穩定;
-# 想省 quota 改 `provider: groq`,但 tool calling 在簡單意圖 OK,複雜的失敗率較高。
-provider: claude-bash
+# Provider 留空 → 跟 config.json 預設 `provider` 走(純 API 即可,不需 CLI)。
+# 進階要更穩定的 multi-step 工具呼叫,有裝對應 CLI 才開:
+#   - provider: claude-bash   # Claude Code(`npm i -g @anthropic-ai/claude-code`)
+#   - provider: gemini-bash   # Gemini CLI(`npm i -g @google/gemini-cli`)
+#   - provider: codex-bash    # Codex CLI(`npm i -g @openai/codex`)
+# 純 API(`gemini` / `groq` / `ollama`)tool calling 在簡單意圖 OK,複雜的失敗率較高。
+
+# provider: claude-bash    # 進階:有裝 Claude Code 才打開
 enable_read: true
 enabled_skills:
   - ask_gemini

--- a/examples/agent/AGENT.md
+++ b/examples/agent/AGENT.md
@@ -1,9 +1,13 @@
 ---
 # 預設 Mori — Ctrl+Alt+0 啟動
 # 跟 crates/mori-core/src/agent_profile.rs::DEFAULT_AGENT_MD 對齊。
-# 5I 起 claude-bash / gemini-bash / codex-bash 也都看得到 action_skill 和
-# shell_skill(skill_server 已動態化)。可改成任何支援工具呼叫的 provider。
-provider: claude-bash
+#
+# provider 留空 → 跟 config.json 的 `provider` 走(Quickstart 設的)。純 API
+# (gemini / groq / ollama)即可,不需先裝 CLI。進階要用外部 AI CLI 當 agent
+# loop 才打開 `provider: claude-bash` / `gemini-bash` / `codex-bash`(需各自裝
+# Claude Code / Gemini CLI / Codex CLI)。
+
+# provider: claude-bash   # 進階:有裝 Claude Code 才打開
 enable_read: true   # 啟用 #file: 預處理(讓 body 能引用 ~/.mori/corrections.md)
 
 # enabled_skills 留空 = 全 built-in skill 都可用(包含 open_url / open_app


### PR DESCRIPTION
## Summary

修 fresh install 「設 Gemini API key 但預設 profile 寫死 `provider: claude-bash` → 沒裝 claude CLI 直接炸」的 onboarding bug,順手把 3 個 AI CLI 加進 DepsTab 偵測。

## 變更

### 1. DepsTab 新 3 個 CLI 偵測條目

| ID | binary | install 方式 |
|---|---|---|
| `claude-code-cli` | `claude` | Manual:`npm i -g @anthropic-ai/claude-code` + `claude login` |
| `gemini-cli` | `gemini` | Manual:`npm i -g @google/gemini-cli` |
| `codex-cli` | `codex` | Manual:`npm i -g @openai/codex` + `codex login`(Win v0.130+) |

全 Manual install(各家認證流程不同,自動跑風險高)。Description 內明確標「**只用 API**(`provider=gemini`)**不需要**這個 CLI」,避免 user 誤裝。

### 2. Default profile 不寫死 `provider: claude-bash`

Fresh install user:
1. 跑 Quickstart 設 Gemini API key
2. 開 ChatPanel 試講話
3. → Agent profile(AGENT.md)寫死 `provider: claude-bash` → 沒裝 claude CLI → 立刻炸

Fix:`provider:` line **註解掉**,留 comment 教學。Profile 沒指定 → fallthrough config.json 的全域 `provider`(Quickstart 設的)。純 API(`gemini` / `groq` / `ollama`)即可。

三個 template 都改:
- `crates/mori-core/src/agent_profile.rs::DEFAULT_AGENT_MD`(內嵌)
- `examples/agent/AGENT.md`(Profiles tab「加入範本」用)
- `examples/agent/AGENT-05.聽我指令.md`(常用語音助理 starter)

### 3. Codex 整合驗證

`codex-bash` / `codex-cli` provider 在 `llm/mod.rs` 已存在(line 106 / 139),這版只是把 codex CLI 加進 DepsTab + comment 提到當選項。

實機 user 機器:`which codex` → `/home/ct/.nvm/versions/node/v22.17.1/bin/codex`(已裝)。

## Test plan

- [x] `bash scripts/verify.sh` 全綠
- [ ] CI ubuntu + windows
- [ ] 實機 Linux:DepsTab 看到 3 條新 CLI 條目,本機已裝 ✓
- [ ] (fresh install simulate)刪掉 ~/.mori/agent/ → 重啟 mori-tauri → 看新 AGENT.md 沒寫死 claude-bash → 開 ChatPanel → 用純 Gemini API 講話可以 work
- [ ] 改成 `provider: codex-bash` → 試講話 → 看 codex CLI 跑起來

## 留 v0.6.x+

- Profile preflight UI(profile provider 沒裝對應 binary 時 UI 紅字)
- CLI install 自動化(npm install)— 目前 Manual 保守

🤖 Generated with [Claude Code](https://claude.com/claude-code)