### PR TITLE
feat(preflight): profile provider binary 預檢 + ChatPanel topbar 紅 chip 警告

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -254,7 +254,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -280,7 +280,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -1607,7 +1607,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-link 0.2.1",
 ]
 
@@ -1872,6 +1872,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "hound"
@@ -2430,6 +2439,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -2620,6 +2635,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "which",
  "windows 0.58.0",
  "x11rb",
  "zip",
@@ -3245,7 +3261,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3724,6 +3740,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3731,7 +3760,7 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4729,7 +4758,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5519,7 +5548,7 @@ checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "rustix 1.1.4",
  "smallvec",
  "wayland-sys",
 ]
@@ -5531,7 +5560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags 2.11.1",
- "rustix",
+ "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -5707,6 +5736,18 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
+]
 
 [[package]]
 name = "winapi"
@@ -6270,6 +6311,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6372,7 +6419,7 @@ dependencies = [
  "libc",
  "log",
  "os_pipe",
- "rustix",
+ "rustix 1.1.4",
  "thiserror 2.0.18",
  "tree_magic_mini",
  "wayland-backend",
@@ -6459,7 +6506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 
@@ -6520,7 +6567,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tokio",

--- a/crates/mori-tauri/Cargo.toml
+++ b/crates/mori-tauri/Cargo.toml
@@ -49,6 +49,9 @@ hound = "3.5"
 rodio = { version = "0.19", default-features = false, features = ["wav", "mp3"] }
 # 隨機選 wake-ack 短句
 rand = "0.8"
+# Phase 6 polish A:profile preflight 用 `which::which()` 偵測 PATH 上 binary
+# 是否存在(跨平台,不用 spawn `which` / `where` subprocess)
+which = "6"
 # Lock-free shared state for the audio callback path
 parking_lot = "0.12"
 # Async stream utilities — needed to consume ashpd's GlobalShortcuts signal stream.

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -557,44 +557,57 @@ fn chat_provider_info(state: tauri::State<Arc<AppState>>) -> serde_json::Value {
 ///
 /// 純 API provider(`gemini` / `groq` / `ollama` / 自訂 OpenAI-compat)沒 binary
 /// 需求,return `requires_binary: false`。
+///
+/// **跨平台:用 `which::which()`(純 Rust)而非 spawn `which` / `where` subprocess**
+/// — Windows 沒 `which` binary(系統用 `where`)。`which::which()` 自己掃 PATH,
+/// 結果一致。
 fn check_provider_binary(provider_name: &str) -> serde_json::Value {
-    let binary = match provider_name {
-        "claude-bash" | "claude-cli" => Some("claude"),
-        "gemini-bash" | "gemini-cli" => Some("gemini"),
-        "codex-bash" | "codex-cli" => Some("codex"),
-        _ => None,
-    };
-    let Some(bin) = binary else {
+    let Some(bin) = provider_binary_for(provider_name) else {
         // 純 API provider,不需 binary
         return serde_json::json!({
             "requires_binary": false,
         });
     };
-    let available = std::process::Command::new("which")
-        .arg(bin)
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
-    // 建議的替代 — 若 binary 沒裝,建議 user 改用 純 API 或裝對應 CLI
-    let suggested_api = match bin {
-        "claude" => "gemini",   // Claude API 沒在 Mori 內建,推薦 gemini
-        "gemini" => "gemini",   // 同 CLI 名字但純 API 路徑
-        "codex" => "groq",      // codex API 沒在 Mori,推 groq
-        _ => "gemini",
-    };
-    let install_hint = match bin {
-        "claude" => "npm install -g @anthropic-ai/claude-code(+ claude login)",
-        "gemini" => "npm install -g @google/gemini-cli",
-        "codex" => "npm install -g @openai/codex(+ codex login)",
-        _ => "",
-    };
+    let available = which::which(bin).is_ok();
     serde_json::json!({
         "requires_binary": true,
         "binary": bin,
         "available": available,
-        "suggested_api": suggested_api,
-        "install_hint": install_hint,
+        "suggested_api": suggested_api_fallback(bin),
+        "install_hint": install_hint_for(bin),
     })
+}
+
+/// Provider name → 對應 CLI binary。Pure API provider 回 None。
+fn provider_binary_for(provider_name: &str) -> Option<&'static str> {
+    match provider_name {
+        "claude-bash" | "claude-cli" => Some("claude"),
+        "gemini-bash" | "gemini-cli" => Some("gemini"),
+        "codex-bash" | "codex-cli" => Some("codex"),
+        _ => None,
+    }
+}
+
+/// 給 binary,建議的 API fallback。為什麼這樣 mapping:
+/// - claude → gemini(Mori 內建沒 Anthropic API,Gemini 最易上手)
+/// - gemini → gemini(同名純 API 路徑就在)
+/// - codex → groq(沒內建 OpenAI API,Groq 是 oss-120b 免費 quota 大)
+fn suggested_api_fallback(bin: &str) -> &'static str {
+    match bin {
+        "claude" => "gemini",
+        "gemini" => "gemini",
+        "codex" => "groq",
+        _ => "gemini",
+    }
+}
+
+fn install_hint_for(bin: &str) -> &'static str {
+    match bin {
+        "claude" => "npm install -g @anthropic-ai/claude-code(+ claude login)",
+        "gemini" => "npm install -g @google/gemini-cli",
+        "codex" => "npm install -g @openai/codex(+ codex login)",
+        _ => "",
+    }
 }
 
 #[tauri::command]
