### PR TITLE
feat(recordings-ui): 新 Recordings tab — sessions 列表 + audio 播放 + 詳細 expand

### DIFF
--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -4342,6 +4342,11 @@ fn main() {
             speaker_id::speaker_id_status,
             speaker_id::speaker_id_enroll,
             speaker_id::speaker_id_clear,
+            recordings::recordings_list,
+            recordings::recordings_session_detail,
+            recordings::recordings_audio_bytes,
+            recordings::recordings_delete_session,
+            recordings::recordings_stats,
         ])
         .on_window_event(|window, event| {
             // 關視窗時不殺 app — 隱藏到系統匣繼續跑(像 Slack / Discord)

--- a/crates/mori-tauri/src/recordings.rs
+++ b/crates/mori-tauri/src/recordings.rs
@@ -354,3 +354,190 @@ pub fn cleanup_old_if_needed() {
         );
     }
 }
+
+// ── IPC commands(給 RecordingsTab UI)─────────────────────────────────────
+
+/// 列表 summary — 一筆 per session,給 UI 列表顯示。詳細內容 lazy load 另一條 IPC。
+#[derive(Debug, Serialize)]
+pub struct SessionSummary {
+    pub timestamp: String,           // dir name(已 url-safe)
+    pub iso_time: String,            // ISO 8601(從 meta.json 讀,fallback dir name)
+    pub mode: Option<String>,
+    pub profile: Option<String>,
+    pub provider: Option<String>,
+    pub transcript_preview: Option<String>, // 前 60 字
+    pub response_preview: Option<String>,
+    pub duration_ms: Option<u64>,
+    pub size_bytes: u64,             // 整個 dir 大小
+}
+
+/// List 全部 session(newest first)。給 RecordingsTab mount + refresh 用。
+#[tauri::command]
+pub fn recordings_list() -> Vec<SessionSummary> {
+    let root = recordings_root();
+    let Ok(entries) = fs::read_dir(&root) else {
+        return vec![];
+    };
+    let mut out: Vec<SessionSummary> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .filter_map(|e| {
+            let path = e.path();
+            let timestamp = path.file_name()?.to_string_lossy().to_string();
+            let summary = build_session_summary(&path, &timestamp);
+            Some(summary)
+        })
+        .collect();
+    // Newest first(dir name 是 ISO 字典序,直接 reverse 排)
+    out.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    out
+}
+
+fn build_session_summary(dir: &Path, timestamp: &str) -> SessionSummary {
+    let meta_text = fs::read_to_string(dir.join("meta.json")).unwrap_or_default();
+    let meta: serde_json::Value = serde_json::from_str(&meta_text).unwrap_or(serde_json::Value::Null);
+    let transcript = fs::read_to_string(dir.join("transcript.txt")).ok();
+    let response = fs::read_to_string(dir.join("response.txt")).ok();
+    let size_bytes = dir_size(dir);
+    SessionSummary {
+        timestamp: timestamp.to_string(),
+        iso_time: meta
+            .pointer("/timestamp")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| timestamp.to_string()),
+        mode: meta.pointer("/mode").and_then(|v| v.as_str()).map(|s| s.to_string()),
+        profile: meta.pointer("/profile").and_then(|v| v.as_str()).map(|s| s.to_string()),
+        provider: meta.pointer("/provider").and_then(|v| v.as_str()).map(|s| s.to_string()),
+        transcript_preview: transcript.as_ref().map(|s| preview(s, 60)),
+        response_preview: response.as_ref().map(|s| preview(s, 60)),
+        duration_ms: meta.pointer("/timings_ms/total_ms").and_then(|v| v.as_u64()),
+        size_bytes,
+    }
+}
+
+fn dir_size(dir: &Path) -> u64 {
+    fs::read_dir(dir)
+        .ok()
+        .map(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .filter_map(|e| e.metadata().ok())
+                .map(|m| m.len())
+                .sum()
+        })
+        .unwrap_or(0)
+}
+
+fn preview(s: &str, max_chars: usize) -> String {
+    let s = s.trim();
+    if s.chars().count() <= max_chars {
+        s.to_string()
+    } else {
+        format!("{}...", s.chars().take(max_chars).collect::<String>())
+    }
+}
+
+/// 完整 session 細節 — meta / context / history / transcript / response。
+#[derive(Debug, Serialize, Default)]
+pub struct SessionDetail {
+    pub timestamp: String,
+    pub meta: Option<serde_json::Value>,
+    pub context: Option<serde_json::Value>,
+    pub history: Option<serde_json::Value>,
+    pub transcript: Option<String>,
+    pub response: Option<String>,
+    pub system_prompt: Option<String>,
+    pub has_audio_raw: bool,
+    pub has_audio_trimmed: bool,
+}
+
+#[tauri::command]
+pub fn recordings_session_detail(timestamp: String) -> Result<SessionDetail, String> {
+    let dir = recordings_root().join(sanitize_timestamp(&timestamp)?);
+    if !dir.is_dir() {
+        return Err(format!("session not found: {timestamp}"));
+    }
+    let read_json = |name: &str| -> Option<serde_json::Value> {
+        fs::read_to_string(dir.join(name))
+            .ok()
+            .and_then(|t| serde_json::from_str(&t).ok())
+    };
+    let read_text = |name: &str| -> Option<String> { fs::read_to_string(dir.join(name)).ok() };
+    Ok(SessionDetail {
+        timestamp,
+        meta: read_json("meta.json"),
+        context: read_json("context.json"),
+        history: read_json("history.json"),
+        transcript: read_text("transcript.txt"),
+        response: read_text("response.txt"),
+        system_prompt: read_text("system-prompt.txt"),
+        has_audio_raw: dir.join("audio-raw.wav").exists(),
+        has_audio_trimmed: dir.join("audio-trimmed.wav").exists(),
+    })
+}
+
+/// 回 audio bytes — UI 用 blob URL 播放。
+/// `which`: "raw" or "trimmed"
+#[tauri::command]
+pub fn recordings_audio_bytes(timestamp: String, which: String) -> Result<Vec<u8>, String> {
+    let file = match which.as_str() {
+        "raw" => "audio-raw.wav",
+        "trimmed" => "audio-trimmed.wav",
+        _ => return Err(format!("unknown audio variant: {which}(只接 raw/trimmed)")),
+    };
+    let dir = recordings_root().join(sanitize_timestamp(&timestamp)?);
+    let path = dir.join(file);
+    fs::read(&path).map_err(|e| format!("read {}: {e}", path.display()))
+}
+
+#[tauri::command]
+pub fn recordings_delete_session(timestamp: String) -> Result<(), String> {
+    let dir = recordings_root().join(sanitize_timestamp(&timestamp)?);
+    if !dir.is_dir() {
+        return Err(format!("not a session dir: {timestamp}"));
+    }
+    fs::remove_dir_all(&dir).map_err(|e| format!("rm -rf {}: {e}", dir.display()))
+}
+
+#[derive(Debug, Serialize)]
+pub struct RecordingsStats {
+    pub session_count: usize,
+    pub total_bytes: u64,
+    pub retention_days: u32,
+    pub enabled: bool,
+}
+
+#[tauri::command]
+pub fn recordings_stats() -> RecordingsStats {
+    let cfg = read_config();
+    let root = recordings_root();
+    let (session_count, total_bytes) = fs::read_dir(&root)
+        .ok()
+        .map(|entries| {
+            let mut count = 0usize;
+            let mut bytes = 0u64;
+            for e in entries.flatten() {
+                if e.path().is_dir() {
+                    count += 1;
+                    bytes += dir_size(&e.path());
+                }
+            }
+            (count, bytes)
+        })
+        .unwrap_or((0, 0));
+    RecordingsStats {
+        session_count,
+        total_bytes,
+        retention_days: cfg.retention_days,
+        enabled: cfg.enabled,
+    }
+}
+
+/// 防 path traversal — timestamp 只能是 dir name format,不能含 `/` / `..` / abs path。
+fn sanitize_timestamp(ts: &str) -> Result<String, String> {
+    if ts.is_empty() || ts.contains('/') || ts.contains('\\') || ts.starts_with('.') || ts.contains("..") {
+        return Err(format!("invalid timestamp: {ts}"));
+    }
+    Ok(ts.to_string())
+}

