### PR TITLE
docs(v0.5.2 leftover): 3 頁文件 — logs / installed-apps / prompt-engineering

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -494,6 +494,18 @@
     <div class="doc-name">Profile 範本 →</div>
     <div class="doc-desc">Agent + VoiceInput starter pack(實體檔在 <code>examples/</code>)</div>
   </a>
+  <a class="doc-card" href="logs.html">
+    <div class="doc-name">Logs →</div>
+    <div class="doc-desc">7 層 event log + Logs tab filter + outcome chip 結構說明</div>
+  </a>
+  <a class="doc-card" href="installed-apps.html">
+    <div class="doc-name">Installed Apps Catalog →</div>
+    <div class="doc-desc">Mori 開機掃本機 app(Phase C),<code>open_app</code> skill 不亂猜 binary</div>
+  </a>
+  <a class="doc-card" href="prompt-engineering.html">
+    <div class="doc-name">Prompt Engineering →</div>
+    <div class="doc-desc">怎麼寫 AGENT.md / USER.md profile · system prompt 結構 · anti-injection</div>
+  </a>
   <a class="doc-card" href="troubleshooting.html">
     <div class="doc-name">Troubleshooting →</div>
     <div class="doc-desc">Whisper / 全域熱鍵 / cargo deps 等常見問題</div>