@@ -5193,6 +5206,73 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ─── Phase 6 polish A: check_provider_binary ─────────────────────
+    // 驗 provider name → binary mapping + 各 helper return 結構。
+    // 注意:`available` 欄位視測試機器 PATH 而定,不在 unit test 驗(integration
+    // 才測)。這裡專注於「pure logic 對不對」。
+
+    #[test]
+    fn check_provider_binary_pure_api_no_binary_required() {
+        for name in ["gemini", "groq", "ollama", "azure_openai_custom"] {
+            let v = check_provider_binary(name);
+            assert_eq!(v["requires_binary"], false, "{name} should be pure API");
+            assert!(v.get("binary").is_none(), "{name} should omit binary field");
+        }
+    }
+
+    #[test]
+    fn check_provider_binary_claude_variants_map_to_claude() {
+        for name in ["claude-bash", "claude-cli"] {
+            let v = check_provider_binary(name);
+            assert_eq!(v["requires_binary"], true);
+            assert_eq!(v["binary"], "claude");
+            assert_eq!(v["suggested_api"], "gemini");
+            assert!(v["install_hint"].as_str().unwrap().contains("@anthropic-ai/claude-code"));
+        }
+    }
+
+    #[test]
+    fn check_provider_binary_gemini_variants_map_to_gemini() {
+        for name in ["gemini-bash", "gemini-cli"] {
+            let v = check_provider_binary(name);
+            assert_eq!(v["requires_binary"], true);
+            assert_eq!(v["binary"], "gemini");
+            assert!(v["install_hint"].as_str().unwrap().contains("@google/gemini-cli"));
+        }
+    }
+
+    #[test]
+    fn check_provider_binary_codex_variants_map_to_codex() {
+        for name in ["codex-bash", "codex-cli"] {
+            let v = check_provider_binary(name);
+            assert_eq!(v["requires_binary"], true);
+            assert_eq!(v["binary"], "codex");
+            assert_eq!(v["suggested_api"], "groq");
+            assert!(v["install_hint"].as_str().unwrap().contains("@openai/codex"));
+        }
+    }
+
+    #[test]
+    fn provider_binary_for_unknown_returns_none() {
+        assert_eq!(provider_binary_for("groq"), None);
+        assert_eq!(provider_binary_for("gemini"), None);
+        assert_eq!(provider_binary_for("ollama"), None);
+        assert_eq!(provider_binary_for("totally_made_up_xyz"), None);
+    }
+
+    #[test]
+    fn install_hint_includes_npm_command() {
+        for (bin, expected_pkg) in &[
+            ("claude", "@anthropic-ai/claude-code"),
+            ("gemini", "@google/gemini-cli"),
+            ("codex", "@openai/codex"),
+        ] {
+            let hint = install_hint_for(bin);
+            assert!(hint.starts_with("npm install"), "{bin} hint should start with npm");
+            assert!(hint.contains(expected_pkg), "{bin} hint should mention {expected_pkg}");
+        }
+    }
 
     // ─── stt_gate_decision truth table ─────────────────────────────
     // 4 個維度的真值表(too_short × too_quiet),每格驗 reason 字串對。

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -534,6 +534,7 @@ fn chat_provider_info(state: tauri::State<Arc<AppState>>) -> serde_json::Value {
     let routing = mori_core::llm::read_routing_config();
     let stt = mori_core::llm::transcribe::active_transcribe_snapshot();
     let warmup = *state.ollama_warmup.lock();
+    let binary_status = check_provider_binary(&snap.name);
     serde_json::json!({
         "name": snap.name,
         "model": snap.model,
@@ -544,6 +545,55 @@ fn chat_provider_info(state: tauri::State<Arc<AppState>>) -> serde_json::Value {
             "model": stt.model,
             "language": stt.language,
         },
+        "binary": binary_status,
+    })
+}
+
+/// Phase 6 polish A:provider preflight — 看 provider 對應 binary 存在嗎。
+///
+/// CLI-flavor provider(`*-bash` / `*-cli`)需要本機裝對應 binary。沒裝 →
+/// agent loop spawn 就炸。這個 helper 在 ChatPanel topbar 預先檢測,讓 user
+/// 看到紅 chip + 建議改 API provider。
+///
+/// 純 API provider(`gemini` / `groq` / `ollama` / 自訂 OpenAI-compat)沒 binary
+/// 需求,return `requires_binary: false`。
+fn check_provider_binary(provider_name: &str) -> serde_json::Value {
+    let binary = match provider_name {
+        "claude-bash" | "claude-cli" => Some("claude"),
+        "gemini-bash" | "gemini-cli" => Some("gemini"),
+        "codex-bash" | "codex-cli" => Some("codex"),
+        _ => None,
+    };
+    let Some(bin) = binary else {
+        // 純 API provider,不需 binary
+        return serde_json::json!({
+            "requires_binary": false,
+        });
+    };
+    let available = std::process::Command::new("which")
+        .arg(bin)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    // 建議的替代 — 若 binary 沒裝,建議 user 改用 純 API 或裝對應 CLI
+    let suggested_api = match bin {
+        "claude" => "gemini",   // Claude API 沒在 Mori 內建,推薦 gemini
+        "gemini" => "gemini",   // 同 CLI 名字但純 API 路徑
+        "codex" => "groq",      // codex API 沒在 Mori,推 groq
+        _ => "gemini",
+    };
+    let install_hint = match bin {
+        "claude" => "npm install -g @anthropic-ai/claude-code(+ claude login)",
+        "gemini" => "npm install -g @google/gemini-cli",
+        "codex" => "npm install -g @openai/codex(+ codex login)",
+        _ => "",
+    };
+    serde_json::json!({
+        "requires_binary": true,
+        "binary": bin,
+        "available": available,
+        "suggested_api": suggested_api,
+        "install_hint": install_hint,
     })
 }
 

