### PR TITLE
feat(logs): Logs tab outcome filter + 5 個新 event kind 進 dropdown

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -39,6 +39,7 @@
     "date_label": "Date",
     "kind_label": "Kind",
     "provider_label": "Provider",
+    "outcome_label": "Outcome",
     "refresh_title": "Reload",
     "loading": "Loading…",
     "empty_title": "No logs yet",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -39,6 +39,7 @@
     "date_label": "日期",
     "kind_label": "Kind",
     "provider_label": "Provider",
+    "outcome_label": "Outcome",
     "refresh_title": "重新讀取",
     "loading": "讀取中…",
     "empty_title": "尚無 log",

--- a/src/shell.css
+++ b/src/shell.css
@@ -1444,6 +1444,29 @@
 }
 .mori-logs-status.ok { color: var(--c-success-text); }
 .mori-logs-status.err { color: var(--c-danger-text); }
+/* evaluator_decision outcome chip — 三色對應三種 path */
+.mori-logs-outcome {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 6px;
+  font-size: 10px;
+  letter-spacing: 0.2px;
+  border: 1px solid var(--c-border);
+}
+.mori-logs-outcome.proceed {
+  background: var(--c-success-bg);
+  color: var(--c-success-text);
+  border-color: var(--c-border-strong);
+}
+.mori-logs-outcome.skip {
+  background: var(--c-input-bg);
+  color: var(--c-text-muted);
+}
+.mori-logs-outcome.ask_back {
+  background: var(--c-warning-bg);
+  color: var(--c-warning-text);
+  border-color: var(--c-warning-border);
+}
 .mori-logs-error {
   margin-top: 4px;
   font-size: 11px;

--- a/src/tabs/LogsTab.tsx
+++ b/src/tabs/LogsTab.tsx
@@ -23,7 +23,24 @@ type LogEntry = {
   [k: string]: unknown;
 };
 
-const KIND_FILTERS = ["all", "llm_call", "spawn_error", "skill_dispatch", "transcribe", "error"];
+const KIND_FILTERS = [
+  "all",
+  "llm_call",
+  "spawn_error",
+  "skill_dispatch",
+  "transcribe",
+  "error",
+  // Phase 3 events
+  "evaluator_decision",
+  "wake_word_event",
+  "speaker_id_pass",
+  "speaker_id_reject",
+  "agent_completed",
+];
+
+/// `evaluator_decision` 的 `outcome` 欄位三種值。selected kind = evaluator_decision
+/// 時才顯示這個 sub-filter。`skip` 跟舊 `skip:bool` field 是 backward-compat 對應的。
+const OUTCOME_FILTERS = ["all", "proceed", "skip", "ask_back"];
 
 function formatTs(ts: string | undefined): string {
   if (!ts) return "";
@@ -54,6 +71,7 @@ function LogsTab() {
   const [loading, setLoading] = useState(true);
   const [kindFilter, setKindFilter] = useState<string>("all");
   const [providerFilter, setProviderFilter] = useState<string>("all");
+  const [outcomeFilter, setOutcomeFilter] = useState<string>("all");
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
 
   const loadDates = useCallback(async () => {
@@ -107,9 +125,17 @@ function LogsTab() {
     return entries.filter((e) => {
       if (kindFilter !== "all" && e.kind !== kindFilter) return false;
       if (providerFilter !== "all" && e.provider !== providerFilter) return false;
+      // outcome filter 只在 kind=evaluator_decision 時有意義。其他 kind 永遠通過。
+      if (
+        outcomeFilter !== "all" &&
+        kindFilter === "evaluator_decision" &&
+        e.outcome !== outcomeFilter
+      ) {
+        return false;
+      }
       return true;
     });
-  }, [entries, kindFilter, providerFilter]);
+  }, [entries, kindFilter, providerFilter, outcomeFilter]);
 
   const refresh = () => {
     loadDates();
@@ -157,6 +183,16 @@ function LogsTab() {
             options={providers.map((p) => ({ value: p, label: p }))}
           />
         </label>
+        {kindFilter === "evaluator_decision" && (
+          <label className="mori-logs-toolbar-field">
+            <span>{t("logs_tab.outcome_label")}</span>
+            <Select
+              value={outcomeFilter}
+              onChange={setOutcomeFilter}
+              options={OUTCOME_FILTERS.map((o) => ({ value: o, label: o }))}
+            />
+          </label>
+        )}
         <button className="mori-btn" onClick={refresh} title={t("logs_tab.refresh_title")}>
           <IconRefresh width={13} height={13} />
         </button>
@@ -186,6 +222,10 @@ function LogsTab() {
                 <div className="mori-logs-row-head">
                   <span className="mori-logs-ts">{formatTs(e.ts)}</span>
                   <span className="mori-logs-kind">{e.kind ?? "—"}</span>
+                  {/* evaluator_decision 多 outcome chip,跟 kind 連著看一眼就懂 */}
+                  {e.kind === "evaluator_decision" && typeof e.outcome === "string" && (
+                    <span className={`mori-logs-outcome ${e.outcome}`}>{e.outcome}</span>
+                  )}
                   {e.provider && <span className="mori-logs-provider">{e.provider}</span>}
                   {e.model && <span className="mori-logs-model">{e.model}</span>}
                   {e.latency_ms != null && (


### PR DESCRIPTION
## Summary

v0.6.3 ship ask-back 時 event_log `evaluator_decision` 加了 `outcome` 欄位(`proceed`/`skip`/`ask_back`),但 Logs tab 沒消費 — user 想找「所有 ask-back」沒得選。這版補上。

- `KIND_FILTERS` 補進 5 個 Phase 3 event:`evaluator_decision` / `wake_word_event` / `speaker_id_pass` / `speaker_id_reject` / `agent_completed`(過去這些都被當成 kind=other 沒辦法獨立 filter)
- 新 `outcomeFilter` state + `OUTCOME_FILTERS` dropdown,**只有當 `kindFilter === evaluator_decision` 時顯示**
- log row 在 `kind=evaluator_decision` 時多顯示 outcome chip(三色:`proceed`=success bg,`skip`=灰,`ask_back`=warning bg),一眼看出三種 path
- zh-TW + en i18n 補 `outcome_label` key

PR 3/4 voice UX polish 線。

## Test plan

- [x] `npm run build` — vite build pass
- [ ] 手動驗:Logs tab kind=`evaluator_decision` → 看到三色 outcome chip,outcome filter 下拉出來
- [ ] 手動驗:選 outcome=`ask_back` → 只剩反問 event
- [ ] 手動驗:換 kind 不是 evaluator_decision → outcome filter 自動藏起
- [ ] 手動驗:light + dark theme 三色 chip 都對(用 `--c-*` token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)