--- a/docs/installed-apps.html
+++ b/docs/installed-apps.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+<meta charset="utf-8">
+<title>Mori — Installed Apps Catalog</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="icon" type="image/png" href="sprites/logo.png">
+<link rel="stylesheet" href="_book.css">
+<meta property="og:title" content="Mori — 靜靜記得你經過的痕跡">
+<meta property="og:description" content="Mori 開機時掃一輪本機 .desktop / Start Menu / Applications,寫進 installed-apps catalog。open_app skill 拿到「打開 Slack」就照表查到 exec,不亂猜 binary 名。">
+<meta property="og:image" content="https://yazelin.github.io/mori-desktop/og-image.png">
+<meta property="og:url" content="https://yazelin.github.io/mori-desktop/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Mori">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Mori — Installed Apps">
+<meta name="twitter:description" content="開機掃 .desktop / Start Menu 寫成 catalog,open_app skill 不亂猜">
+<meta name="twitter:image" content="https://yazelin.github.io/mori-desktop/og-image.png">
+</head>
+<body>
+
+<header class="book-header">
+  <img class="book-logo" src="sprites/logo.png" alt="Mori logo">
+  <div>
+    <h1>Mori</h1>
+    <div class="book-title-sub">DOCS</div>
+  </div>
+  <nav class="book-nav">
+    <a href="index.html">Home</a>
+    <a href="getting-started.html">Getting Started</a>
+    <a href="dwelling-rite.html">宿靈儀式</a>
+    <a href="hotkeys.html">Hotkeys</a>
+    <a href="providers.html">Providers</a>
+    <a href="mori-home.html">~/.mori/</a>
+    <a href="profile-examples.html">Profile 範本</a>
+    <a href="design-book.html">Design Book</a>
+    <a href="https://github.com/yazelin/mori-desktop">GitHub</a>
+  </nav>
+</header>
+
+<h1 class="page-title">Installed Apps Catalog</h1>
+<div class="page-subtitle">PHASE C · OPEN_APP 不亂猜</div>
+
+<p>Mori 想幫你「打開 Slack」前,要先知道 Slack 在哪。早期版本 <code>open_app</code> 是 LLM 猜 binary 名(<code>slack</code> / <code>Slack</code> / <code>com.tinyspeck.slackmacgap</code>?),經常猜錯。Phase C 改成:Mori 開機掃本機已裝的 app,寫進 <strong>installed-apps catalog</strong>,LLM 拿到「Slack」就照表查 exec。</p>
+
+<h2 id="layout">檔案位置</h2>
+
+<pre><code>~/.mori/installed-apps.linux.json    # Linux
+~/.mori/installed-apps.windows.json  # Windows
+~/.mori/installed-apps.macos.json    # macOS(未支援)
+</code></pre>
+
+<p>檔名帶 OS 後綴是因為 Mori 可能跨多機(同 vault sync),catalog 跟本機綁。</p>
+
+<h2 id="scan-sources">掃描來源</h2>
+
+<table style="border-collapse: collapse; margin: 12px 0;">
+  <tr style="border-bottom: 1px solid var(--c-beige);">
+    <th style="text-align: left; padding: 6px 12px;">OS</th>
+    <th style="text-align: left; padding: 6px 12px;">掃哪些路徑</th>
+  </tr>
+  <tr style="border-bottom: 1px solid var(--c-beige);">
+    <td style="padding: 6px 12px;">Linux</td>
+    <td style="padding: 6px 12px;">
+      <code>/usr/share/applications/</code><br>
+      <code>/usr/local/share/applications/</code><br>
+      <code>~/.local/share/applications/</code><br>
+      <code>/var/lib/flatpak/exports/share/applications/</code>(Flatpak)<br>
+      <code>~/.local/share/flatpak/exports/share/applications/</code>
+    </td>
+  </tr>
+  <tr>
+    <td style="padding: 6px 12px;">Windows</td>
+    <td style="padding: 6px 12px;">
+      <code>%PROGRAMDATA%\Microsoft\Windows\Start Menu\Programs</code><br>
+      <code>%APPDATA%\Microsoft\Windows\Start Menu\Programs</code><br>
+      遞迴掃 <code>.lnk</code> shortcut 抓 target
+    </td>
+  </tr>
+</table>
+
+<h2 id="schema">Catalog 結構</h2>
+
+<pre><code>{
+  "os": "linux",
+  "scanned_at": "2026-05-19T08:00:00Z",
+  "apps": [
+    {
+      "name": "Slack",
+      "exec": "/usr/bin/slack",
+      "aliases": ["slack"],
+      "categories": ["Network", "InstantMessaging"]
+    },
+    {
+      "name": "Firefox Web Browser",
+      "exec": "/usr/bin/firefox",
+      "aliases": ["firefox", "Firefox"],
+      "categories": ["Network", "WebBrowser"]
+    }
+  ]
+}
+</code></pre>
+
+<p><code>aliases</code> 含 .desktop 的 <code>X-AppName</code> / GenericName / 中文名等多種寫法,LLM 拿到使用者口語(「火狐」/「FF」)有更大機會 match。</p>
+
+<h2 id="rescan">重新掃描</h2>
+
+<p>三種觸發:</p>
+
+<ul>
+  <li><strong>開機自動</strong> — mori-tauri 啟動時跑一次,失敗只 log warn 不擋啟動</li>
+  <li><strong>裝完新 app 後</strong> — catalog 沒更新前,Mori 不會看到新 app。手動 rescan:刪掉 catalog file Mori 下次開機重掃</li>
+  <li><strong>每 24h 自動</strong> — 若 catalog 太舊(<code>scanned_at</code> 超過 24h),下次開機重掃</li>
+</ul>
+
+<h2 id="open-app-skill">open_app skill 怎麼用 catalog</h2>
+
+<p>LLM 看到使用者說「打開 Slack」,呼叫 <code>open_app(name: "Slack")</code>。skill 內部:</p>
+
+<ol>
+  <li>讀 catalog 找名稱 / alias match(含 fuzzy)</li>
+  <li>找到 → 用平台 API 啟動(Linux <code>xdg-open</code> / Windows <code>ShellExecuteExW</code>)</li>
+  <li>找不到 → 回 LLM「Mori 沒看到這個 app,要不要先裝?」,不亂猜 binary</li>
+</ol>
+
+<h2 id="privacy">隱私</h2>
+
+<p>Catalog 是純本機檔,Mori 不會上傳。LLM 看到的是 catalog snippet 不是全部資料 — system prompt 只塞「app 名 + 是否安裝」,不塞 exec 路徑(那會洩漏系統結構)。</p>
+
+<p>不想 Mori 知道某個 app → 手動編輯 catalog 刪掉那行(下次開機可能重新加回來,要永久排除可加到 <code>~/.mori/installed-apps.ignore</code>,一行一個正則,catalog 規劃中)。</p>
+
+</body>
+</html>

