### PR TITLE
feat(tts): TTS 中斷 — Ctrl+Alt+Esc 停 sink + 新 tts_stop IPC

### DIFF
--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -144,6 +144,13 @@ pub struct AppState {
     /// 重讀更新 → 改完即時生效不必重啟。Listener 永遠掛 PRESSED + RELEASED,在
     /// handler 內讀這個 mutex 決定 dispatch。
     pub toggle_mode: Mutex<hotkey_config::ToggleMode>,
+    /// Phase 3D.2:當前正在播的 TTS sink。`speak_async` 把 Sink 包 Arc 存進這裡,
+    /// `synth_and_play` 跑完(或被 stop)後清回 None。Ctrl+Alt+Esc abort handler
+    /// 在 phase 跟 recording / pipeline 都沒事時,take + stop() 中斷 TTS 播放。
+    /// `Sink` 透過內部 `Arc<Mutex<…>>` 是 Send+Sync,所以可跨 task 共享。
+    /// 外層用 `Arc<Mutex<…>>` 是為了讓 `speak_async` 可以 clone 出去帶進
+    /// spawn_blocking。
+    pub tts_sink: Arc<Mutex<Option<Arc<rodio::Sink>>>>,
 }
 
 impl AppState {
@@ -2884,7 +2891,7 @@ async fn run_agent_pipeline(
                 }),
             );
             // TTS 念出反問句(若 tts.enabled,否則 silent — UI 仍會顯示)。