--- a/src/MainShell.tsx
+++ b/src/MainShell.tsx
@@ -21,10 +21,11 @@ import AnnuliTab from "./tabs/AnnuliTab";
 import SkillsTab from "./tabs/SkillsTab";
 import DepsTab from "./tabs/DepsTab";
 import LogsTab from "./tabs/LogsTab";
+import RecordingsTab from "./tabs/RecordingsTab";
 import TranscribeTab from "./tabs/TranscribeTab";
 import {
   IconChat, IconProfiles, IconConfig, IconMemory, IconAnnuli, IconSkills, IconDeps,
-  IconSun, IconMoon, IconGlobe, IconHelp, IconTranscribe,
+  IconSun, IconMoon, IconGlobe, IconHelp, IconTranscribe, IconMic,
 } from "./icons";
 import { toggleTheme, loadActiveTheme } from "./theme";
 import { setLocale, nextLocale } from "./i18n";
@@ -32,7 +33,7 @@ import { Quickstart, shouldShowQuickstart } from "./Quickstart";
 
 type NavPayload = { tab: TabId; subTab?: string };
 
-type TabId = "chat" | "profiles" | "config" | "memory" | "annuli" | "skills" | "deps" | "logs" | "transcribe";
+type TabId = "chat" | "profiles" | "config" | "memory" | "annuli" | "skills" | "deps" | "logs" | "transcribe" | "recordings";
 
 type TabDef = {
   id: TabId;
@@ -51,6 +52,7 @@ const TABS: TabDef[] = [
   { id: "transcribe", Icon: IconTranscribe, key: "transcribe" },
   { id: "deps",     Icon: IconDeps,     key: "deps" },
   { id: "logs",     Icon: IconHelp,     key: "logs" },
+  { id: "recordings", Icon: IconMic,    key: "recordings" },
 ];
 
 function MainShell() {
@@ -181,6 +183,7 @@ function MainShell() {
         {tab === "transcribe" && <TranscribeTab />}
         {tab === "deps" && <DepsTab />}
         {tab === "logs" && <LogsTab />}
+        {tab === "recordings" && <RecordingsTab />}
       </main>
       {quickstartOpen && <Quickstart onDone={() => setQuickstartOpen(false)} />}
     </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -29,7 +29,9 @@
     "deps": "Deps",
     "deps_sub": "Optional tools",
     "logs": "Logs",
-    "logs_sub": "Events / debug"
+    "logs_sub": "Events / debug",
+    "recordings": "Recordings",
+    "recordings_sub": "Voice session replay"
   },
   "logs_tab": {
     "title": "Logs",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -29,7 +29,9 @@
     "deps": "Deps",
     "deps_sub": "選用工具",
     "logs": "Logs",
-    "logs_sub": "事件 / 除錯"
+    "logs_sub": "事件 / 除錯",
+    "recordings": "Recordings",
+    "recordings_sub": "語音 session 回顧"
   },
   "logs_tab": {
     "title": "Logs",

--- a/src/tabs/RecordingsTab.tsx
+++ b/src/tabs/RecordingsTab.tsx
@@ -1,0 +1,498 @@
+// Phase B per-pipeline recordings UI(v0.6.2 ship 完 backend,v0.6.3 上 UI)。
+//
+// 列出 ~/.mori/recordings/<ts>/ 內每個 session,展開可看:
+//   - meta.json(timing / scores / profile / provider / skill_calls)
+//   - context.json(clipboard / selection / window / urls)
+//   - history.json(對話 history 摘要)
+//   - transcript.txt + response.txt
+//   - system-prompt.txt(完整 prompt LLM 看的)
+//   - audio-raw.wav / audio-trimmed.wav(可播放)
+//
+// 設計:
+//   - 列表 mount 載 summary(輕量,不含 audio bytes)
+//   - 點開單筆 → lazy fetch session_detail
+//   - 點播放 audio → 拉 bytes → blob URL <audio>
+//   - 刪除單筆 → confirm → IPC
+
+import { useEffect, useMemo, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useTranslation } from "react-i18next";
+
+type SessionSummary = {
+  timestamp: string;
+  iso_time: string;
+  mode: string | null;
+  profile: string | null;
+  provider: string | null;
+  transcript_preview: string | null;
+  response_preview: string | null;
+  duration_ms: number | null;
+  size_bytes: number;
+};
+
+type SessionDetail = {
+  timestamp: string;
+  meta: Record<string, unknown> | null;
+  context: Record<string, unknown> | null;
+  history: Record<string, unknown> | null;
+  transcript: string | null;
+  response: string | null;
+  system_prompt: string | null;
+  has_audio_raw: boolean;
+  has_audio_trimmed: boolean;
+};
+
+type RecordingsStats = {
+  session_count: number;
+  total_bytes: number;
+  retention_days: number;
+  enabled: boolean;
+};
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function formatDuration(ms: number | null): string {
+  if (!ms) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function formatTime(iso: string): string {
+  // ISO 8601 → 「2026-05-19 17:12:34」(去掉 T 跟微秒)
+  return iso.replace("T", " ").substring(0, 19);
+}
+
+function RecordingsTab() {
+  const { t: _ } = useTranslation(); // i18n 之後接,目前先 hardcode 中文
+  const [sessions, setSessions] = useState<SessionSummary[]>([]);
+  const [stats, setStats] = useState<RecordingsStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [detail, setDetail] = useState<SessionDetail | null>(null);
+  const [audioUrls, setAudioUrls] = useState<{ raw?: string; trimmed?: string }>({});
+  const [modeFilter, setModeFilter] = useState<string>("all");
+  const [providerFilter, setProviderFilter] = useState<string>("all");
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      const [list, st] = await Promise.all([
+        invoke<SessionSummary[]>("recordings_list"),
+        invoke<RecordingsStats>("recordings_stats"),
+      ]);
+      setSessions(list);
+      setStats(st);
+    } catch (e) {
+      console.error("recordings list", e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  // 清掉 blob URL(避免 memory leak)
+  useEffect(() => {
+    return () => {
+      Object.values(audioUrls).forEach((u) => u && URL.revokeObjectURL(u));
+    };
+  }, [audioUrls]);
+
+  const flashMsg = (m: string) => {
+    setMsg(m);
+    setTimeout(() => setMsg(null), 2500);
+  };
+
+  const onExpand = async (timestamp: string) => {
+    // toggle:再點同一筆 → 收起
+    if (expanded === timestamp) {
+      setExpanded(null);
+      setDetail(null);
+      Object.values(audioUrls).forEach((u) => u && URL.revokeObjectURL(u));
+      setAudioUrls({});
+      return;
+    }
+    setExpanded(timestamp);
+    setDetail(null);
+    Object.values(audioUrls).forEach((u) => u && URL.revokeObjectURL(u));
+    setAudioUrls({});
+    try {
+      const d = await invoke<SessionDetail>("recordings_session_detail", { timestamp });
+      setDetail(d);
+    } catch (e) {
+      flashMsg(`讀失敗:${String(e)}`);
+    }
+  };
+
+  const loadAudio = async (timestamp: string, which: "raw" | "trimmed") => {
+    if (audioUrls[which]) return; // 已 load
+    try {
+      const bytes = await invoke<number[]>("recordings_audio_bytes", { timestamp, which });
+      const blob = new Blob([new Uint8Array(bytes)], { type: "audio/wav" });
+      const url = URL.createObjectURL(blob);
+      setAudioUrls((prev) => ({ ...prev, [which]: url }));
+    } catch (e) {
+      flashMsg(`audio 讀失敗:${String(e)}`);
+    }
+  };
+
+  const onDelete = async (timestamp: string) => {
+    if (!confirm(`刪除 session ${timestamp}?(audio + transcript + 全部 metadata)`)) return;
+    try {
+      await invoke("recordings_delete_session", { timestamp });
+      if (expanded === timestamp) setExpanded(null);
+      flashMsg(`已刪除 ${timestamp}`);
+      await refresh();
+    } catch (e) {
+      flashMsg(`刪除失敗:${String(e)}`);
+    }
+  };
+
+  const modes = useMemo(() => {
+    const s = new Set<string>();
+    sessions.forEach((x) => x.mode && s.add(x.mode));
+    return ["all", ...Array.from(s)];
+  }, [sessions]);
+
+  const providers = useMemo(() => {
+    const s = new Set<string>();
+    sessions.forEach((x) => x.provider && s.add(x.provider));
+    return ["all", ...Array.from(s)];
+  }, [sessions]);
+
+  const filtered = sessions.filter((s) => {
+    if (modeFilter !== "all" && s.mode !== modeFilter) return false;
+    if (providerFilter !== "all" && s.provider !== providerFilter) return false;
+    return true;
+  });
+
+  return (
+    <div className="mori-tab">
+      <h2 className="mori-tab-title">Recordings</h2>
+      <p className="mori-tab-hint">
+        每次 voice pipeline 的完整 I/O snapshot(audio / transcript / system prompt /
+        context / meta)。給 Whisper fine-tune dataset、debug、隱私自管用。
+        資料夾:<code>~/.mori/recordings/</code>
+      </p>
+
+      {/* Stats bar */}
+      {stats && (
+        <div
+          style={{
+            display: "flex",
+            gap: 18,
+            padding: "10px 14px",
+            background: "var(--c-surface-bg)",
+            border: "1px solid var(--c-border)",
+            borderRadius: 6,
+            fontSize: 13,
+            marginBottom: 12,
+            alignItems: "center",
+          }}
+        >
+          <span>
+            <strong>{stats.session_count}</strong> sessions
+          </span>
+          <span>
+            <strong>{formatBytes(stats.total_bytes)}</strong> disk
+          </span>
+          <span style={{ color: "var(--c-text-muted)" }}>
+            retention <strong>{stats.retention_days}</strong> days
+            {!stats.enabled && (
+              <span style={{ marginLeft: 8, color: "var(--c-danger-text)" }}>(recordings disabled)</span>
+            )}
+          </span>
+          <span style={{ marginLeft: "auto", display: "flex", gap: 8 }}>
+            <label style={{ fontSize: 12, color: "var(--c-text-muted)" }}>
+              mode{" "}
+              <select
+                value={modeFilter}
+                onChange={(e) => setModeFilter(e.target.value)}
+                style={{ marginLeft: 4 }}
+              >
+                {modes.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label style={{ fontSize: 12, color: "var(--c-text-muted)" }}>
+              provider{" "}
+              <select
+                value={providerFilter}
+                onChange={(e) => setProviderFilter(e.target.value)}
+                style={{ marginLeft: 4 }}
+              >
+                {providers.map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button className="mori-btn small ghost" onClick={refresh}>
+              重新整理
+            </button>
+          </span>
+        </div>
+      )}
+
+      {msg && (
+        <div style={{ padding: 8, fontSize: 12, color: "var(--c-text-muted)" }}>{msg}</div>
+      )}
+
+      {loading && <div className="mori-tab-placeholder"><p>讀取中...</p></div>}
+
+      {!loading && filtered.length === 0 && (
+        <div className="mori-tab-placeholder">
+          <p>沒 session(或都被 filter 掉)。對 mic 講一輪 Mori 試試。</p>
+        </div>
+      )}
+
+      {/* Session list */}
+      {!loading && filtered.length > 0 && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {filtered.map((s) => (
+            <div
+              key={s.timestamp}
+              style={{
+                border: "1px solid var(--c-border)",
+                borderRadius: 6,
+                background: "var(--c-surface-bg)",
+              }}
+            >
+              {/* Row header */}
+              <div
+                onClick={() => onExpand(s.timestamp)}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  padding: "8px 12px",
+                  cursor: "pointer",
+                  borderBottom: expanded === s.timestamp ? "1px solid var(--c-border)" : "none",
+                }}
+              >
+                <span style={{ fontFamily: "monospace", fontSize: 12, color: "var(--c-text-muted)", minWidth: 160 }}>
+                  {formatTime(s.iso_time)}
+                </span>
+                <span style={{
+                  fontSize: 11,
+                  padding: "1px 6px",
+                  background: "var(--c-input-bg)",
+                  border: "1px solid var(--c-border)",
+                  borderRadius: 3,
+                  color: "var(--c-text-muted)",
+                }}>
+                  {s.mode ?? "?"}
+                </span>
+                <span style={{ fontSize: 11, color: "var(--c-text-muted)" }}>
+                  {s.profile ?? "—"} · {s.provider ?? "—"} · {formatDuration(s.duration_ms)} · {formatBytes(s.size_bytes)}
+                </span>
+                <span style={{ fontSize: 13, flex: 1, marginLeft: 8 }}>
+                  {s.transcript_preview ? `「${s.transcript_preview}」` : <em style={{ color: "var(--c-text-muted)" }}>(無 transcript)</em>}
+                </span>
+                <span style={{ color: "var(--c-text-muted)" }}>
+                  {expanded === s.timestamp ? "▾" : "▸"}
+                </span>
+              </div>
+
+              {/* Expanded detail */}
+              {expanded === s.timestamp && (
+                <div style={{ padding: 12 }}>
+                  {!detail && <p style={{ color: "var(--c-text-muted)", fontSize: 13 }}>讀取 detail 中...</p>}
+                  {detail && (
+                    <>
+                      {/* Transcript / response */}
+                      {detail.transcript && (
+                        <DetailField label="Transcript" content={detail.transcript} />
+                      )}
+                      {detail.response && (
+                        <DetailField label="Response" content={detail.response} />
+                      )}
+
+                      {/* Audio players */}
+                      {(detail.has_audio_raw || detail.has_audio_trimmed) && (
+                        <div style={{ marginTop: 10 }}>
+                          <div style={{ fontSize: 12, color: "var(--c-text-muted)", marginBottom: 4 }}>
+                            🎵 Audio
+                          </div>
+                          {detail.has_audio_raw && (
+                            <AudioRow
+                              label="raw(silence-trim 前)"
+                              url={audioUrls.raw}
+                              onLoad={() => loadAudio(s.timestamp, "raw")}
+                            />
+                          )}
+                          {detail.has_audio_trimmed && (
+                            <AudioRow
+                              label="trimmed(STT 用)"
+                              url={audioUrls.trimmed}
+                              onLoad={() => loadAudio(s.timestamp, "trimmed")}
+                            />
+                          )}
+                        </div>
+                      )}
+
+                      {/* Meta json — collapsible */}
+                      <CollapsibleJson label="meta.json" data={detail.meta} defaultOpen />
+                      <CollapsibleJson label="context.json" data={detail.context} />
+                      <CollapsibleJson label="history.json" data={detail.history} />
+                      {detail.system_prompt && (
+                        <DetailField
+                          label={`system-prompt.txt (${detail.system_prompt.length} chars)`}
+                          content={detail.system_prompt}
+                          collapsible
+                        />
+                      )}
+
+                      {/* Actions */}
+                      <div style={{ marginTop: 14, textAlign: "right" }}>
+                        <button
+                          className="mori-btn small ghost"
+                          onClick={() => onDelete(s.timestamp)}
+                          style={{ color: "var(--c-danger-text)" }}
+                        >
+                          ✕ 刪除這個 session
+                        </button>
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DetailField({
+  label,
+  content,
+  collapsible = false,
+}: {
+  label: string;
+  content: string;
+  collapsible?: boolean;
+}) {
+  const [open, setOpen] = useState(!collapsible);
+  return (
+    <div style={{ marginTop: 8 }}>
+      <div
+        onClick={collapsible ? () => setOpen(!open) : undefined}
+        style={{
+          fontSize: 12,
+          color: "var(--c-text-muted)",
+          marginBottom: 4,
+          cursor: collapsible ? "pointer" : "default",
+        }}
+      >
+        {collapsible && <span style={{ marginRight: 4 }}>{open ? "▾" : "▸"}</span>}
+        {label}
+      </div>
+      {open && (
+        <pre
+          style={{
+            padding: 8,
+            background: "var(--c-input-bg)",
+            color: "var(--c-text)",
+            border: "1px solid var(--c-border)",
+            borderRadius: 4,
+            fontSize: 12,
+            lineHeight: 1.55,
+            whiteSpace: "pre-wrap",
+            maxHeight: 280,
+            overflow: "auto",
+            margin: 0,
+          }}
+        >
+          {content}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function CollapsibleJson({
+  label,
+  data,
+  defaultOpen = false,
+}: {
+  label: string;
+  data: unknown;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  if (data === null || data === undefined) return null;
+  return (
+    <div style={{ marginTop: 8 }}>
+      <div
+        onClick={() => setOpen(!open)}
+        style={{
+          fontSize: 12,
+          color: "var(--c-text-muted)",
+          marginBottom: 4,
+          cursor: "pointer",
+        }}
+      >
+        <span style={{ marginRight: 4 }}>{open ? "▾" : "▸"}</span>
+        {label}
+      </div>
+      {open && (
+        <pre
+          style={{
+            padding: 8,
+            background: "var(--c-input-bg)",
+            color: "var(--c-text)",
+            border: "1px solid var(--c-border)",
+            borderRadius: 4,
+            fontSize: 11,
+            lineHeight: 1.55,
+            whiteSpace: "pre-wrap",
+            maxHeight: 240,
+            overflow: "auto",
+            fontFamily: "ui-monospace, monospace",
+            margin: 0,
+          }}
+        >
+          {JSON.stringify(data, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function AudioRow({
+  label,
+  url,
+  onLoad,
+}: {
+  label: string;
+  url?: string;
+  onLoad: () => void;
+}) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
+      <span style={{ fontSize: 11, color: "var(--c-text-muted)", minWidth: 160 }}>{label}</span>
+      {url ? (
+        <audio controls src={url} style={{ height: 28, flex: 1 }} />
+      ) : (
+        <button className="mori-btn small ghost" onClick={onLoad}>
+          ▶ 載入
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default RecordingsTab;


### PR DESCRIPTION
## Summary(Plan B)

v0.6.2 ship recordings 後端後,UI 還在 \`ls ~/.mori/recordings/\`。這版加 sidebar 新 tab,user 直接在 Mori 內看 / 聽 / 刪 session。

## 變更

### Backend(`recordings.rs` 加 5 個 IPC)

| Command | 回傳 |
|---|---|
| `recordings_list` | `Vec<SessionSummary>`(timestamp / mode / profile / provider / preview / duration / size) |
| `recordings_session_detail(timestamp)` | meta + context + history + transcript + response + system_prompt + has_audio_* |
| `recordings_audio_bytes(timestamp, which)` | `Vec<u8>` WAV(UI 用 blob URL 播) |
| `recordings_delete_session(timestamp)` | 刪 dir |
| `recordings_stats` | session_count + total_bytes + retention_days + enabled |

Path traversal 防護:`sanitize_timestamp` 拒 `/` / `..` / abs path / 隱藏檔。

### Frontend(`src/tabs/RecordingsTab.tsx` new)

- Sidebar 新 tab(IconMic)
- 頂部 stats bar:session 數 / disk usage / retention_days / enabled 狀態
- Filter:mode / provider dropdown
- 列表 row:時間 / mode badge / profile · provider · duration · size / transcript preview / ▸▾ 展開
- Expand 後 lazy fetch detail:
  - Transcript / Response 內容 block
  - Audio players(raw / trimmed,點載入拉 bytes → blob URL → `<audio>`)
  - meta.json / context.json / history.json(collapsible JSON viewer)
  - system-prompt.txt(可能 5-50KB,collapsible)
  - 刪除按鈕(danger 色 + confirm)

CSS 全用 `var(--c-*)` token(light/dark 自動對齊,memory rule 已記)。

i18n key 補 sidebar(zh-TW + en):recordings / recordings_sub。

## Test plan

- [x] `bash scripts/verify.sh` 全綠(206 tests)
- [ ] CI ubuntu + windows
- [ ] 實機 Linux:
  - [ ] Sidebar 看到新 Recordings tab(IconMic)
  - [ ] 列表顯示既有 sessions(~/.mori/recordings/ 內 ~20 個)
  - [ ] Filter by mode / provider 可運作
  - [ ] 展開一筆 → 看到 transcript / response / meta.json / context.json
  - [ ] 「載入 raw」拉 audio bytes → `<audio>` 可播放
  - [ ] 刪除按鈕 → confirm → 刪除後列表更新
  - [ ] 切 dark / light theme 都對齊主視窗配色

## 限制 / 留 v0.6.x+

- Audio bytes 一次傳整檔(>1min 錄音傳輸有點重)— 後續 streaming / range
- 列表沒分頁(>100 session 可能慢)
- 沒 search by transcript text(只 mode / provider filter)
- Audio + transcript 沒 word-level sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)