--- a/docs/logs.html
+++ b/docs/logs.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+<meta charset="utf-8">
+<title>Mori — Logs</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="icon" type="image/png" href="sprites/logo.png">
+<link rel="stylesheet" href="_book.css">
+<meta property="og:title" content="Mori — 靜靜記得你經過的痕跡">
+<meta property="og:description" content="Mori 把每一輪 voice pipeline / agent call 拆 7 層各自寫一條 event log,~/.mori/logs/ 是 append-only JSONL。Logs tab 可篩 kind / outcome / provider。">
+<meta property="og:image" content="https://yazelin.github.io/mori-desktop/og-image.png">
+<meta property="og:url" content="https://yazelin.github.io/mori-desktop/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Mori">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Mori — Logs">
+<meta name="twitter:description" content="觀測 7 層 voice pipeline + filter / outcome / event 結構">
+<meta name="twitter:image" content="https://yazelin.github.io/mori-desktop/og-image.png">
+</head>
+<body>
+
+<header class="book-header">
+  <img class="book-logo" src="sprites/logo.png" alt="Mori logo">
+  <div>
+    <h1>Mori</h1>
+    <div class="book-title-sub">DOCS</div>
+  </div>
+  <nav class="book-nav">
+    <a href="index.html">Home</a>
+    <a href="getting-started.html">Getting Started</a>
+    <a href="dwelling-rite.html">宿靈儀式</a>
+    <a href="hotkeys.html">Hotkeys</a>
+    <a href="providers.html">Providers</a>
+    <a href="mori-home.html">~/.mori/</a>
+    <a href="profile-examples.html">Profile 範本</a>
+    <a href="design-book.html">Design Book</a>
+    <a href="https://github.com/yazelin/mori-desktop">GitHub</a>
+  </nav>
+</header>
+
+<h1 class="page-title">Logs</h1>
+<div class="page-subtitle">EVENT LOG · 7-LAYER OBSERVABILITY</div>
+
+<p>Mori 把每一輪 voice pipeline / agent call 拆成 <strong>7 個 layer</strong>,每層做完寫一條 JSONL event 到 <code>~/.mori/logs/mori-YYYY-MM-DD.jsonl</code>。Append-only、一天一檔、明文 JSON,不需要 DB。</p>
+
+<h2 id="layers">7 個 layer</h2>
+
+<p>從 wake event 觸發到 Mori 回應完成,事件鏈大致是:</p>
+
+<ol>
+  <li><code>wake_word_event</code> — Hey Mori 偵測到,score / threshold</li>
+  <li><code>speaker_id_pass</code> / <code>speaker_id_reject</code> — 聲紋比對(若 <code>speaker_id.enabled</code>)</li>
+  <li><code>transcribe</code> — Whisper STT 出 transcript</li>
+  <li><code>evaluator_decision</code> — 過 fast LLM 判 intent(若 <code>evaluator.enabled</code>)</li>
+  <li><code>llm_call</code> — agent 跑時主 LLM call,可能多輪(tool calls)</li>
+  <li><code>skill_dispatch</code> — agent 呼叫某個 skill(translate / polish / shell skill / 動作 skill 等)</li>
+  <li><code>agent_completed</code> — 該輪 agent loop 全部 done,寫 response_chars + skill_calls list</li>
+</ol>
+
+<p>另外還有獨立事件:<code>spawn_error</code>(CLI provider 啟動失敗)、<code>error</code>(雜項)。</p>
+
+<h2 id="logs-tab">Logs tab</h2>
+
+<p>主視窗左側 sidebar 「Logs」 tab:</p>
+
+<ul>
+  <li><strong>日期</strong> — 預設今天,可選任一有 log 的日期</li>
+  <li><strong>Kind</strong> — 篩特定 layer 的 event,例 <code>evaluator_decision</code> 看所有意圖判斷</li>
+  <li><strong>Provider</strong> — 篩特定 LLM provider(<code>groq</code> / <code>gemini</code> / <code>claude-bash</code> 等)</li>
+  <li><strong>Outcome</strong> — 只有當 Kind = <code>evaluator_decision</code> 時顯示;可篩 <code>proceed</code>(走 agent)/ <code>skip</code>(背景噪音)/ <code>ask_back</code>(Mori 反問)</li>
+</ul>
+
+<p>每筆 row 點開 → 看完整 JSON。Evaluator row 額外顯示三色 outcome chip(綠 = proceed,灰 = skip,黃 = ask_back),不展開也看得出該輪走哪條路。</p>
+
+<h2 id="schema-evaluator">Schema 範例 — evaluator_decision</h2>
+
+<pre><code>{
+  "ts": "2026-05-19T15:30:42.123Z",
+  "kind": "evaluator_decision",
+  "intent": "Unclear",
+  "reason": "半截話",
+  "confidence": 0.68,
+  "confidence_threshold": 0.85,
+  "outcome": "ask_back",
+  "skip": true,
+  "clarifying_question": "然後呢?"
+}</code></pre>
+
+<p>Intent 三種:<code>AddressMori</code> / <code>BackgroundNoise</code> / <code>Unclear</code>。Outcome 三種:<code>proceed</code> / <code>skip</code> / <code>ask_back</code>。<code>clarifying_question</code> 只在 <code>outcome=ask_back</code> 時出現。</p>
+
+<h2 id="schema-llm">Schema 範例 — llm_call</h2>
+
+<pre><code>{
+  "ts": "2026-05-19T15:30:43.456Z",
+  "kind": "llm_call",
+  "provider": "gemini",
+  "model": "gemini-2.5-flash",
+  "latency_ms": 1340,
+  "ok": true,
+  "output_chars": 280,
+  "tool_calls": ["translate"]
+}</code></pre>
+
+<h2 id="vs-recordings">Logs vs Recordings</h2>
+
+<p>兩個系統互補:</p>
+
+<table style="border-collapse: collapse; margin: 12px 0;">
+  <tr style="border-bottom: 1px solid var(--c-beige);">
+    <th style="text-align: left; padding: 6px 12px;">系統</th>
+    <th style="text-align: left; padding: 6px 12px;">用途</th>
+    <th style="text-align: left; padding: 6px 12px;">大小</th>
+  </tr>
+  <tr style="border-bottom: 1px solid var(--c-beige);">
+    <td style="padding: 6px 12px;"><code>~/.mori/logs/</code></td>
+    <td style="padding: 6px 12px;">事件摘要 — filter / 統計 / 找 pattern</td>
+    <td style="padding: 6px 12px;">輕(~KB / 天)</td>
+  </tr>
+  <tr>
+    <td style="padding: 6px 12px;"><code>~/.mori/recordings/</code></td>
+    <td style="padding: 6px 12px;">每輪完整 I/O(audio / transcript / prompt / context)— 重播、訓資料、debug</td>
+    <td style="padding: 6px 12px;">重(~MB / session)</td>
+  </tr>
+</table>
+
+<p>Logs 永遠開啟、留 30+ 天無壓力。Recordings 預設保留 14 天可調(Recordings tab → retention)。</p>
+
+<h2 id="privacy">隱私</h2>
+
+<p>兩個目錄都 100% 本機,Mori 不會上傳到任何雲端。要刪自己刪:</p>
+
+<pre><code>rm -rf ~/.mori/logs/
+rm -rf ~/.mori/recordings/
+</code></pre>
+
+<p>Logs tab 沒提供 UI 刪除單筆 — 因為 logs 是 append-only diagnostic data,刪單筆失去意義。Recordings tab 有 per-session 刪 + retention 自動清。</p>
+
+</body>
+</html>