-            tts::speak_async(question.clone(), app.clone());
+            tts::speak_async(question.clone(), app.clone(), state.tts_sink.clone());
             // Phase B:finalize session(ask-back path)— response 用 question 兜
             if let Some(rec) = state.recording_session.lock().take() {
                 let mut rec = rec;
@@ -3275,7 +3282,7 @@ async fn run_agent_pipeline(
             // Phase 3D:agent response 完成 → 若 tts.enabled,背景 spawn edge-tts
             // 念出 response。預設 OFF,user 在 Config tab 主動 enable 才會講話。
             // 不擋 UI update — speak_async 立刻 return,實際合成 + 播放在 tokio task。
-            tts::speak_async(response.clone(), app.clone());
+            tts::speak_async(response.clone(), app.clone(), state.tts_sink.clone());
 
             // Phase B:finalize session — 把 response / skill_calls / profile / provider
             // 都灌進 SessionRecord 後寫到 ~/.mori/recordings/<ts>/。
@@ -4383,6 +4390,7 @@ fn main() {
         // 5T: 啟動先用 default(Toggle),setup 讀 ~/.mori/config.json 後覆寫成
         // 實際值(見下方 hotkey_config 載入處)。
         toggle_mode: Mutex::new(hotkey_config::ToggleMode::default()),
+        tts_sink: Arc::new(Mutex::new(None)),
     });
 
     if let Some(key) = GroqProvider::discover_api_key() {
@@ -4503,6 +4511,7 @@ fn main() {
             wake_sound::wake_ack_upload,
             wake_sound::wake_ack_delete_alternate,
             tts::tts_preview,
+            tts::tts_stop,
             speaker_id::speaker_id_status,
             speaker_id::speaker_id_enroll,
             speaker_id::speaker_id_clear,
@@ -5188,6 +5197,8 @@ fn main() {
             });
 
             // 5J: Ctrl+Alt+Esc — 全域中斷
+            // - 第一階段:正在播 TTS → 停 sink(Phase 已是 Done,所以這條走在 phase
+            //   match 之前不影響其他邏輯)
             // - Phase::Recording → 停錄音 + 丟掉音檔不送 STT
             // - Phase::Transcribing / Responding → abort pipeline task,
             //   kill_on_drop 讓 claude / gemini / codex 子程序連帶 SIGKILL
@@ -5195,6 +5206,20 @@ fn main() {
             let handle_cancel = app.handle().clone();
             let state_for_cancel = state_for_setup.clone();
             app.listen(hotkey_config::PORTAL_CANCEL_EVENT, move |_event| {
+                // Phase 3D.2:先嘗試 stop TTS(任何 phase 都可能正在播 — speak_async
+                // 是 fire-and-forget tokio task,Phase 已是 Done 後 sink 還在跑)
+                let tts_stopped = {
+                    let taken = state_for_cancel.tts_sink.lock().take();
+                    match taken {
+                        Some(sink) => {
+                            sink.stop();
+                            tracing::info!("Ctrl+Alt+Esc — TTS sink stopped");
+                            true
+                        }
+                        None => false,
+                    }
+                };
+
                 let phase = state_for_cancel.phase.lock().clone();
                 match phase {
                     Phase::Recording { .. } => {
@@ -5227,7 +5252,9 @@ fn main() {
                         state_for_cancel.set_phase(&handle_cancel, Phase::Idle);
                     }
                     _ => {
-                        tracing::debug!(?phase, "Ctrl+Alt+Esc fired but no in-flight work — ignored");
+                        if !tts_stopped {
+                            tracing::debug!(?phase, "Ctrl+Alt+Esc fired but no in-flight work — ignored");
+                        }
                     }
                 }
             });

--- a/crates/mori-tauri/src/tts.rs
+++ b/crates/mori-tauri/src/tts.rs
@@ -19,19 +19,25 @@
 //!
 //! ## 中斷
 //!
-//! 暫時不支援中斷正在播的 TTS(後續可加 `Mutex<Option<Sink>>` 共享 state
-//! + Ctrl+Alt+Esc handler 呼叫 sink.stop)。目前 TTS 開始就會放完。
+//! `speak_async` 把 `Sink` 包 `Arc` 存進 `AppState::tts_sink` slot,Ctrl+Alt+Esc
+//! 全域 abort handler 在 Phase 跟 recording / pipeline 都沒事時,take +
+//! `sink.stop()` 中斷正在播的 TTS。Sink 內部是 `Arc<Mutex<…>>`,Send+Sync 安全。
 
 use std::fs;
 use std::io::{BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::Arc;
 use std::time::SystemTime;
 
+use parking_lot::Mutex;
 use rodio::{Decoder, OutputStream, Sink, Source};
 use tauri::AppHandle;
 
 use crate::mori_dir;
+
+/// 共享 `Sink` slot 的型別 alias — `AppState::tts_sink` 用。
+pub type TtsSinkSlot = Arc<Mutex<Option<Arc<Sink>>>>;
 
 /// Bundled mori-tts-edge.py(Phase 3D)— Python edge-tts bridge script。
 /// `ensure_script_deployed` 在 user dir 沒檔時寫一份過去當預設,user 可覆寫。
@@ -142,9 +148,9 @@ fn read_config() -> TtsConfig {
 /// 公開入口 — agent response 完成時呼叫。立刻 return,實際合成 + 播放在
 /// tokio task 內背景跑。失敗只 log warn,不影響 Phase::Done UI 更新。
 ///
-/// `_app` 目前沒用上,保留 signature 給未來「emit tts-started / tts-finished
-/// event 讓 UI 顯示 "Mori 在講話" 」用。
-pub fn speak_async(text: String, _app: AppHandle) {
+/// `sink_slot` — 共享的 `AppState::tts_sink`。synth_and_play 會把當前 Sink 塞
+/// 進去,Ctrl+Alt+Esc abort handler 拿到後就能 stop。
+pub fn speak_async(text: String, _app: AppHandle, sink_slot: TtsSinkSlot) {
     let cfg = read_config();
     if !cfg.enabled {
         return;
@@ -168,13 +174,15 @@ pub fn speak_async(text: String, _app: AppHandle) {
     }
 
     tokio::task::spawn_blocking(move || {
-        if let Err(e) = synth_and_play(&cfg, &text) {
+        if let Err(e) = synth_and_play(&cfg, &text, &sink_slot) {
             tracing::warn!(error = %e, "tts: synth_and_play failed");
         }
+        // 跑完(或 stop 後 sleep_until_end 返回)把 slot 清空,給下一輪 TTS 用
+        *sink_slot.lock() = None;
     });
 }
 
-fn synth_and_play(cfg: &TtsConfig, text: &str) -> anyhow::Result<()> {
+fn synth_and_play(cfg: &TtsConfig, text: &str, sink_slot: &TtsSinkSlot) -> anyhow::Result<()> {
     // 用 timestamp 避免並發 collision。/tmp 上 OS 開機重啟自動清。
     let ts = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -229,9 +237,15 @@ fn synth_and_play(cfg: &TtsConfig, text: &str) -> anyhow::Result<()> {
 
     let (_stream, handle) =
         OutputStream::try_default().map_err(|e| anyhow::anyhow!("no audio output: {e}"))?;
-    let sink = Sink::try_new(&handle).map_err(|e| anyhow::anyhow!("sink create: {e}"))?;
+    let sink = Arc::new(Sink::try_new(&handle).map_err(|e| anyhow::anyhow!("sink create: {e}"))?);
     sink.append(source.convert_samples::<i16>());
+    // 把 sink 放進共享 slot,abort handler 可以 stop。先放再 sleep,確保
+    // 即使 sleep 一開始就被 stop(極短音檔)也能正確返回。
+    *sink_slot.lock() = Some(sink.clone());
     sink.sleep_until_end();
+    // sleep 返回後不管是自然結束或 stop() 都把 slot 拿掉(speak_async 那邊也會
+    // 兜底清,雙保險)。
+    *sink_slot.lock() = None;
 
     // 3. cleanup
     let _ = fs::remove_file(&out_mp3);
@@ -240,8 +254,14 @@ fn synth_and_play(cfg: &TtsConfig, text: &str) -> anyhow::Result<()> {
 }
 
 /// IPC command — 試聽 voice。給 ConfigTab UI 用。
+///
+/// Preview 走的 sink 也塞共享 slot,所以 Ctrl+Alt+Esc 也能中斷預覽。
 #[tauri::command]
-pub async fn tts_preview(text: Option<String>, voice: Option<String>) -> Result<(), String> {
+pub async fn tts_preview(
+    state: tauri::State<'_, std::sync::Arc<crate::AppState>>,
+    text: Option<String>,
+    voice: Option<String>,
+) -> Result<(), String> {
     let mut cfg = read_config();
     if let Some(v) = voice {
         cfg.voice = v;
@@ -261,9 +281,25 @@ pub async fn tts_preview(text: Option<String>, voice: Option<String>) -> Result<
             cfg.script_path.display()
         ));
     }
-    tokio::task::spawn_blocking(move || synth_and_play(&cfg, &sample_text))
+    let sink_slot = state.tts_sink.clone();
+    tokio::task::spawn_blocking(move || synth_and_play(&cfg, &sample_text, &sink_slot))
         .await
         .map_err(|e| format!("join: {e}"))?
         .map_err(|e| format!("synth/play: {e}"))?;
     Ok(())
+}
+
+/// IPC command — 立刻中斷正在播的 TTS(若有)。回 `true` 表示有 sink 被 stop。
+/// Ctrl+Alt+Esc abort handler 跟未來 UI 「停止講話」按鈕都呼這個。
+#[tauri::command]
+pub fn tts_stop(state: tauri::State<'_, std::sync::Arc<crate::AppState>>) -> bool {
+    let taken = state.tts_sink.lock().take();
+    match taken {
+        Some(sink) => {
+            sink.stop();
+            tracing::info!("tts: sink stopped via tts_stop");
+            true
+        }
+        None => false,
+    }
 }


### PR DESCRIPTION
## Summary

TTS 開了就會把整段 response 念完,長回應沒法中途停。這版讓 Ctrl+Alt+Esc 不只 abort recording / pipeline,也 stop 正在播的 TTS sink。

- `AppState::tts_sink: Arc<Mutex<Option<Arc<Sink>>>>` 共享 slot
- `synth_and_play` 建 Sink 後包 Arc 塞 slot,sleep_until_end 後清回 None
- `tts::speak_async` 收 slot 參數,call site(agent done / ask-back)補上
- `tts_preview` 也走同 slot,preview 試聽也可中斷
- 新 IPC `tts_stop` 給未來 UI 「停止講話」按鈕用(本 PR 不加按鈕)
- abort handler 在 phase 跟 recording / pipeline match 之前先嘗試 stop TTS — 一個 hotkey 三種 abort,語義一致

Sink 內部是 `Arc<Mutex<…>>`,Send+Sync 跨 task 共享安全;OutputStream 留在 spawn_blocking 內,生命期跟著 sleep_until_end 走。

PR 2/4 voice UX polish 線。

## Test plan

- [x] `bash scripts/verify.sh` 全綠(208 tests + workspace check)
- [ ] 手動驗:`tts.enabled = true` 念長 response 中途按 Ctrl+Alt+Esc → 立刻停
- [ ] 手動驗:ask-back 也走同條 → 反問念到一半 Esc 也能停
- [ ] 手動驗:TTS preview(Config tab)念到一半 Esc 也能停
- [ ] 手動驗:沒在播 TTS 時按 Esc → 走原本的 recording/pipeline abort 邏輯

🤖 Generated with [Claude Code](https://claude.com/claude-code)