### PR TITLE
feat(annuli): 一鍵啟用 — install 完不必再手動編輯 config + 切 mode

### DIFF
--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -1742,6 +1742,128 @@ fn character_upgrade_pack_to_4x4(stem: String) -> Result<(usize, usize), String>
 ///   state.annuli_handle() 拿 snapshot,所以 swap 完下一次 invoke 自動拿到新 store。
 /// - 既有 in-flight 請求(例如 AnnuliMemoryStore 正在 POST /memory/section)持有
 ///   舊 client 的 Arc,會跑完才 drop — 不會中斷。
+/// 偵測 annuli runtime 在不在(`~/mori-universe/annuli/.venv/bin/python`)。
+/// AnnuliTab 用這條決定要不要顯示「一鍵啟用」按鈕。Windows fallback `Scripts/python.exe`。
+#[tauri::command]
+fn annuli_runtime_installed() -> bool {
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    let root = home.join("mori-universe").join("annuli");
+    let py = if cfg!(target_os = "windows") {
+        root.join(".venv").join("Scripts").join("python.exe")
+    } else {
+        root.join(".venv").join("bin").join("python")
+    };
+    py.exists() && root.join("main.py").exists()
+}
+
+/// 一鍵啟用 annuli(DepsTab 裝完後給 user 的「直接打開」入口)。流程:
+/// 1. 驗 runtime 已裝(否則早回 err)
+/// 2. 寫 `annuli.enabled = true` + sane defaults(endpoint / spirit_name / user_id 空才填)
+/// 3. Reload AnnuliClient + AnnuliMemoryStore swap 進 state
+/// 4. 若 supervisor 不是 healthy → drop 舊 + maybe_spawn 新(該 fn 內部自己 health-check
+///    +「已 reachable 就 not-spawn」邏輯,跑兩次安全)
+///
+/// 回 user-facing 訊息(成功 / 失敗 reason)。
+#[tauri::command]
+async fn annuli_quick_enable(
+    app: AppHandle,
+    state: tauri::State<'_, Arc<AppState>>,
+) -> Result<String, String> {
+    // 1. 驗 runtime
+    if !annuli_runtime_installed() {
+        return Err(
+            "annuli runtime 沒裝 — 先到 DepsTab 裝「Annuli 反思服務 runtime」(等同 \
+             git clone ~/mori-universe/annuli + uv venv + pip install -e .)"
+                .into(),
+        );
+    }
+
+    // 2. 讀現有 config + 補 defaults
+    let config_path = mori_dir().join("config.json");
+    let mut json: serde_json::Value = std::fs::read_to_string(&config_path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+    let obj = json
+        .as_object_mut()
+        .ok_or_else(|| "config.json 不是 object".to_string())?;
+    let annuli = obj
+        .entry("annuli".to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    let a = annuli
+        .as_object_mut()
+        .ok_or_else(|| "config.json /annuli 不是 object".to_string())?;
+    a.insert("enabled".to_string(), serde_json::json!(true));
+    let str_empty = |a: &serde_json::Map<String, serde_json::Value>, k: &str| -> bool {
+        a.get(k).and_then(|v| v.as_str()).map(|s| s.is_empty()).unwrap_or(true)
+    };
+    if str_empty(a, "endpoint") {
+        a.insert("endpoint".to_string(), serde_json::json!("http://localhost:5000"));
+    }
+    if str_empty(a, "spirit_name") {
+        a.insert("spirit_name".to_string(), serde_json::json!("mori"));
+    }
+    if str_empty(a, "user_id") {
+        let default_uid = std::env::var("USER")
+            .or_else(|_| std::env::var("USERNAME"))
+            .unwrap_or_else(|_| "user".into());
+        a.insert("user_id".to_string(), serde_json::json!(default_uid));
+    }
+    std::fs::create_dir_all(mori_dir())
+        .map_err(|e| format!("mkdir ~/.mori: {e}"))?;
+    std::fs::write(
+        &config_path,
+        serde_json::to_string_pretty(&json).map_err(|e| format!("serialize: {e}"))?,
+    )
+    .map_err(|e| format!("write {}: {e}", config_path.display()))?;
+
+    // 3. Reload AnnuliClient / store(同 annuli_reload 的 if-ready 分支)
+    let annuli_cfg = annuli_config::AnnuliConfig::load(&config_path);
+    if !annuli_cfg.is_ready() {
+        return Err("config 寫好了但 is_ready=false — endpoint/spirit/user_id 還是空(不該發生)".into());
+    }
+    let client = mori_core::annuli::AnnuliClient::new(annuli_cfg.to_client_config())
+        .map_err(|e| format!("build annuli client: {e:#}"))?;
+    let client = Arc::new(client);
+    let store: Arc<dyn mori_core::memory::MemoryStore> =
+        Arc::new(mori_core::memory::annuli::AnnuliMemoryStore::new(client.clone()));
+    *state.memory.write() = store;
+    *state.annuli.write() = Some(client);
+
+    // 4. supervisor spawn — 只在沒 healthy 時動。已 spawned/already-running 別重啟。
+    let cur_state = state
+        .annuli_supervisor
+        .lock()
+        .as_ref()
+        .map(|s| s.info.state)
+        .unwrap_or("none");
+    let info_msg = if !matches!(cur_state, "spawned" | "already-running") {
+        // drop old(kill child if any)
+        *state.annuli_supervisor.lock() = None;
+        let sup = annuli_supervisor::AnnuliSupervisor::maybe_spawn(&annuli_cfg).await;
+        let m = format!("supervisor: {} ({})", sup.info.state, sup.info.reason);
+        *state.annuli_supervisor.lock() = Some(sup);
+        m
+    } else {
+        let r = state
+            .annuli_supervisor
+            .lock()
+            .as_ref()
+            .map(|s| s.info.reason.clone())
+            .unwrap_or_default();
+        format!("supervisor 已健康({cur_state} — {r})")
+    };
+    tracing::info!(info = %info_msg, "annuli quick-enable done");
+    let _ = app.emit(
+        "annuli-supervisor-changed",
+        serde_json::json!({ "from": "quick_enable" }),
+    );
+    Ok(format!("✓ Annuli 已啟用。{info_msg}"))
+}
+
 #[tauri::command]
 async fn annuli_reload(state: tauri::State<'_, Arc<AppState>>) -> Result<String, String> {
     let config_path = mori_core::llm::groq::GroqProvider::bootstrap_mori_config()
@@ -4547,6 +4669,8 @@ fn main() {
             wake_word::wake_word_set_model,
             wake_word::wake_word_train_command,
             wake_word_restart_listener,
+            annuli_runtime_installed,
+            annuli_quick_enable,
         ])
         .on_window_event(|window, event| {
             // 關視窗時不殺 app — 隱藏到系統匣繼續跑(像 Slack / Discord)

--- a/src/tabs/AnnuliTab.tsx
+++ b/src/tabs/AnnuliTab.tsx
@@ -77,6 +77,11 @@ export default function AnnuliTab() {
   const [sleepBusy, setSleepBusy] = useState(false);
   const [sleepResult, setSleepResult] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
+  // 一鍵啟用相關:`runtimeInstalled` 偵測 `~/mori-universe/annuli/.venv` 在不在;
+  // 在 → unconfigured 狀態下顯示快速啟用按鈕。`enableBusy` / `enableMsg` 給按鈕回饋。
+  const [runtimeInstalled, setRuntimeInstalled] = useState<boolean | null>(null);
+  const [enableBusy, setEnableBusy] = useState(false);
+  const [enableMsg, setEnableMsg] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -113,6 +118,10 @@ export default function AnnuliTab() {
 
   useEffect(() => {
     refresh();
+    // 偵測 runtime 是否已裝(同 mount 一次,enable 後再 refresh status 帶到)
+    invoke<boolean>("annuli_runtime_installed")
+      .then(setRuntimeInstalled)
+      .catch(() => setRuntimeInstalled(false));
     // Wave 4 step 11:30s 自動刷新 status / events 數,給 background polling 感
     const id = setInterval(() => {
       // 只 refresh status / events,不重 fetch SOUL / sections(那兩個基本不變)
@@ -121,6 +130,24 @@ export default function AnnuliTab() {
     }, 30_000);
     return () => clearInterval(id);
   }, [refresh]);
+
+  const quickEnable = async () => {
+    setEnableBusy(true);
+    setEnableMsg(null);
+    try {
+      const out = await invoke<string>("annuli_quick_enable");
+      setEnableMsg(out);
+      // 等 supervisor 跑(spawn + health-check 最多 15s),再 refresh
+      setTimeout(() => {
+        refresh();
+        invoke<boolean>("annuli_runtime_installed").then(setRuntimeInstalled).catch(() => {});
+      }, 2000);
+    } catch (e) {
+      setEnableMsg(`❌ ${String(e)}`);
+    } finally {
+      setEnableBusy(false);
+    }
+  };
 
   const triggerSleep = async () => {
     setSleepBusy(true);
@@ -157,10 +184,36 @@ export default function AnnuliTab() {
       <div className="mori-tab">
         <h1 className="mori-tab-title">{t("annuli_tab.title_unconfigured")}</h1>
         <p className="mori-tab-hint">{t("annuli_tab.unconfigured_hint")}</p>
-        <div className="mori-annuli-sleep-row">
-          <button className="mori-btn primary" onClick={gotoConfig}>
+        <div className="mori-annuli-sleep-row" style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+          {runtimeInstalled && (
+            <button
+              className="mori-btn primary"
+              onClick={quickEnable}
+              disabled={enableBusy}
+              title="偵測到 ~/mori-universe/annuli runtime 已裝。按此自動寫入 annuli.enabled=true + 預設 endpoint/spirit/user_id + 啟動 supervisor"
+            >
+              {enableBusy ? "啟用中…" : "✨ 一鍵啟用 Annuli(runtime 已偵測到)"}
+            </button>
+          )}
+          <button className="mori-btn" onClick={gotoConfig}>
             <IconConfig /> {t("annuli_tab.go_config")}
           </button>
+          {runtimeInstalled === false && (
+            <span style={{ fontSize: 12, color: "var(--c-text-muted)" }}>
+              提示:Annuli runtime 未偵測到(`~/mori-universe/annuli/.venv` 不存在)。先到 Deps tab 裝「Annuli 反思服務 runtime」。
+            </span>
+          )}
+          {enableMsg && (
+            <span
+              style={{
+                fontSize: 12,
+                color: enableMsg.startsWith("❌") ? "var(--c-danger-text)" : "var(--c-success-text)",
+                marginLeft: 4,
+              }}
+            >
+              {enableMsg}
+            </span>
+          )}
         </div>
         <p className="mori-tab-hint">{t("annuli_tab.schema_hint")}</p>
         <pre className="mori-annuli-pre">


### PR DESCRIPTION
## Summary

回答 user 的問題:「**annuli 端啟動服務不能包含在我們 mori-desktop 的安裝或啟動流程中嗎**」

答案是「**已經可以,supervisor 早就寫好,只缺一個 enabled 開關 + 啟用入口**」。這版補上。

## 雙邊配合

- **PR #61** 加 DepsTab「Install Annuli runtime」(git clone + uv venv + pip install -e)→ install side
- **此 PR** 加 AnnuliTab unconfigured 狀態的「✨ 一鍵啟用」按鈕 + supervisor 對上流程 → enable side

兩個 PR 合起來 = user 從新裝完 mori-desktop → DepsTab 一鍵裝 annuli runtime → AnnuliTab 一鍵啟用 → 對話開始走 annuli vault。

## 新 IPC

- `annuli_runtime_installed` → bool。檢查 `~/mori-universe/annuli/.venv/bin/python` + `main.py`(Windows fallback `Scripts/python.exe`)
- `annuli_quick_enable` → String。**完整流程**:
  1. 驗 runtime 已裝(否則早回 err 帶教學)
  2. 寫 `annuli.enabled=true` + 預設值(endpoint http://localhost:5000 / spirit_name=mori / user_id=$USER)
  3. Swap AnnuliClient / AnnuliMemoryStore 進 state(熱重載,等同 `annuli_reload`)
  4. supervisor 不是 healthy(disabled / failed / remote)→ drop + maybe_spawn 新;已 healthy → 不動,只報告
  5. 2 秒後 UI 自動 refresh status(supervisor /health 等待最多 15s,常見 < 2s)

## UI

AnnuliTab unconfigured 狀態:
- runtime 偵測到 → primary 按鈕「✨ 一鍵啟用 Annuli(runtime 已偵測到)」
- runtime 沒裝 → 提示句「Annuli runtime 未偵測到,先到 Deps tab 裝」
- 「Configure Annuli in Config」改非 primary(進階手動 config 路徑保留)

## 行為保證

- **Idempotent**:重複按一鍵啟用不重 spawn(`maybe_spawn` 內部 `/health` check,已 reachable 就 not-spawn)
- **不殺健康 supervisor**:state 是 `spawned` 或 `already-running` 時不 drop replace
- **defaults 只填空欄**:user 之前設過的 endpoint / spirit / user_id 不會被覆蓋

## Test plan

- [x] `cargo check -p mori-tauri` 通過
- [x] `npm run build` 通過
- [x] `bash scripts/verify.sh` 全綠
- [ ] 手動驗:annuli 不在 → AnnuliTab unconfigured 時看到「runtime 未偵測到」提示,沒一鍵啟用按鈕
- [ ] 手動驗:`cd ~/mori-universe/annuli` 確認 venv 已建 → AnnuliTab 應該出現「✨ 一鍵啟用」按鈕
- [ ] 手動驗:按下一鍵啟用 → 2s 後 status 轉 reachable(annuli main.py admin --port 5000 應該被 spawn 起來)
- [ ] 手動驗:再按一次一鍵啟用 → 應該不重 spawn(訊息「supervisor 已健康」)

🤖 Generated with [Claude Code](https://claude.com/claude-code)