### PR TITLE
feat(chat-panel): ChatPanel ask-back chip — Mori 反問時 bubble 標 ✦ chip

### DIFF
--- a/src/ChatPanel.tsx
+++ b/src/ChatPanel.tsx
@@ -132,6 +132,11 @@ function ChatPanel() {
   // 5A-3b: fallback chain 觸發時 backend 推 system message,渲染在 thread 內。
   // 每次 recording / transcribing 重置(新 pipeline 開始時清舊訊息)。
   const [systemMessages, setSystemMessages] = useState<FallbackSystemMessage[]>([]);
+  // Phase 3C.2:ask-back chip — 收 evaluator-ask-back event 時把 question 文字
+  // 記下,ChatBubble 跟 conv[i].content 比對就能標 chip。
+  // 不 dedup / 不 cap 因為單次 session 內 ask-back 不會多;page reload 清空也可接受
+  //(過去 turn 失去 chip 但內容仍在)。
+  const [askBackQuestions, setAskBackQuestions] = useState<Set<string>>(() => new Set());
 
   const threadRef = useRef<HTMLDivElement | null>(null);
 
@@ -191,6 +196,18 @@ function ChatPanel() {
     const unlistenSys = listen<FallbackSystemMessage>("chat-system-message", (e) => {
       setSystemMessages((prev) => [...prev, e.payload]);
     });
+    // Phase 3C.2:evaluator 判 Unclear → 後端 emit `evaluator-ask-back`,
+    // 把 clarifying question 文字記下來,ChatBubble 拿來 match conv[i].content 標 chip。
+    const unlistenAskBack = listen<{ question: string }>("evaluator-ask-back", (e) => {
+      const q = e.payload?.question?.trim();
+      if (!q) return;
+      setAskBackQuestions((prev) => {
+        if (prev.has(q)) return prev;
+        const next = new Set(prev);
+        next.add(q);
+        return next;
+      });
+    });
 
     return () => {
       unlistenPhase.then((f) => f());
@@ -200,6 +217,7 @@ function ChatPanel() {
       unlistenCtx.then((f) => f());
       unlistenSys.then((f) => f());
       unlistenProfileSwitched.then((f) => f());
+      unlistenAskBack.then((f) => f());
     };
   }, []);
 
@@ -325,9 +343,13 @@ function ChatPanel() {
           </div>
         )}
         {conv.map((turn, i) => (
-          <ChatBubble key={i} turn={turn} />
+          <ChatBubble
+            key={i}
+            turn={turn}
+            isAskBack={turn.role === "assistant" && askBackQuestions.has(turn.content.trim())}
+          />
         ))}