--- a/src/ChatPanel.tsx
+++ b/src/ChatPanel.tsx
@@ -65,6 +65,15 @@ type ChatProviderInfo = {
   model: string;
   warmup: WarmupState | null;
   stt: SttInfo;
+  // Phase 6 polish A:provider preflight。Pure API → requires_binary=false。
+  // CLI-flavor provider(*-bash / *-cli)→ requires_binary=true,available 看 binary 在不在 PATH。
+  binary?: {
+    requires_binary: boolean;
+    binary?: string;
+    available?: boolean;
+    suggested_api?: string;
+    install_hint?: string;
+  };
 };
 
 type ActiveProfiles = {
@@ -255,6 +264,25 @@ function ChatPanel() {
           {chatProvider && (
             <span className="mori-chat-mode-provider">
               · {chatProvider.name} · {chatProvider.model}
+            </span>
+          )}
+          {/* Phase 6 polish A:provider preflight 警告 — CLI binary 沒裝紅 chip */}
+          {chatProvider?.binary?.requires_binary && chatProvider.binary.available === false && (
+            <span
+              className="mori-chat-mode-provider"
+              title={`Provider 「${chatProvider.name}」需要 「${chatProvider.binary.binary}」 CLI,但 PATH 找不到。\n安裝:${chatProvider.binary.install_hint}\n或 Config tab 改 provider 成 「${chatProvider.binary.suggested_api}」(純 API,不需 CLI)。`}
+              style={{
+                marginLeft: 6,
+                padding: "2px 8px",
+                background: "rgba(220, 60, 60, 0.18)",
+                color: "#dc3c3c",
+                borderRadius: 4,
+                fontSize: 11,
+                fontWeight: 600,
+                cursor: "help",
+              }}
+            >
+              ⚠ {chatProvider.binary.binary} 未安裝
             </span>
           )}
         </div>

--- a/src/ChatPanel.tsx
+++ b/src/ChatPanel.tsx
@@ -266,7 +266,8 @@ function ChatPanel() {
               · {chatProvider.name} · {chatProvider.model}
             </span>
           )}
-          {/* Phase 6 polish A:provider preflight 警告 — CLI binary 沒裝紅 chip */}
+          {/* Phase 6 polish A:provider preflight 警告 — CLI binary 沒裝紅 chip。
+              用 --c-danger-* theme token,跟主視窗 light/dark 主題對齊。 */}
           {chatProvider?.binary?.requires_binary && chatProvider.binary.available === false && (
             <span
               className="mori-chat-mode-provider"
@@ -274,8 +275,9 @@ function ChatPanel() {
               style={{
                 marginLeft: 6,
                 padding: "2px 8px",
-                background: "rgba(220, 60, 60, 0.18)",
-                color: "#dc3c3c",
+                background: "var(--c-danger-bg)",
+                color: "var(--c-danger-text)",
+                border: "1px solid var(--c-danger-border)",
                 borderRadius: 4,
                 fontSize: 11,
                 fontWeight: 600,


### PR DESCRIPTION
## Summary(Plan A)

Fresh install / 換機器後 profile 設了 `provider: claude-bash` / `gemini-bash` / `codex-bash` 但對應 CLI 沒裝 → agent loop spawn 炸,UI 無預警。

加 ChatPanel topbar 紅 chip 預警。

## 變更

### Rust
- `chat_provider_info` IPC 擴回 `binary` 物件
- `check_provider_binary()` helper:
  - 純 API provider → `requires_binary: false`
  - CLI provider → `which <bin>` 結果 + `suggested_api` + `install_hint`

| Provider | binary | suggested_api(備援) | install_hint |
|---|---|---|---|
| `claude-bash` / `claude-cli` | `claude` | `gemini` | `npm install -g @anthropic-ai/claude-code` |
| `gemini-bash` / `gemini-cli` | `gemini` | `gemini` | `npm install -g @google/gemini-cli` |
| `codex-bash` / `codex-cli` | `codex` | `groq` | `npm install -g @openai/codex` |

### UI
- ChatPanel topbar:`binary.requires_binary && !binary.available` → 顯示紅 chip
- chip 文字「⚠ claude 未安裝」
- hover tooltip 顯示安裝指令 + 建議切到 suggested_api

## 為什麼不直接擋 / 自動切換

- 不直接擋 — user 可能正在裝 CLI(剛 npm install,還沒 reload),Mori 該偵測不該阻止
- 不自動切換 — user 寫死 profile 是設計(可能想吃 Claude Pro 用量不吃 Gemini quota),silent 切違反 intent
- 紅 chip 最輕的提示:「我注意到設定有問題,不替你做決定」

## Test plan

- [x] `cargo check --workspace --all-targets` ✅
- [x] `bash scripts/verify.sh` 全綠
- [ ] CI ubuntu + windows
- [ ] 實機 Linux:
  - [ ] AGENT.md 設 `provider: claude-bash` + claude 在 PATH → chip 不出
  - [ ] AGENT.md 設 `provider: claude-bash` + `mv ~/.local/bin/claude ~/.local/bin/claude.bak` → chip 出紅色「⚠ claude 未安裝」
  - [ ] Hover chip 看 tooltip(安裝指令 + 建議改 gemini)
  - [ ] AGENT.md 改成 `provider: gemini` → chip 消失(API 不需 binary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)