### PR TITLE
feat(ask-back): Phase 3C.2 — Intent::Unclear → Mori 用 TTS 反問

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@
 
 ---
 
+## v0.6.3 — Ask-back(Mori 反問)+ Phase 3C 收尾(2026-05-19)
+
+Phase 3C 的「未盡之事」— evaluator 過去把 `unclear`(半截話 / 模糊起頭)當 `address_mori` 強跑 agent,Mori 拿到「然後...」也照樣亂回。這版改成讓 Mori 直接反問。
+
+### Ask-back
+
+**Intent::Unclear → Mori 用 TTS 反問,不走 agent**(PR #51)。
+
+LLM 判 `unclear` 時除了 intent 還要產 `clarifying_question`(短句、口語、20 字內,例「然後呢?」「你想做什麼?跟我說」)。Pipeline 接到 `EvaluatorOutcome::AskBack` 時:
+
+- 在 ChatPanel 顯示反問句(以 Mori 身份)
+- 若 `tts.enabled` 開了 → 同步 TTS 念出來
+- 把 `transcript`(原半截話)+ 反問句寫進 conversation history,user 下次 wake 再講「我是想說...」時,agent 看得到上下文
+- emit `evaluator-ask-back` event 給未來 UI 加 chip 用
+- event log 多一條 `evaluator_decision` with `outcome:"ask_back"` + `clarifying_question`
+
+Config:`evaluator.ask_back_enabled`(預設 ON,evaluator 開了通常就想要這個分流;OFF → 退回舊行為,unclear 當 address_mori 跑 agent)。
+
+### Evaluator internals refactor
+
+`EvaluatorOutcome` 從 `struct { skip: bool, reason }` 重構成 `enum { Proceed, Skip, AskBack }` — 三種 intent 路徑各自顯式,加新 outcome 不用拆 bool。`EvaluationResult` 新增 `clarifying_question: Option<String>` field,LLM 不給時 fallback 預設句「可以再說清楚一點嗎?」。
+
+### Migration
+
+無 breaking change。既有 `evaluator.enabled = false` 行為完全不變;`evaluator.enabled = true` 預設啟用 ask-back,不想要可單獨關 `ask_back_enabled = false`。
+
+---
+
 ## v0.6.2 — Phase 3 polish + 完整 per-pipeline observability(2026-05-19)
 
 v0.6.1 ship 完 Phase 3 全 7 layer 後,user 實測一輪驗 4 個邊緣 case 都對:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,7 +2571,7 @@ dependencies = [
 
 [[package]]
 name = "mori-cli"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "mori-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "mori-tauri"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "MIT"
 authors = ["yazelin"]

--- a/crates/mori-core/src/evaluator.rs
+++ b/crates/mori-core/src/evaluator.rs
@@ -9,7 +9,9 @@
 //!   叫 Mori,是自言自語 / 跟別人講話被 mic 收到。
 //!   → 直接 skip agent dispatch,emit `noise_rejected` event 給 UI 顯示
 //! - [`Intent::Unclear`] — 模糊,可能是斷句不完整 / 半截話。
-//!   → 走 agent 但加 hint 提示「user 句子不完整,可禮貌反問」
+//!   → **不**走 agent,而是讓 Mori 直接反問 user(ask-back),透過 TTS 念
+//!   出 clarifying question + 在 ChatPanel 顯示。User 下一次 wake 才會再
+//!   走完整 agent。
 //!
 //! ## 為什麼有這個
 //!
@@ -45,7 +47,7 @@ pub enum Intent {
     Unclear,
 }
 
-/// Evaluator output。`intent` 必填,`reason` / `confidence` 可選。
+/// Evaluator output。`intent` 必填,其他可選。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EvaluationResult {
     pub intent: Intent,
@@ -55,6 +57,10 @@ pub struct EvaluationResult {
     /// 0.0..=1.0 信心值(LLM 自評,別太當真 — 主要看 intent)
     #[serde(default)]
     pub confidence: f32,
+    /// 當 `intent == Unclear` 時,Mori 可以拿這句話反問 user(ask-back)。
+    /// 短句、口語、不超過 20 字。LLM 沒提供時,呼叫端應用預設句兜底。
+    #[serde(default)]
+    pub clarifying_question: Option<String>,
 }
 
 const EVALUATOR_SYSTEM_PROMPT: &str = r#"你是 Mori(桌面 AI 同伴)的 wake-word evaluator。每個 wake event 觸發後,user 的語音轉成 transcript 給你。你**只**判斷一件事:user 是不是在跟 Mori 講話?
@@ -62,18 +68,25 @@ const EVALUATOR_SYSTEM_PROMPT: &str = r#"你是 Mori(桌面 AI 同伴)的 wake-w
 三種輸出:
 - `address_mori`:user 在跟 Mori 講話(指令 / 對話 / 問問題 / 閒聊)。明確或合理推斷都算。
 - `background_noise`:wake-word false positive — user 在跟別人講話、自言自語、看影片唸出來、隨口提到「Mori」這個詞。**不是**在跟 Mori 互動。
-- `unclear`:模糊 — 句子半截 / 內容空泛無上下文 / 像在思考但沒講完。
+- `unclear`:模糊 — 句子半截 / 內容空泛無上下文 / 像在思考但沒講完,但**像是**在對 Mori 起頭。
 
 判準:
 - 短指令「打開瀏覽器」「Mori 來幫我」「Hey Mori 查一下」→ address_mori
 - 完整對話「Mori 你今天好嗎」「我想問你一件事」→ address_mori
 - 自言自語「奇怪我剛剛在做什麼」「啊好煩」→ background_noise(沒提到 Mori 也沒指示)
 - 別人對話「他剛剛在玩什麼遊戲」「等下要吃什麼」→ background_noise
-- 半截話「然後...」「嗯...那個...」→ unclear
+- 半截話「Mori 我想...」「然後...」「嗯...那個...」→ unclear
 - 看 YouTube 念稿「主持人說很多 AI 助手像 Siri 或 Mori」→ background_noise(只是提及)
 
+當 intent = unclear 時,**額外**提供 `clarifying_question`:一句短的、口語、像森林精靈會說的反問句(中文,不超過 20 字,符合 transcript 的 context)。例:
+- transcript「然後...」→ clarifying_question「然後呢?」
+- transcript「Mori 我想...」→ clarifying_question「你想做什麼?跟我說」
+- transcript「嗯那個...」→ clarifying_question「我在聽,你說」
+
+其他 intent 不需要 clarifying_question。
+
 回 JSON,format:
-{"intent":"address_mori|background_noise|unclear","reason":"<10字內理由>","confidence":0.0-1.0}
+{"intent":"address_mori|background_noise|unclear","reason":"<10字內理由>","confidence":0.0-1.0,"clarifying_question":"<unclear 時填,其他 null>"}
 
 不要加 markdown fence,不要加說明,純 JSON。"#;
 
@@ -110,6 +123,7 @@ pub async fn evaluate(
                 intent: Intent::AddressMori,
                 reason: "parse_failed".into(),
                 confidence: 0.0,
+                clarifying_question: None,
             })
         }
     }