-        {inProgress && <ChatBubble turn={inProgress} />}
+        {inProgress && <ChatBubble turn={inProgress} isAskBack={false} />}
         {/* 5A-3b: fallback chain 觸發時的提示行(每次 pipeline 開始清空) */}
         {systemMessages.map((sm, i) => (
           <div key={`sys-${i}`} className="mori-chat-system">
@@ -444,7 +466,7 @@ function ChatPanel() {
   );
 }
 
-function ChatBubble({ turn }: { turn: ChatTurn }) {
+function ChatBubble({ turn, isAskBack = false }: { turn: ChatTurn; isAskBack?: boolean }) {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
   const copy = async () => {
@@ -463,9 +485,14 @@ function ChatBubble({ turn }: { turn: ChatTurn }) {
     ? t("chat_panel.role_user")
     : "Mori";
   return (
-    <div className={`mori-bubble ${turn.role}`}>
+    <div className={`mori-bubble ${turn.role}${isAskBack ? " askback" : ""}`}>
       <span className="role-label">
         {isVoice && <IconMic width={11} height={11} />} {label}
+        {isAskBack && (
+          <span className="askback-chip" title={t("chat_panel.askback_chip_title")}>
+            ✦ {t("chat_panel.askback_chip_label")}
+          </span>
+        )}
       </span>
       {/* 語音輸入 bubble 加右上角複製鈕 — user 之前抱怨「轉錄完就消失」,
           這個讓他能事後 grab transcripts 再貼到別處用 */}

--- a/src/chat-panel.css
+++ b/src/chat-panel.css
@@ -177,6 +177,28 @@
   color: var(--c-mono-color);
 }
 
+/* Phase 3C.2:ask-back chip — Mori 判 user 話不完整時用 TTS 反問,
+   chat bubble 標個小 chip 讓 user 一眼看出「這是反問,不是普通回答」。
+   用 warning token(yellow tint),不是 danger(紅 = 真錯誤)。 */
+.mori-bubble .askback-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: var(--c-warning-bg);
+  border: 1px solid var(--c-warning-border);
+  color: var(--c-warning-text);
+  font-size: 9.5px;
+  letter-spacing: 0.2px;
+  cursor: help;
+}
+/* 連 bubble-body 也輕微染色提示,但比 chip 淡很多 — 不搶眼 */
+.mori-bubble.assistant.askback .bubble-body {
+  border-color: var(--c-warning-border);
+}
+
 /* ── voice_input bubble:dictation 紀錄(灰、italic 內容、右上 copy 鈕) ── */
 .mori-bubble.voice_input .role-label {
   display: inline-flex;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -190,6 +190,8 @@
     "role_voice_input": "Voice input",
     "role_empty": "(empty)",
     "copy_voice_input": "Copy this voice input",
+    "askback_chip_label": "ask-back",
+    "askback_chip_title": "Mori thought your message was incomplete and is asking you to clarify (evaluator: Intent::Unclear)",
     "session_path_x11": "x11 · via tauri-plugin-global-shortcut",
     "session_path_wayland": "wayland · via xdg-desktop-portal",
     "session_path_linux_other": "linux (tty / unset) · global hotkey unavailable, UI buttons still work",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -190,6 +190,8 @@
     "role_voice_input": "語音輸入",
     "role_empty": "(空)",
     "copy_voice_input": "複製這筆語音輸入內容",
+    "askback_chip_label": "反問",
+    "askback_chip_title": "Mori 認為你的話不完整,在請你說清楚一點(evaluator: Intent::Unclear)",
     "session_path_x11": "x11 · 走 tauri-plugin-global-shortcut",
     "session_path_wayland": "wayland · 走 xdg-desktop-portal",
     "session_path_linux_other": "linux (tty / 未設) · 全域熱鍵失效，UI 按鈕仍可用",


### PR DESCRIPTION
## Summary

v0.6.3 ship ask-back 時 backend 已 emit `evaluator-ask-back` event,但 ChatPanel 沒 listen,user 在 chat 看不出哪句是「Mori 反問」哪句是「Mori 回答」。這版補上 visual gap。

- listen `evaluator-ask-back` → 把 question text 記進 `askBackQuestions` Set(state-local,page reload 重置不持久化,過去 turn 失去 chip 但內容仍在)
- ChatBubble 多 `isAskBack` prop,`turn.role === "assistant"` 且 `content` match Set 時標小 chip「✦ 反問」
- chip 用 `--c-warning-*` theme token(yellow tint,非紅 — 不是錯誤是提示)
- bubble border 同色輕微染色,不搶眼
- 對應 zh-TW + en i18n keys

PR 1/4 voice UX polish 線。

## Test plan

- [x] `npm run build` — vite build pass
- [ ] 手動驗:`evaluator.enabled = true` + `ask_back_enabled = true`,故意講半截話 → Mori bubble 應該標 ✦ chip
- [ ] 手動驗:light + dark theme 都顯示對(chip 用 `--c-warning-*` token,理論上自動跟主題)
- [ ] 手動驗:hover chip 出 tooltip 解釋為什麼是反問

🤖 Generated with [Claude Code](https://claude.com/claude-code)