--- a/docs/prompt-engineering.html
+++ b/docs/prompt-engineering.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+<meta charset="utf-8">
+<title>Mori — Prompt Engineering</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="icon" type="image/png" href="sprites/logo.png">
+<link rel="stylesheet" href="_book.css">
+<meta property="og:title" content="Mori — 靜靜記得你經過的痕跡">
+<meta property="og:description" content="怎麼寫 AGENT.md / USER.md profile。System prompt 結構、context section、anti-injection、tone & persona、什麼該寫進 profile 什麼留給 memory。">
+<meta property="og:image" content="https://yazelin.github.io/mori-desktop/og-image.png">
+<meta property="og:url" content="https://yazelin.github.io/mori-desktop/">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Mori">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Mori — Prompt Engineering">
+<meta name="twitter:description" content="profile 結構、system prompt 結構、anti-injection、tone & persona">
+<meta name="twitter:image" content="https://yazelin.github.io/mori-desktop/og-image.png">
+</head>
+<body>
+
+<header class="book-header">
+  <img class="book-logo" src="sprites/logo.png" alt="Mori logo">
+  <div>
+    <h1>Mori</h1>
+    <div class="book-title-sub">DOCS</div>
+  </div>
+  <nav class="book-nav">
+    <a href="index.html">Home</a>
+    <a href="getting-started.html">Getting Started</a>
+    <a href="dwelling-rite.html">宿靈儀式</a>
+    <a href="hotkeys.html">Hotkeys</a>
+    <a href="providers.html">Providers</a>
+    <a href="mori-home.html">~/.mori/</a>
+    <a href="profile-examples.html">Profile 範本</a>
+    <a href="design-book.html">Design Book</a>
+    <a href="https://github.com/yazelin/mori-desktop">GitHub</a>
+  </nav>
+</header>
+
+<h1 class="page-title">Prompt Engineering</h1>
+<div class="page-subtitle">怎麼寫 AGENT.md / USER.md</div>
+
+<p>Mori 把 system prompt 拆成三層,你只需要管 <strong>profile body</strong>(persona + 行為指示),context section + memory index 是 Rust 自動注入。</p>
+
+<h2 id="prompt-layers">System prompt 三層</h2>
+
+<pre><code>┌─────────────────────────────────────────────────┐
+│  Profile body (persona + 你寫的行為規則)        │  ← 你管這層
+│  例:「你是 Mori,森林精靈的口吻,繁中回答...」 │
+├─────────────────────────────────────────────────┤
+│  Context section (Rust 自動,每輪 wake 重抓)    │  ← Rust 注入
+│  - active window / app / process name           │
+│  - clipboard preview + selection                │
+│  - urls detected                                │
+│  - cursor position (若可得)                    │
+├─────────────────────────────────────────────────┤
+│  Memory index (~/.mori/memory/MEMORY.md)        │  ← Rust 注入
+│  記憶系統的 index 摘要(完整內容 lazy load)    │
+└─────────────────────────────────────────────────┘
+</code></pre>
+
+<p>Profile body 跟下兩層用 <code>---</code> 分隔。LLM 看到 user 訊息時,前面有完整三層,後面接 conversation history,最後是當輪 user input。</p>
+
+<h2 id="frontmatter">Frontmatter</h2>
+
+<p>每個 profile .md 開頭可以有 YAML frontmatter,設定 routing / skill enable:</p>
+
+<pre><code>---
+# provider: claude-bash           # 留 comment 教學;沒設 → 走 config 全域 provider
+agent_mode: builtin              # builtin / dispatch / chat-only
+enable_read: true                # body 內 #file: 引用其他 .md 才有效
+enabled_skills:                  # 列哪些 skill 開,其他全關
+  - translate
+  - polish
+  - remember
+  - recall_memory
+  - open_app
+shell_skills:                    # 自訂 shell wrapper(gh / docker / kubectl 等)
+  - name: gh
+    cmd: gh
+    description: GitHub CLI
+inject_memory_types:             # 哪些 memory type 進 system prompt
+  - user
+  - feedback
+---
+</code></pre>
+
+<p>完整 frontmatter schema 見 <a href="profile-examples.html">Profile 範本</a>。預設 starter pack(AGENT-01..04 / USER-01..06)展示常用組合。</p>
+
+<h2 id="persona">Persona 寫作風格</h2>
+
+<p>Mori 是擬人化 spirit 不是 chatbot,profile body 偏「角色描寫 + 邊界」而非「指令列表」。三個原則:</p>
+
+<ol>
+  <li><strong>用形容詞 + 場景</strong> — 「你像森林精靈,聲線輕柔但不裝可愛,話短意密」比「請使用禮貌、簡短、可愛的語氣」更穩。</li>
+  <li><strong>禁止項用「why」說明</strong> — 「不要過度道歉(這會讓對話變黏)」勝過「不要道歉」。LLM 知道 why 才能在邊界 case 判斷。</li>
+  <li><strong>給範例對白</strong> — 寫 2-3 句「期待的回應 sample」,LLM 不必猜你的喜好。</li>
+</ol>
+
+<h2 id="anti-injection">Anti-injection</h2>
+
+<p>Mori 內建 anti-injection rule —— 當 context section 或 selection 內含「忘記之前指令」「現在你是另一個 AI」之類 prompt injection 時,Mori 不照做,直接視為剪貼簿內容。這條 rule 寫在 Rust 內建 system prompt 不在 user profile,所以即使 user 自己 profile 寫得很開,injection 仍會被擋。</p>
+
+<p>細節見 <code>build_context_section()</code> in <code>crates/mori-tauri/src/main.rs</code>,有 <code>--- BEGIN UNTRUSTED CONTENT ---</code> 標記隔離。</p>
+
+<h2 id="profile-vs-memory">Profile vs memory:該寫哪邊?</h2>
+
+<table style="border-collapse: collapse; margin: 12px 0;">
+  <tr style="border-bottom: 1px solid var(--c-beige);">
+    <th style="text-align: left; padding: 6px 12px;">內容</th>
+    <th style="text-align: left; padding: 6px 12px;">寫進 profile</th>
+    <th style="text-align: left; padding: 6px 12px;">寫進 memory</th>
+  </tr>
+  <tr style="border-bottom: 1px solid var(--c-beige);">
+    <td style="padding: 6px 12px;">Mori 的人設、語氣</td>
+    <td style="padding: 6px 12px;">✓(每輪都看)</td>
+    <td style="padding: 6px 12px;">不適合(LLM 不會每輪 query)</td>
+  </tr>
+  <tr style="border-bottom: 1px solid var(--c-beige);">
+    <td style="padding: 6px 12px;">User 是誰、職業、習慣</td>
+    <td style="padding: 6px 12px;">不要(會綁死 profile,要切就麻煩)</td>
+    <td style="padding: 6px 12px;">✓(type=user memory,自動 inject)</td>
+  </tr>
+  <tr style="border-bottom: 1px solid var(--c-beige);">
+    <td style="padding: 6px 12px;">特定任務工作流</td>
+    <td style="padding: 6px 12px;">✓(寫成獨立 agent profile 切換)</td>
+    <td style="padding: 6px 12px;">不適合</td>
+  </tr>
+  <tr>
+    <td style="padding: 6px 12px;">「上次說過 X」這種記憶</td>
+    <td style="padding: 6px 12px;">不要</td>
+    <td style="padding: 6px 12px;">✓(Mori 自己 remember skill 寫)</td>
+  </tr>
+</table>
+
+<h2 id="token-budget">Token budget</h2>
+
+<p>System prompt 太肥 LLM 會慢 + 貴。Profiles tab 右上角有 token 估算 chip,把 profile body + memory index 加起來估值:</p>
+
+<ul>
+  <li><strong>gpt-oss-120b (o200k_harmony)</strong> — 完整估算</li>
+  <li><strong>Gemini Flash</strong> — 估算(略不準,Gemini tokenizer 跟 OpenAI 差)</li>
+</ul>
+
+<p>建議 system prompt 控在 <strong>2000 tokens 以下</strong>(profile body 加上 context 加 memory index)。超過會明顯慢。</p>
+
+<h2 id="iteration">迭代 prompt 的 SOP</h2>
+
+<ol>
+  <li>跑一輪正常對話</li>
+  <li>到 Recordings tab 點開那次 session</li>
+  <li>看 <code>system-prompt.txt</code>(完整三層 prompt LLM 看的)</li>
+  <li>看 <code>response.txt</code> 不對勁的地方</li>
+  <li>改 profile body 對應 section</li>
+  <li>Profiles tab 按「切換」(下一輪 hotkey 即時生效,不必重啟 Mori)</li>
+</ol>
+
+<p>Recordings 是觀測 prompt 的金牌工具 — 看見完整 prompt 比靠想像 debug 強 10 倍。</p>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

補 v0.5.2 release notes 提到的 3 頁 onboarding 文件 — 過去這些功能 ship 了但沒寫 doc。

| 頁面 | 對應功能 |
|---|---|
| `docs/logs.html` | 7 層 event log 結構 + Logs tab kind/outcome/provider filter + outcome chip(v0.6.3 ask-back 新增) |
| `docs/installed-apps.html` | Phase C `installed-apps.<os>.json` catalog,`open_app` skill 不亂猜 binary |
| `docs/prompt-engineering.html` | 怎麼寫 AGENT.md / USER.md · system prompt 三層結構 · anti-injection · profile vs memory |

`docs/index.html` 加 3 個 doc-card link。沒動全域 nav 避免擠爆。

## Test plan

- [ ] 開 `docs/index.html` 看 3 個新 card 出現
- [ ] 每頁能正常開啟、style 跟 hotkeys.html / troubleshooting.html 一致
- [ ] 內部連結(logs↔recordings、prompt-engineering↔profile-examples)沒斷

純文件 PR,無 code 改動,無版號 bump。

🤖 Generated with [Claude Code](https://claude.com/claude-code)