@@ -186,5 +200,21 @@ mod tests {
     fn parse_invalid_intent_fails() {
         let raw = r#"{"intent":"foo","reason":"x","confidence":1.0}"#;
         assert!(parse_evaluation(raw).is_err());
+    }
+
+    #[test]
+    fn parse_with_clarifying_question() {
+        let raw = r#"{"intent":"unclear","reason":"半截話","confidence":0.6,"clarifying_question":"然後呢?"}"#;
+        let r = parse_evaluation(raw).unwrap();
+        assert_eq!(r.intent, Intent::Unclear);
+        assert_eq!(r.clarifying_question.as_deref(), Some("然後呢?"));
+    }
+
+    #[test]
+    fn parse_clarifying_question_absent_defaults_none() {
+        let raw = r#"{"intent":"unclear","reason":"半截話","confidence":0.6}"#;
+        let r = parse_evaluation(raw).unwrap();
+        assert_eq!(r.intent, Intent::Unclear);
+        assert!(r.clarifying_question.is_none());
     }
 }

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -2641,12 +2641,26 @@ fn stop_and_transcribe(app: AppHandle, state: Arc<AppState>) {
     *state_for_handle.pipeline_task.lock() = Some(task);
 }
 
-/// Phase 3C — evaluator gate 的回傳。`skip=true` 代表判定 background noise,
-/// 呼叫端應跳過 agent;`skip=false` → 走正常 agent。`reason` 給 UI / log 用。
-struct EvaluatorOutcome {
-    skip: bool,
-    reason: String,
+/// Phase 3C — evaluator gate 的回傳。
+///
+/// - `Proceed` → user 在跟 Mori 講話,走 agent。`reason` 給 log / 偵錯。
+/// - `Skip` → background noise,直接結束。`reason` 用來顯示「(背景噪音 — ...)」。
+/// - `AskBack` → user 開頭模糊 / 半截話,Mori 用 `question` 反問,**不**走 agent。
+enum EvaluatorOutcome {
+    Proceed {
+        reason: String,
+    },
+    Skip {
+        reason: String,
+    },
+    AskBack {
+        reason: String,
+        question: String,
+    },
 }
+
+/// Ask-back 預設兜底句:LLM 沒給 clarifying_question 時用這句。
+const DEFAULT_ASK_BACK_QUESTION: &str = "可以再說清楚一點嗎?";
 
 /// 讀 `~/.mori/config.json` `evaluator.*` config,跑 evaluator LLM,回 outcome。
 /// 任何環節失敗 → return None(等同 disabled,呼叫端走正常 agent flow)。
@@ -2680,6 +2694,12 @@ async fn evaluator_gate(transcript: &str) -> Option<EvaluatorOutcome> {
         .and_then(|v| v.as_f64())
         .map(|v| v.clamp(0.0, 1.0) as f32)
         .unwrap_or(0.85);
+    // Phase 3C.2:ask-back 開關。預設 true — evaluator 啟用代表 user 想要
+    // intent 分流,把 unclear 當 ask-back 才合邏輯。User 不想被反問可以單獨關。
+    let ask_back_enabled = json
+        .pointer("/evaluator/ask_back_enabled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
 
     // Build provider
     let provider = match mori_core::llm::build_named_provider(&provider_name, None) {
@@ -2697,49 +2717,75 @@ async fn evaluator_gate(transcript: &str) -> Option<EvaluatorOutcome> {
     // Run evaluator
     match evaluate(transcript, provider).await {
         Ok(result) => {
-            // Confidence gate:reject 路徑(BackgroundNoise)在 confidence
-            // < threshold 時不 skip(LLM 不夠確定就不應該擋掉 user 真指令)。
-            let skip = if matches!(result.intent, Intent::BackgroundNoise) {
-                if result.confidence < confidence_threshold {
-                    tracing::info!(
-                        intent = ?result.intent,
-                        reason = %result.reason,
-                        confidence = result.confidence,
-                        threshold = confidence_threshold,
-                        "evaluator: confidence too low to skip — fallthrough to agent",
-                    );
-                    false
-                } else {
-                    true
+            // 三種 intent 分流:
+            // - BackgroundNoise + confidence >= threshold → Skip
+            // - BackgroundNoise + confidence < threshold → 不夠確定,Proceed
+            // - Unclear + ask_back_enabled → AskBack(用 LLM 給的 question,沒有兜底)
+            // - Unclear + ask_back_disabled → Proceed(舊行為)
+            // - AddressMori → Proceed
+            let outcome = match result.intent {
+                Intent::BackgroundNoise => {
+                    if result.confidence < confidence_threshold {
+                        tracing::info!(
+                            intent = ?result.intent,
+                            reason = %result.reason,
+                            confidence = result.confidence,
+                            threshold = confidence_threshold,
+                            "evaluator: confidence too low to skip — fallthrough to agent",
+                        );
+                        EvaluatorOutcome::Proceed {
+                            reason: result.reason.clone(),
+                        }
+                    } else {
+                        EvaluatorOutcome::Skip {
+                            reason: format!("{}(confidence {:.2})", result.reason, result.confidence),
+                        }
+                    }
                 }
-            } else {
-                false
+                Intent::Unclear if ask_back_enabled => {
+                    let question = result
+                        .clarifying_question
+                        .clone()
+                        .filter(|q| !q.trim().is_empty())
+                        .unwrap_or_else(|| DEFAULT_ASK_BACK_QUESTION.to_string());
+                    EvaluatorOutcome::AskBack {
+                        reason: result.reason.clone(),
+                        question,
+                    }
+                }
+                Intent::Unclear | Intent::AddressMori => EvaluatorOutcome::Proceed {
+                    reason: result.reason.clone(),
+                },
+            };
+            let outcome_kind = match &outcome {
+                EvaluatorOutcome::Proceed { .. } => "proceed",
+                EvaluatorOutcome::Skip { .. } => "skip",
+                EvaluatorOutcome::AskBack { .. } => "ask_back",
             };
             tracing::info!(
                 intent = ?result.intent,
                 reason = %result.reason,
                 confidence = result.confidence,
-                skip,
+                outcome = outcome_kind,
                 "evaluator: result",
             );
             // Phase 6 event log:evaluator 每次判斷都記 — 給 Logs tab filter
             // 「給我看所有 evaluator skip 但 confidence 不高的」之類 query。
-            mori_core::event_log::append(serde_json::json!({
+            let mut entry = serde_json::json!({
                 "kind": "evaluator_decision",
                 "intent": format!("{:?}", result.intent),
                 "reason": result.reason,
                 "confidence": result.confidence,
                 "confidence_threshold": confidence_threshold,
-                "skip": skip,
-            }));
-            Some(EvaluatorOutcome {
-                skip,
-                reason: if skip {
-                    format!("{}(confidence {:.2})", result.reason, result.confidence)
-                } else {
-                    result.reason
-                },
-            })
+                "outcome": outcome_kind,
+                // backward-compat:舊版 Logs UI 還在用 skip:bool。Skip outcome 才是 true。
+                "skip": matches!(outcome, EvaluatorOutcome::Skip { .. }),
+            });
+            if let EvaluatorOutcome::AskBack { question, .. } = &outcome {
+                entry["clarifying_question"] = serde_json::Value::String(question.clone());
+            }
+            mori_core::event_log::append(entry);
+            Some(outcome)
         }
         Err(e) => {
             tracing::warn!(error = %e, "evaluator: evaluate() failed — skipping gate");
@@ -2761,23 +2807,33 @@ async fn run_agent_pipeline(
     routing: Arc<mori_core::llm::Routing>,
 ) {
     // Phase 3C:evaluator pre-gate — config 開啟時,先過 fast LLM 判 user 是不是
-    // 在跟 Mori 講話。Background noise → 直接 skip agent + 進 Done(空 response)。
-    // AddressMori / Unclear → 走原本 agent flow。
+    // 在跟 Mori 講話。三種 outcome:
+    //   Skip    → background noise,直接 Phase::Done(`(背景噪音 — ...)`)。
+    //   AskBack → Unclear,Mori 用 clarifying_question 反問 + TTS 念,**不**走 agent。
+    //   Proceed → AddressMori / 不夠確定的 noise / ask-back 關時的 Unclear,走 agent。
     let evaluator_t0 = std::time::Instant::now();
-    if let Some(EvaluatorOutcome { skip, reason }) = evaluator_gate(&transcript).await {
+    let evaluator_outcome = evaluator_gate(&transcript).await;
+    if let Some(outcome) = &evaluator_outcome {
         let evaluator_ms = evaluator_t0.elapsed().as_millis() as u64;
+        let (reason, skipped) = match outcome {
+            EvaluatorOutcome::Proceed { reason } => (reason.clone(), false),
+            EvaluatorOutcome::Skip { reason } => (reason.clone(), true),
+            EvaluatorOutcome::AskBack { reason, .. } => (reason.clone(), true),
+        };
         // Phase B:record evaluator timing + result snapshot
         if let Some(rec) = state.recording_session.lock().as_mut() {
             rec.add_evaluator_ms(evaluator_ms);
             rec.set_evaluator(recordings::EvaluatorSnapshot {
                 enabled: true,
                 intent: None, // 細節在 reason 內,簡化先不細拆
-                reason: Some(reason.clone()),
+                reason: Some(reason),
                 confidence: None,
-                skipped: skip,
+                skipped,
             });
         }
-        if skip {
+    }
+    match evaluator_outcome {
+        Some(EvaluatorOutcome::Skip { reason }) => {
             tracing::info!(reason, "evaluator: background noise — skipping agent");
             let _ = app.emit(
                 "evaluator-rejected",
@@ -2802,6 +2858,51 @@ async fn run_agent_pipeline(
                 },
             );
             return;
+        }
+        Some(EvaluatorOutcome::AskBack { reason, question }) => {
+            tracing::info!(reason, question, "evaluator: unclear — Mori asks back");
+            // 把反問句也寫進 conversation history(以 assistant 身份)— 下次
+            // user 再 wake 講「我是想說...」時,agent 看得到上下文。
+            {
+                let mut conv = state.conversation.lock();
+                conv.push(ChatMessage::user(transcript.clone()));
+                conv.push(ChatMessage::assistant_with_tool_calls(
+                    Some(question.clone()),
+                    Vec::new(),
+                ));
+                let max_msgs = MAX_HISTORY_PAIRS * 2;
+                while conv.len() > max_msgs {
+                    conv.remove(0);
+                }
+            }
+            let _ = app.emit(
+                "evaluator-ask-back",
+                serde_json::json!({
+                    "transcript": transcript,
+                    "question": question,
+                    "reason": reason,
+                }),
+            );
+            // TTS 念出反問句(若 tts.enabled,否則 silent — UI 仍會顯示)。
+            tts::speak_async(question.clone(), app.clone());
+            // Phase B:finalize session(ask-back path)— response 用 question 兜
+            if let Some(rec) = state.recording_session.lock().take() {
+                let mut rec = rec;
+                rec.set_response(question.clone());
+                rec.finalize();
+            }
+            state.set_phase(
+                &app,
+                Phase::Done {
+                    transcript,
+                    response: question,
+                    skill_calls: vec![],
+                },
+            );
+            return;
+        }
+        Some(EvaluatorOutcome::Proceed { .. }) | None => {
+            // fallthrough 給 agent
         }
     }
 

--- a/crates/mori-tauri/tauri.conf.json
+++ b/crates/mori-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Mori",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "identifier": "ai.yazelin.mori",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -138,7 +138,9 @@ Mori 還不能開口說話。要補:
 **留 v0.6.x**:
 - Phase 3A.2 — Custom wake-word phrase UI(目前只有 CLI 訓練,要 UI 化 + Windows
   piper-phonemize 跨平台修)
-- Phase 3C.2 — Ask-back UI(Intent::Unclear 時 Mori 反問 + 自動重進 Listening)
+- ✅ Phase 3C.2 — Ask-back(Intent::Unclear → Mori 用 TTS 反問 + 寫進
+  conversation 給下次 wake 當 context)— v0.6.3。**自動**重進 Listening 留到
+  下個迭代(目前 user 需手動再 wake)
 - TTS 中斷支援(Ctrl+Alt+Esc 停 sink)+ sentence streaming
 - Speaker enrollment 進度 real-time UI(目前 modal 是純 JS 倒數,Python 已 emit JSON event 待 Rust forward)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mori-desktop",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "scripts": {
     "predev": "cargo build -p mori-cli",

--- a/src/tabs/ConfigTab.tsx
+++ b/src/tabs/ConfigTab.tsx
@@ -1745,6 +1745,21 @@ function ConfigTab({
                 }
               />
             </FormRow>
+            <FormRow
+              label="ask_back_enabled"
+              hint="LLM 判 unclear(半截話 / 模糊起頭)時,讓 Mori 用 TTS 反問(例「然後呢?」)而不是強跑 agent。預設 ON — 啟用 evaluator 通常就想要這個分流。OFF → unclear 當 address_mori 走 agent(舊行為)。即使 TTS 沒開,反問句也會在 ChatPanel 顯示。"
+            >
+              <input
+                type="checkbox"
+                checked={cfg.evaluator?.ask_back_enabled !== false}
+                onChange={(e) =>
+                  applyPatch((c) => {
+                    const ev = ensureSubObj(c, "evaluator");
+                    ev.ask_back_enabled = e.target.checked;
+                  })
+                }
+              />
+            </FormRow>
           </Section>
 
           {/* ── Phase 3D: Mori 講話(edge-tts speak-back)── */}


### PR DESCRIPTION
## Summary

- Phase 3C.2 收尾 — evaluator 判 `unclear`(半截話 / 模糊起頭)時,Mori 用 TTS 反問,不浪費 agent loop 亂回半截話
- LLM 在 `intent=unclear` 時順便產 `clarifying_question`(短句、口語、20 字內,例「然後呢?」「你想做什麼?跟我說」);沒給時 fallback 預設句「可以再說清楚一點嗎?」
- `EvaluatorOutcome` 從 `struct { skip, reason }` 重構成 `enum { Proceed, Skip, AskBack }` — 三種 intent 顯式分流
- Bump 0.6.2 → 0.6.3

## 行為

| Intent | 過去 | 這版 |
|---|---|---|
| `address_mori` | → agent | → agent(同) |
| `background_noise` + 高 confidence | → Skip(假對話) | → Skip(同) |
| `background_noise` + 低 confidence | → fallthrough agent | → fallthrough(同) |
| `unclear` | → 當 address_mori 強跑 agent | **→ ask-back:TTS 念反問句 + 寫 conversation 給下次 wake 看** |

新 config `evaluator.ask_back_enabled`(預設 ON)— 不想要可單獨關。

## 細節

- Ask-back 把 `transcript`(原半截話)+ 反問句以 user/assistant 寫進 conversation,trim 同正常 agent 流(`MAX_HISTORY_PAIRS * 2`)
- emit `evaluator-ask-back` event 給未來 UI 加 chip 用(目前 ChatPanel 還沒 listen)
- event log `evaluator_decision` 加 `outcome` (`proceed` / `skip` / `ask_back`) + 反問時加 `clarifying_question` 欄位;`skip:bool` 保留向後相容
- ConfigTab Evaluator section 加 `ask_back_enabled` toggle + 中文 hint

## Test plan

- [x] `cargo test -p mori-core --lib evaluator` — 7 passed,新增 2 個 ask-back parser test
- [x] `bash scripts/verify.sh` — build + 208 tests + workspace check 全綠
- [ ] 手動驗:`evaluator.enabled = true` + `ask_back_enabled = true`,故意講半截話(「然後...」「嗯那個...」)→ Mori 應該反問而不是亂跑 agent
- [] 手動驗:`ask_back_enabled = false` → unclear 退回舊 agent 行為
- [ ] 手動驗:`tts.enabled = true` → 反問會用聲音念

🤖 Generated with [Claude Code](https://claude.com/claude-code)