### PR TITLE
feat(wake-word): custom phrase UI — Hey Mori section 加 model picker + 訓練指令 helper

### DIFF
--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -271,6 +271,27 @@ fn update_wake_word_listener(state: &AppState, app: &AppHandle, prev: Mode, new:
     }
 }
 
+/// IPC — 在 Listening mode 時 drop + 重 spawn wake-word listener,
+/// 拿到新 config(例 user 剛 switch model 後)。其他 mode → noop。
+/// 回 `true` 代表真的 restart;`false` 代表 not in Listening mode。
+#[tauri::command]
+fn wake_word_restart_listener(
+    app: AppHandle,
+    state: tauri::State<'_, Arc<AppState>>,
+) -> bool {
+    let mode = *state.mode.lock();
+    if !matches!(mode, Mode::Listening) {
+        tracing::info!(?mode, "wake_word_restart_listener: not in Listening, skip");
+        return false;
+    }
+    // 假裝離開後重進 Listening 把 listener 重啟 — 利用既有
+    // update_wake_word_listener 的 entering/leaving 分支邏輯。
+    update_wake_word_listener(&state, &app, Mode::Listening, Mode::Agent);
+    update_wake_word_listener(&state, &app, Mode::Agent, Mode::Listening);
+    tracing::info!("wake_word_restart_listener: drop + respawn done");
+    true
+}
+
 /// `ModeController` 實作給 mori-core 的 `SetModeSkill` 用 — 這樣 skill
 /// 在 mori-core 不依賴 Tauri,也能改 Mode。
 struct StateModeController {
@@ -4522,6 +4543,10 @@ fn main() {
             recordings::recordings_stats,
             recordings::recordings_cleanup_now,
             recordings::recordings_set_retention_days,
+            wake_word::wake_word_list_models,
+            wake_word::wake_word_set_model,
+            wake_word::wake_word_train_command,
+            wake_word_restart_listener,
         ])
         .on_window_event(|window, event| {
             // 關視窗時不殺 app — 隱藏到系統匣繼續跑(像 Slack / Discord)

--- a/crates/mori-tauri/src/wake_word.rs
+++ b/crates/mori-tauri/src/wake_word.rs
@@ -303,6 +303,136 @@ pub fn config_from_disk(mori_dir: &Path) -> WakeWordConfig {
     }
 }
 
+// ─── IPC commands(給 ConfigTab Hey Mori section 的 model picker 用)──────
+
+#[derive(Debug, serde::Serialize)]
+pub struct WakeModelInfo {
+    /// `~/.mori/wakeword/` 下的 .onnx 完整 path。
+    pub path: String,
+    /// 不含副檔名的 slug(顯示用,例 `hey-mori` / `mori-起床`)。
+    pub slug: String,
+    /// 檔案 bytes(顯示用,讓 user 看出 bundled 205KB vs 自訓 ~1-5MB)。
+    pub size_bytes: u64,
+    /// Modified UNIX seconds(顯示用,自訓新 model 排上面)。
+    pub modified_secs: u64,
+    /// 是否為當前 active model(config.json `/listening_mode/model_path`)。
+    pub is_active: bool,
+}
+
+/// 掃 `~/.mori/wakeword/*.onnx`(不遞迴),回 list 給 UI dropdown。
+/// 失敗(目錄不存在 / 讀取出錯)回空 vec — UI 會顯示「沒可選 model」。
+#[tauri::command]
+pub fn wake_word_list_models() -> Vec<WakeModelInfo> {
+    let mori = crate::mori_dir();
+    let dir = mori.join("wakeword");
+    let active = config_from_disk(&mori).model_path;
+    let mut out: Vec<WakeModelInfo> = std::fs::read_dir(&dir)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.path()
+                .extension()
+                .map(|x| x.eq_ignore_ascii_case("onnx"))
+                .unwrap_or(false)
+        })
+        .filter_map(|e| {
+            let path = e.path();
+            let meta = e.metadata().ok()?;
+            let slug = path.file_stem()?.to_string_lossy().into_owned();
+            let modified_secs = meta
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            Some(WakeModelInfo {
+                is_active: path == active,
+                path: path.to_string_lossy().into_owned(),
+                slug,
+                size_bytes: meta.len(),
+                modified_secs,
+            })
+        })
+        .collect();
+    // newest first
+    out.sort_by(|a, b| b.modified_secs.cmp(&a.modified_secs));
+    out
+}
+
+/// 切換 active wake-word model。寫 config 後**不**自動重啟 listener — 呼叫端
+/// 再決定要不要呼 `wake_word_restart_listener`(在 Listening mode 時才重啟)。
+#[tauri::command]
+pub fn wake_word_set_model(path: String) -> Result<(), String> {
+    let target = PathBuf::from(&path);
+    if !target.exists() {
+        return Err(format!("model 檔不存在:{path}"));
+    }
+    if target
+        .extension()
+        .map(|e| !e.eq_ignore_ascii_case("onnx"))
+        .unwrap_or(true)
+    {
+        return Err("只接受 .onnx 副檔名".into());
+    }
+    let mori = crate::mori_dir();
+    let cfg_path = mori.join("config.json");
+    let mut json: serde_json::Value = std::fs::read_to_string(&cfg_path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+    let lm = json
+        .as_object_mut()
+        .ok_or_else(|| "config.json 不是 object".to_string())?
+        .entry("listening_mode".to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    let lm_obj = lm
+        .as_object_mut()
+        .ok_or_else(|| "config.json /listening_mode 不是 object".to_string())?;
+    lm_obj.insert("model_path".to_string(), serde_json::json!(path));
+    std::fs::create_dir_all(&mori).map_err(|e| format!("mkdir ~/.mori: {e}"))?;
+    std::fs::write(
+        &cfg_path,
+        serde_json::to_string_pretty(&json).map_err(|e| format!("serialize: {e}"))?,
+    )
+    .map_err(|e| format!("write {}: {e}", cfg_path.display()))?;
+    tracing::info!(path, "wake_word_set_model saved");
+    Ok(())
+}
+
+/// 給 UI 顯示「複製這行到 terminal 跑」用 — 不在 UI 內 spawn 訓練(訓練 30-50
+/// 分鐘 + 需要 ~10GB datasets,不適合 UI inline streaming)。Linux only,
+/// Windows 因 piper-phonemize wheel 不全暫無法本機訓。
+#[tauri::command]
+pub fn wake_word_train_command(phrase: String) -> Result<String, String> {
+    let phrase = phrase.trim();
+    if phrase.is_empty() {
+        return Err("phrase 不能空".into());
+    }
+    if phrase.len() > 60 {
+        return Err("phrase 太長(>60 字元)".into());
+    }
+    // 簡單 shell-escape — 只允許單引號 wrap,內含單引號 → 用 '\'' 接;
+    // 不允許控制字元(避免 user 貼進 newline 之類)。
+    if phrase
+        .chars()
+        .any(|c| c.is_control())
+    {
+        return Err("phrase 不能含控制字元".into());
+    }
+    let escaped = phrase.replace('\'', "'\\''");
+    let mori = crate::mori_dir();
+    let venv_py = mori.join("wake-train-venv").join("bin").join("python");
+    let script = mori.join("bin").join("mori-wake-train.py");
+    Ok(format!(
+        "{} {} '{}'",
+        venv_py.display(),
+        script.display(),
+        escaped
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tabs/ConfigTab.tsx
+++ b/src/tabs/ConfigTab.tsx
@@ -1688,6 +1688,7 @@ function ConfigTab({
                 }
               />
             </FormRow>
+            <WakeWordModelPicker />
           </Section>
 
           {/* Wake-ack 應答音(獨立 Section,Phase 3A.1.2)*/}
@@ -2275,6 +2276,223 @@ function ConfigTab({
         </div>
       </div>
     </div>
+  );
+}
+
+// ─── Wake-word model picker(Phase 3A.2)─────────────────────────────
+//
+// 列 ~/.mori/wakeword/*.onnx 給 user 選,套用後若在 Listening mode 自動 restart
+// listener。訓練本身 30-50 分鐘 + 需 ~10GB datasets,不適合 UI inline —
+// 給「複製 CLI 指令到 terminal 跑」按鈕 + 訓完按 refresh 重抓 model list。
+
+type WakeModelInfo = {
+  path: string;
+  slug: string;
+  size_bytes: number;
+  modified_secs: number;
+  is_active: boolean;
+};
+
+function formatModelSize(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function WakeWordModelPicker() {
+  const [models, setModels] = useState<WakeModelInfo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [trainPhrase, setTrainPhrase] = useState("");
+  const [trainCmd, setTrainCmd] = useState("");
+  const [showTrainHelper, setShowTrainHelper] = useState(false);
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      const list = await invoke<WakeModelInfo[]>("wake_word_list_models");
+      setModels(list);
+    } catch (e) {
+      console.error("wake_word_list_models", e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const flash = (m: string) => {
+    setMsg(m);
+    setTimeout(() => setMsg(null), 3000);
+  };
+
+  const applyModel = async (path: string) => {
+    try {
+      await invoke("wake_word_set_model", { path });
+      const restarted = await invoke<boolean>("wake_word_restart_listener");
+      flash(
+        restarted
+          ? "✓ 已套用 + 重啟 listener(Listening mode)"
+          : "✓ 已套用(下次進 Listening mode 生效)",
+      );
+      await refresh();
+    } catch (e) {
+      flash(`套用失敗:${String(e)}`);
+    }
+  };
+
+  const genTrainCmd = async () => {
+    setTrainCmd("");
+    try {
+      const cmd = await invoke<string>("wake_word_train_command", { phrase: trainPhrase });
+      setTrainCmd(cmd);
+    } catch (e) {
+      flash(String(e));
+    }
+  };
+
+  const copyCmd = async () => {
+    try {
+      await navigator.clipboard.writeText(trainCmd);
+      flash("✓ 已複製到剪貼簿,貼到 terminal 跑");
+    } catch (e) {
+      flash(`copy failed: ${String(e)}`);
+    }
+  };
+
+  return (
+    <FormRow
+      label="custom model"
+      hint="切換 wake-word 模型(`~/.mori/wakeword/*.onnx`)。bundled hey-mori.onnx 是 TTS-only 通用版,訓練自己的 phrase / 對自己聲線 fine-tune 命中率高很多。訓練流程見 examples/scripts/README.wake-train.md(30-50 分鐘 + ~10GB datasets,Linux only)。"
+    >
+      <div style={{ display: "flex", flexDirection: "column", gap: 6, width: "100%" }}>
+        <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
+          {loading ? (
+            <span style={{ fontSize: 12, color: "var(--c-text-muted)" }}>讀取中...</span>
+          ) : models.length === 0 ? (
+            <span style={{ fontSize: 12, color: "var(--c-text-muted)" }}>
+              ~/.mori/wakeword/ 沒任何 .onnx — 開機應該會放 bundled 進去,確認跑過 Mori 一次
+            </span>
+          ) : (
+            models.map((m) => (
+              <button
+                key={m.path}
+                onClick={() => !m.is_active && applyModel(m.path)}
+                disabled={m.is_active}
+                title={`${m.path}\n${formatModelSize(m.size_bytes)} · modified ${new Date(m.modified_secs * 1000).toLocaleString()}`}
+                style={{
+                  padding: "4px 10px",
+                  borderRadius: 6,
+                  fontSize: 12,
+                  cursor: m.is_active ? "default" : "pointer",
+                  background: m.is_active ? "var(--c-active-bg)" : "var(--c-input-bg)",
+                  border: m.is_active
+                    ? "1px solid var(--c-active-border)"
+                    : "1px solid var(--c-border)",
+                  color: m.is_active ? "var(--c-icon-active)" : "var(--c-text)",
+                }}
+              >
+                {m.is_active && "● "}
+                {m.slug}
+                <span style={{ marginLeft: 6, fontSize: 10, color: "var(--c-text-muted)" }}>
+                  {formatModelSize(m.size_bytes)}
+                </span>
+              </button>
+            ))
+          )}
+          <button
+            className="mori-btn small ghost"
+            onClick={refresh}
+            style={{ fontSize: 11, marginLeft: 6 }}
+          >
+            ↻
+          </button>
+          <button
+            className="mori-btn small ghost"
+            onClick={() => setShowTrainHelper((v) => !v)}
+            style={{ fontSize: 11 }}
+          >
+            {showTrainHelper ? "收起訓練" : "訓練新 phrase"}
+          </button>
+        </div>
+        {msg && (
+          <span style={{ fontSize: 11, color: "var(--c-text-muted)" }}>{msg}</span>
+        )}
+        {showTrainHelper && (
+          <div
+            style={{
+              marginTop: 4,
+              padding: 10,
+              background: "var(--c-input-bg)",
+              border: "1px solid var(--c-border)",
+              borderRadius: 6,
+              fontSize: 12,
+              color: "var(--c-text)",
+            }}
+          >
+            <p style={{ margin: "0 0 6px", color: "var(--c-text-muted)" }}>
+              訓練在 terminal 跑(30-50 分鐘,Linux only)。
+              先依照 <code>examples/scripts/README.wake-train.md</code> 做一次性 setup,
+              然後輸入 phrase 產生指令貼到 terminal 跑。完成後按 ↻ refresh 抓新 model。
+            </p>
+            <div style={{ display: "flex", gap: 6 }}>
+              <input
+                type="text"
+                placeholder='例:"Hey Mori" / "嘿 小森"'
+                value={trainPhrase}
+                onChange={(e) => setTrainPhrase(e.target.value)}
+                style={{
+                  flex: 1,
+                  padding: "4px 8px",
+                  fontSize: 12,
+                  background: "var(--c-surface-bg)",
+                  color: "var(--c-text)",
+                  border: "1px solid var(--c-border)",
+                  borderRadius: 4,
+                }}
+              />
+              <button
+                className="mori-btn small ghost"
+                onClick={genTrainCmd}
+                disabled={!trainPhrase.trim()}
+              >
+                產生指令
+              </button>
+            </div>
+            {trainCmd && (
+              <div
+                style={{
+                  marginTop: 8,
+                  padding: 8,
+                  background: "var(--c-surface-bg)",
+                  border: "1px solid var(--c-border)",
+                  borderRadius: 4,
+                  fontFamily: "ui-monospace, monospace",
+                  fontSize: 11,
+                  color: "var(--c-mono-color)",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                }}
+              >
+                <code style={{ flex: 1, whiteSpace: "pre-wrap", wordBreak: "break-all" }}>
+                  {trainCmd}
+                </code>
+                <button
+                  className="mori-btn small ghost"
+                  onClick={copyCmd}
+                  style={{ fontSize: 11, flexShrink: 0 }}
+                >
+                  複製
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </FormRow>
   );
 }
 


### PR DESCRIPTION
## Summary

Phase 3A.2 — 過去要換 wake-word phrase / model 必須手動編輯 config.json 加切 Listening mode 來回。這版 UI 一鍵搞定。訓練本身留指令 helper(30-50 分鐘 + ~10GB datasets,不適合 UI inline)。

## 新 IPC(4 個)

- `wake_word_list_models` — 掃 `~/.mori/wakeword/*.onnx` 回 list,標 active
- `wake_word_set_model(path)` — 寫 `listening_mode.model_path` 進 config.json
- `wake_word_restart_listener` — 若在 Listening mode → drop + 重 spawn(讀新 config);其他 mode noop
- `wake_word_train_command(phrase)` — 回 CLI 指令字串(shell-escape 過),不在 UI 內 spawn

## UI

ConfigTab > 「Hey Mori 偵測 + 錄音」section 多 `custom model` row:
- model chip 列(active 標 ●,點未 active → 套用 + restart listener)
- ↻ refresh + 「訓練新 phrase」展開(input phrase + 產生指令 + 複製按鈕)
- 全部用 `--c-*` token,light/dark 都對

## Migration

無 breaking change。Linux only(piper-phonemize Windows wheel 不全),Windows 顯示 ↻ refresh 不會壞但「訓練新 phrase」實際跑指令會 fail(訓練 README 內已提)。

## Test plan

- [x] `bash scripts/verify.sh` 全綠
- [x] `npm run build` pass
- [ ] 手動驗:Listening mode 下選別的 .onnx → 應該 flash「✓ 已套用 + 重啟 listener」+ listener 用新 model
- [ ] 手動驗:Agent mode 下選別的 .onnx → 應該 flash「✓ 已套用(下次進 Listening mode 生效)」
- [ ] 手動驗:訓練新 phrase 展開 → 輸入「Hey Mori」按產生 → 出現 `~/.mori/wake-train-venv/bin/python ~/.mori/bin/mori-wake-train.py 'Hey Mori'`
- [ ] 手動驗:複製按鈕 → 剪貼簿真的有指令

🤖 Generated with [Claude Code](https://claude.com/claude-code)