### PR TITLE
feat(annuli): transparent setup — startup auto-detect + reload 接 supervisor + ConfigTab status banner

### DIFF
--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -1742,6 +1742,57 @@ fn character_upgrade_pack_to_4x4(stem: String) -> Result<(usize, usize), String>
 ///   state.annuli_handle() 拿 snapshot,所以 swap 完下一次 invoke 自動拿到新 store。
 /// - 既有 in-flight 請求(例如 AnnuliMemoryStore 正在 POST /memory/section)持有
 ///   舊 client 的 Arc,會跑完才 drop — 不會中斷。
+/// 把 supervisor 狀態對齊 config — enable / disable 對稱。
+///
+/// - 想 enabled,supervisor 不是 healthy → drop + maybe_spawn(內部 health-check
+///   過會 not-spawn,只 reset SupervisorInfo)
+/// - 想 disabled,supervisor 是「我們 spawn 的」(spawned / spawned-not-ready)
+///   → drop(kill_on_drop 帶走 annuli child)
+/// - 想 disabled,supervisor 是「已 running 外部 process」(already-running)→ 不動,
+///   那是 user 自己跑的 annuli,我們不該殺
+///
+/// 由 `annuli_reload` / `annuli_quick_enable` / startup auto-detect 共用。
+async fn sync_supervisor_to_config(state: &AppState, cfg: &annuli_config::AnnuliConfig) {
+    let cur_state = state
+        .annuli_supervisor
+        .lock()
+        .as_ref()
+        .map(|s| s.info.state);
+
+    if !cfg.enabled {
+        // 只殺「我們 spawn」的;external annuli 不動。
+        if matches!(cur_state, Some("spawned") | Some("spawned-not-ready")) {
+            tracing::info!(
+                prev_state = ?cur_state,
+                "annuli disabled — dropping supervisor to kill our spawned annuli child"
+            );
+            *state.annuli_supervisor.lock() = None;
+        } else {
+            tracing::debug!(
+                prev_state = ?cur_state,
+                "annuli disabled — supervisor state unchanged (not our child)"
+            );
+        }
+        return;
+    }
+
+    // 想 enabled。已 healthy(spawned / already-running)→ 不動。
+    if matches!(cur_state, Some("spawned") | Some("already-running")) {
+        tracing::debug!(prev_state = ?cur_state, "annuli enabled — supervisor 已健康");
+        return;
+    }
+    // 否則:drop 舊(disabled / remote / failed / spawned-not-ready)+ maybe_spawn 新
+    *state.annuli_supervisor.lock() = None;
+    let sup = annuli_supervisor::AnnuliSupervisor::maybe_spawn(cfg).await;
+    tracing::info!(
+        prev_state = ?cur_state,
+        new_state = sup.info.state,
+        reason = %sup.info.reason,
+        "annuli enabled — supervisor (re-)spawned"
+    );
+    *state.annuli_supervisor.lock() = Some(sup);
+}
+
 /// 偵測 annuli runtime 在不在(`~/mori-universe/annuli/.venv/bin/python`)。
 /// AnnuliTab 用這條決定要不要顯示「一鍵啟用」按鈕。Windows fallback `Scripts/python.exe`。
 #[tauri::command]
@@ -1833,29 +1884,14 @@ async fn annuli_quick_enable(
     *state.memory.write() = store;
     *state.annuli.write() = Some(client);
 
-    // 4. supervisor spawn — 只在沒 healthy 時動。已 spawned/already-running 別重啟。
-    let cur_state = state
+    // 4. supervisor 對齊 config(共用 helper,enable→啟動 / disable→殺 child)
+    sync_supervisor_to_config(&state, &annuli_cfg).await;
+    let info_msg = state
         .annuli_supervisor
         .lock()
         .as_ref()
-        .map(|s| s.info.state)
-        .unwrap_or("none");
-    let info_msg = if !matches!(cur_state, "spawned" | "already-running") {
-        // drop old(kill child if any)
-        *state.annuli_supervisor.lock() = None;
-        let sup = annuli_supervisor::AnnuliSupervisor::maybe_spawn(&annuli_cfg).await;
-        let m = format!("supervisor: {} ({})", sup.info.state, sup.info.reason);
-        *state.annuli_supervisor.lock() = Some(sup);
-        m
-    } else {
-        let r = state
-            .annuli_supervisor
-            .lock()
-            .as_ref()
-            .map(|s| s.info.reason.clone())
-            .unwrap_or_default();
-        format!("supervisor 已健康({cur_state} — {r})")
-    };
+        .map(|s| format!("supervisor: {} ({})", s.info.state, s.info.reason))
+        .unwrap_or_else(|| "supervisor: none".into());
     tracing::info!(info = %info_msg, "annuli quick-enable done");
     let _ = app.emit(
         "annuli-supervisor-changed",
@@ -1864,13 +1900,24 @@ async fn annuli_quick_enable(
     Ok(format!("✓ Annuli 已啟用。{info_msg}"))
 }
 
+/// C — annuli 熱重載 command。
+///
+/// 流程:
+/// 1. 重讀 `~/.mori/config.json` 的 `annuli` 子樹
+/// 2. 若 ready:重建 AnnuliClient + AnnuliMemoryStore;不 ready:重建 LocalMarkdownMemoryStore
+/// 3. 原子 swap 進 AppState.memory / AppState.annuli
+/// 4. **`sync_supervisor_to_config`** — enable→啟動 supervisor / disable→殺我們 spawn 的 child
+///
+/// skill_server / annuli_commands / agent pipeline 都走 state.memory_handle() /
+/// state.annuli_handle() 拿 snapshot,swap 完下一次 invoke 自動拿到新 store。
+/// 既有 in-flight 請求(例 AnnuliMemoryStore POST 中)持有舊 client Arc,跑完才 drop。
 #[tauri::command]
 async fn annuli_reload(state: tauri::State<'_, Arc<AppState>>) -> Result<String, String> {
     let config_path = mori_core::llm::groq::GroqProvider::bootstrap_mori_config()
         .map_err(|e| format!("locate config.json: {e:#}"))?;
     let annuli_cfg = annuli_config::AnnuliConfig::load(&config_path);
 
-    if annuli_cfg.is_ready() {
+    let result_msg = if annuli_cfg.is_ready() {
         let client = mori_core::annuli::AnnuliClient::new(annuli_cfg.to_client_config())
             .map_err(|e| format!("build annuli client: {e:#}"))?;
         let client = Arc::new(client);
@@ -1885,10 +1932,10 @@ async fn annuli_reload(state: tauri::State<'_, Arc<AppState>>) -> Result<String,
             user_id = %annuli_cfg.user_id,
             "annuli hot-reload → AnnuliMemoryStore"
         );
-        Ok(format!(
+        format!(
             "reloaded: annuli enabled @ {} (spirit={}, user_id={})",
             annuli_cfg.endpoint, annuli_cfg.spirit_name, annuli_cfg.user_id
-        ))
+        )
     } else {
         let memory_root = mori_core::memory::markdown::LocalMarkdownMemoryStore::default_root()
             .map_err(|e| format!("locate ~/.mori/memory: {e:#}"))?;
@@ -1900,11 +1947,16 @@ async fn annuli_reload(state: tauri::State<'_, Arc<AppState>>) -> Result<String,
             path = %memory_root.display(),
             "annuli hot-reload → LocalMarkdownMemoryStore (annuli disabled)"
         );
-        Ok(format!(
+        format!(
             "reloaded: annuli disabled, fallback LocalMarkdown @ {}",
             memory_root.display()
-        ))
-    }
+        )
+    };
+
+    // 把 supervisor 對齊 config(enable→啟動 / disable→殺我們 spawn 的 child)
+    sync_supervisor_to_config(&state, &annuli_cfg).await;
+
+    Ok(result_msg)
 }
 
 #[tauri::command]
@@ -4472,10 +4524,58 @@ fn main() {
     };
 
     // 載入 annuli config(hoist 出外層 — supervisor spawn task 也要這個 cfg)
-    let annuli_cfg = config_path
+    let mut annuli_cfg = config_path
         .as_deref()
         .map(annuli_config::AnnuliConfig::load)
         .unwrap_or_default();
+
+    // Startup auto-detect:user 從沒設過 annuli + runtime 在 ~/mori-universe/annuli/
+    // → 自動寫 sane defaults 進 config + 開 annuli。**只在 config 完全沒 annuli 段
+    // 時觸發**(尊重 user 明示 disabled 的設定);第二次跑就走正常 load path。
+    let annuli_section_present = config_path
+        .as_deref()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+        .map(|v| v.get("annuli").is_some())
+        .unwrap_or(false);
+    if !annuli_section_present && annuli_runtime_installed() {
+        if let Some(cfg_path) = &config_path {
+            let default_uid = std::env::var("USER")
+                .or_else(|_| std::env::var("USERNAME"))
+                .unwrap_or_else(|_| "user".into());
+            let mut json: serde_json::Value = std::fs::read_to_string(cfg_path)
+                .ok()
+                .and_then(|s| serde_json::from_str(&s).ok())
+                .unwrap_or_else(|| serde_json::json!({}));
+            if let Some(obj) = json.as_object_mut() {
+                obj.insert(
+                    "annuli".to_string(),
+                    serde_json::json!({
+                        "enabled": true,
+                        "endpoint": "http://localhost:5000",
+                        "spirit_name": "mori",
+                        "user_id": default_uid,
+                    }),
+                );
+                if let Ok(text) = serde_json::to_string_pretty(&json) {
+                    match std::fs::write(cfg_path, text) {
+                        Ok(()) => tracing::info!(
+                            path = %cfg_path.display(),
+                            user_id = %default_uid,
+                            "annuli auto-detect: 寫進 default config(從沒設過 + runtime 在)"
+                        ),
+                        Err(e) => tracing::warn!(
+                            error = %e,
+                            path = %cfg_path.display(),
+                            "annuli auto-detect: 寫 config 失敗,跳過"
+                        ),
+                    }
+                }
+            }
+            annuli_cfg = annuli_config::AnnuliConfig::load(cfg_path);
+        }
+    }
+    let annuli_cfg = annuli_cfg; // 從這之後 immutable
 
     // 建立長期記憶 store + (可選)annuli HTTP client。Wave 4:
     // ~/.mori/config.json 有 `annuli.enabled=true` 且 endpoint / spirit / user_id

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -1742,6 +1742,32 @@ fn character_upgrade_pack_to_4x4(stem: String) -> Result<(usize, usize), String>
 ///   state.annuli_handle() 拿 snapshot,所以 swap 完下一次 invoke 自動拿到新 store。
 /// - 既有 in-flight 請求(例如 AnnuliMemoryStore 正在 POST /memory/section)持有
 ///   舊 client 的 Arc,會跑完才 drop — 不會中斷。
+/// 決定 annuli `user_id` 預設值的順序:
+/// 1. `cfg.user.name`(Quickstart 召喚師之名,user 真正取的名)
+/// 2. `$USER` / `$USERNAME` env(OS user 兜底,例如 `ct` / `Administrator`)
+/// 3. `"user"` 字串硬兜底
+///
+/// 給 `annuli_quick_enable` + startup auto-detect 共用,讓 Quickstart 名跟
+/// annuli vault id 自動對齊 — 不會出現 Quickstart「yazelin」但 vault 寫成 `ct` 的 split identity。
+fn pick_annuli_user_id_default(config_path: &std::path::Path) -> String {
+    let from_user_name = std::fs::read_to_string(config_path)
+        .ok()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+        .and_then(|v| {
+            v.pointer("/user/name")
+                .and_then(|x| x.as_str())
+                .map(String::from)
+        })
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    if let Some(name) = from_user_name {
+        return name;
+    }
+    std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .unwrap_or_else(|_| "user".into())
+}
+
 /// 把 supervisor 狀態對齊 config — enable / disable 對稱。
 ///
 /// - 想 enabled,supervisor 不是 healthy → drop + maybe_spawn(內部 health-check
@@ -1858,10 +1884,10 @@ async fn annuli_quick_enable(
         a.insert("spirit_name".to_string(), serde_json::json!("mori"));
     }
     if str_empty(a, "user_id") {
-        let default_uid = std::env::var("USER")
-            .or_else(|_| std::env::var("USERNAME"))
-            .unwrap_or_else(|_| "user".into());
-        a.insert("user_id".to_string(), serde_json::json!(default_uid));
+        a.insert(
+            "user_id".to_string(),
+            serde_json::json!(pick_annuli_user_id_default(&config_path)),
+        );
     }
     std::fs::create_dir_all(mori_dir())
         .map_err(|e| format!("mkdir ~/.mori: {e}"))?;
@@ -4540,9 +4566,7 @@ fn main() {
         .unwrap_or(false);
     if !annuli_section_present && annuli_runtime_installed() {
         if let Some(cfg_path) = &config_path {
-            let default_uid = std::env::var("USER")
-                .or_else(|_| std::env::var("USERNAME"))
-                .unwrap_or_else(|_| "user".into());
+            let default_uid = pick_annuli_user_id_default(cfg_path);
             let mut json: serde_json::Value = std::fs::read_to_string(cfg_path)
                 .ok()
                 .and_then(|s| serde_json::from_str(&s).ok())

--- a/src/MainShell.tsx
+++ b/src/MainShell.tsx
@@ -132,9 +132,8 @@ function MainShell() {
             onClick={() => setQuickstartOpen(true)}
             title="點開 Quickstart 編輯召喚師之名"
           >
-            <span className="mori-sidebar-user-label">為</span>
+            <span className="mori-sidebar-user-label">召喚師</span>
             <span className="mori-sidebar-user-name">{userName}</span>
-            <span className="mori-sidebar-user-label">而存在</span>
           </button>
         )}
         <nav className="mori-sidebar-nav">

--- a/src/MainShell.tsx
+++ b/src/MainShell.tsx
@@ -67,6 +67,24 @@ function MainShell() {
   }, []);
   // brand-3: theme base 給 toggle button 判斷該秀 sun 還是 moon
   const [themeBase, setThemeBase] = useState<"dark" | "light">("dark");
+  // 召喚師之名 — Quickstart 存進 cfg.user.name,sidebar brand 下方顯示。
+  // 空 → 不顯示(老 user 沒過 Quickstart 也不會看到亂跳)。
+  const [userName, setUserName] = useState<string>("");
+  useEffect(() => {
+    import("@tauri-apps/api/core").then(({ invoke }) =>
+      invoke<string>("config_read")
+        .then((text) => {
+          try {
+            const cfg = JSON.parse(text);
+            const n = (cfg?.user?.name ?? "") as string;
+            if (typeof n === "string") setUserName(n.trim());
+          } catch {
+            // 不擋
+          }
+        })
+        .catch(() => {}),
+    );
+  }, [quickstartOpen]); // Quickstart 關閉後重抓(user 改名後即時反映)
 
   useEffect(() => {
     const u = listen<NavPayload>("mori-nav", (e) => {
@@ -108,6 +126,17 @@ function MainShell() {
           <img className="mori-sidebar-brand-icon" src="/logo.png" alt="Mori" />
           <span className="mori-sidebar-brand-name">Mori</span>
         </div>
+        {userName && (
+          <button
+            className="mori-sidebar-user"
+            onClick={() => setQuickstartOpen(true)}
+            title="點開 Quickstart 編輯召喚師之名"
+          >
+            <span className="mori-sidebar-user-label">為</span>
+            <span className="mori-sidebar-user-name">{userName}</span>
+            <span className="mori-sidebar-user-label">而存在</span>
+          </button>
+        )}
         <nav className="mori-sidebar-nav">
           {TABS.map((tab_def) => {
             const label = t(`sidebar.${tab_def.key}`);

--- a/src/Quickstart.tsx
+++ b/src/Quickstart.tsx
@@ -504,6 +504,7 @@ export function Quickstart({ onDone }: QuickstartProps) {
             envGeminiDetected={envGeminiDetected}
             envOpenaiDetected={envOpenaiDetected}
             starterLocale={starterLocale} setStarterLocale={setStarterLocale}
+            isReturning={isReturning}
           />
         ) : (
           <DwellingRite
@@ -594,6 +595,9 @@ interface CommonProps {
   envOpenaiDetected: boolean;
   starterLocale: "zh" | "en";
   setStarterLocale: (l: "zh" | "en") => void;
+  /** First-time(quickstart_completed != true)→ ritual / direct 都顯示「跳過 / 沉睡」
+   *  narrative;Returning(已 completed)→ 「回主畫面」平實。從 Quickstart root 傳下來。 */
+  isReturning: boolean;
 }
 
 // ─── 直接模式 ───────────────────────────────────────────────
@@ -604,7 +608,7 @@ function DirectForm(props: CommonProps) {
     powerBase, setPowerBase, powerModel, setPowerModel,
     verify, setVerify, doVerify, doSave, doSkip,
     envGroqDetected, envGeminiDetected, envOpenaiDetected,
-    starterLocale, setStarterLocale } = props;
+    starterLocale, setStarterLocale, isReturning } = props;
 
   const auraReal = auraKey.trim().length > 5 || (envGroqDetected && auraKey.trim() === "");
   // env-only path:env 偵測到 + 沒填 key 也算 ready(custom 多要求 api_base 已填)
@@ -826,9 +830,9 @@ function DirectForm(props: CommonProps) {
         <button
           className="mori-btn"
           onClick={doSkip}
-          title={t("quickstart.direct_skip_button_hint")}
+          title={t(isReturning ? "quickstart.ritual_dismiss_returning_hint" : "quickstart.direct_skip_button_hint")}
         >
-          {t("quickstart.direct_skip_button")}
+          {t(isReturning ? "quickstart.ritual_dismiss_returning" : "quickstart.direct_skip_button")}
         </button>
         <button
           className="mori-btn primary"
@@ -849,9 +853,6 @@ interface DwellingProps extends CommonProps {
   scene: number;
   setScene: (s: number) => void;
   onSwitchToDirect: () => void;
-  /** First-time setup → 「先離開(Mori 仍會沉睡)」narrative;
-   *  Returning user(quickstart_completed=true)→ 「回主畫面」平實 */
-  isReturning: boolean;
 }
 
 function DwellingRite(props: DwellingProps) {

--- a/src/Quickstart.tsx
+++ b/src/Quickstart.tsx
@@ -67,7 +67,28 @@ interface QuickstartProps {
 
 export function Quickstart({ onDone }: QuickstartProps) {
   const { t, i18n } = useTranslation();
+  // First-time vs returning:第一次跑 quickstart_completed != true → ritual 模式預設,
+  // dismiss 按鈕用「先離開(Mori 仍會沉睡)」narrative。
+  // 已 quickstart_completed → direct 模式預設(?/召喚師 點來改設定的人不需要再走儀式),
+  // dismiss 按鈕變平實「回主畫面」(Mori 已醒,沒有沉睡 narrative)。
+  const [isReturning, setIsReturning] = useState<boolean>(false);
   const [mode, setMode] = useState<Mode>("ritual");
+  useEffect(() => {
+    invoke<string>("config_read")
+      .then((text) => {
+        try {
+          const cfg = JSON.parse(text);
+          const completed = cfg?.quickstart_completed === true;
+          setIsReturning(completed);
+          if (completed) setMode("direct");
+        } catch {
+          /* config parse 失敗 → 當第一次跑 */
+        }
+      })
+      .catch(() => {
+        /* 沒 config → 第一次跑 */
+      });
+  }, []);
   // 收尾用 — 「回家」按下後 modal 跟音樂同步 fade-out 600ms 才 onDone,
   // 不直接硬切視窗破壞儀式氣氛。Direct mode 也吃同一路徑(沒音樂時純 CSS 淡出)。
   const [closing, setClosing] = useState(false);
@@ -503,6 +524,7 @@ export function Quickstart({ onDone }: QuickstartProps) {
             envOpenaiDetected={envOpenaiDetected}
             starterLocale={starterLocale} setStarterLocale={setStarterLocale}
             onSwitchToDirect={() => setMode("direct")}
+            isReturning={isReturning}
           />
         )}
       </div>
@@ -827,6 +849,9 @@ interface DwellingProps extends CommonProps {
   scene: number;
   setScene: (s: number) => void;
   onSwitchToDirect: () => void;
+  /** First-time setup → 「先離開(Mori 仍會沉睡)」narrative;
+   *  Returning user(quickstart_completed=true)→ 「回主畫面」平實 */
+  isReturning: boolean;
 }
 
 function DwellingRite(props: DwellingProps) {
@@ -864,7 +889,7 @@ type StepProps = DwellingProps & {
 // ─── 第一幕 · 召喚 ──────────────────────────────────────────
 
 function SceneSummoning({
-  t, summonerName, setSummonerName, dots, onNext, doSkip, onSwitchToDirect,
+  t, summonerName, setSummonerName, dots, onNext, doSkip, onSwitchToDirect, isReturning,
 }: StepProps) {
   const nameReady = summonerName.trim().length > 0;
   // 召喚師打字時 confirm 兩段會動態冒出來,scroll 容器自動拉到底,
@@ -913,9 +938,9 @@ function SceneSummoning({
         <button
           className="mori-btn ghost"
           onClick={doSkip}
-          title={t("quickstart.ritual_dismiss_hint")}
+          title={t(isReturning ? "quickstart.ritual_dismiss_returning_hint" : "quickstart.ritual_dismiss_hint")}
         >
-          {t("quickstart.ritual_dismiss")}
+          {t(isReturning ? "quickstart.ritual_dismiss_returning" : "quickstart.ritual_dismiss")}
         </button>
         <button
           className="mori-btn ghost"

--- a/src/Quickstart.tsx
+++ b/src/Quickstart.tsx
@@ -310,6 +310,17 @@ export function Quickstart({ onDone }: QuickstartProps) {
       // 召喚師之名 → user.name
       cfg.user.name = summonerName.trim();
 
+      // 同步 annuli.user_id(若 annuli 已存在但 user_id 還沒設,寫進去 — 對齊 vault identity)。
+      // 沒 cfg.annuli → 不建,startup auto-detect 偵測 runtime 時會自己拿 user.name 當 default。
+      // 已設過 user_id(非空)→ 尊重不覆蓋(可能是 user 在 Config tab 改過)。
+      if (cfg.annuli && typeof cfg.annuli === "object") {
+        const annuli = cfg.annuli as Record<string, unknown>;
+        const curUid = typeof annuli.user_id === "string" ? annuli.user_id.trim() : "";
+        if (!curUid) {
+          annuli.user_id = summonerName.trim();
+        }
+      }
+
       // 靈氣 → providers.groq.api_key (STT)
       // 維持寫進 providers.groq.api_key — Mori-core groq.rs discover_api_key 兩處都讀,
       // 但這條 inline path 是 Groq 主要存放位置(模型/STT model 也在 providers.groq.*)

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -403,7 +403,7 @@
       "x11_floating": "Floating widget (X11)",
       "x11_floating_hint": "Only applies in X11 sessions. On Wayland the body is truly transparent and there's no XShape equivalent, so these have no effect.",
       "annuli_connection": "Annuli vault connection",
-      "annuli_connection_hint": "When on, Mori reads/writes the vault via an annuli HTTP service (e.g. localhost:5000) — SOUL.md / MEMORY.md / events / rings. When off, falls back to local ~/.mori/memory/. Restart mori-desktop after changing to swap the client.",
+      "annuli_connection_hint": "When on, Mori reads/writes the vault via an annuli HTTP service (e.g. localhost:5000) — SOUL.md / MEMORY.md / events / rings. When off, falls back to local ~/.mori/memory/. **Client hot-reloads on save (no restart needed)**; check the Annuli tab to see status flip to connected. Tip: if the Annuli runtime is already installed, use the one-click enable button in the Annuli tab instead of filling this page manually.",
       "annuli_basic_auth": "Basic auth (optional)",
       "annuli_basic_auth_hint": "Set when annuli sits behind nginx + basic auth (typically production). Local localhost usually doesn't need this.",
       "corrections_title": "corrections.md",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -253,6 +253,8 @@
     "ritual_scene_4_name": "Scene 4 The Sealing",
     "ritual_scene_5_name": "Scene 5 The Settling",
     "ritual_dismiss": "Leave for now (Mori stays asleep)",
+    "ritual_dismiss_returning": "Back to main",
+    "ritual_dismiss_returning_hint": "Return to the main window (settings unchanged)",
     "ritual_dismiss_hint": "Until you share an aura, she can't hear you — voice & chat won't work. Reopen the rite anytime from the Help menu.",
     "ritual_switch_direct_hint": "Skip the narrative and use a single-page form with all fields at once (keys still required).",
     "ritual_back_hint": "Back to the previous scene (filled fields are kept).",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -253,6 +253,8 @@
     "ritual_scene_4_name": "第四幕 驗印",
     "ritual_scene_5_name": "第五幕 安頓",
     "ritual_dismiss": "先離開(Mori 仍會沉睡)",
+    "ritual_dismiss_returning": "回主畫面",
+    "ritual_dismiss_returning_hint": "回到主畫面(不影響設定)",
     "ritual_dismiss_hint": "沒交一道靈氣前,她聽不見你 — 語音與對話都還無法使用。Help 選單可隨時喚她回來。",
     "ritual_switch_direct_hint": "跳過劇情敘事,改用單頁表單一次填齊所有欄位(同樣需要設 key)",
     "ritual_back_hint": "回到上一幕(已填的東西會保留)",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -403,7 +403,7 @@
       "x11_floating": "Floating 外觀(X11)",
       "x11_floating_hint": "只在 X11 session 有效。Wayland 上 body 真透明、XShape 沒對應 API，這幾項都沒影響。",
       "annuli_connection": "Annuli vault 連線",
-      "annuli_connection_hint": "開啟後 Mori 走 annuli HTTP service(localhost:5000 之類)讀寫 vault — SOUL.md / MEMORY.md / events / rings。關掉走本機 ~/.mori/memory/ 那條 fallback。改完要重啟 mori-desktop 才會切換 client。",
+      "annuli_connection_hint": "開啟後 Mori 走 annuli HTTP service(localhost:5000 之類)讀寫 vault — SOUL.md / MEMORY.md / events / rings。關掉走本機 ~/.mori/memory/ 那條 fallback。**儲存後自動熱重載 client(不必重啟 mori-desktop)**;到 Annuli tab 看 status 是否轉 connected。提示:Annuli runtime 已裝的話 Annuli tab 有「一鍵啟用」按鈕,不必手動填這頁。",
       "annuli_basic_auth": "Basic auth(可選)",
       "annuli_basic_auth_hint": "正式機 annuli 走 nginx + basic auth 時填這。本機 localhost 通常不用。",
       "corrections_title": "corrections.md",

--- a/src/shell.css
+++ b/src/shell.css
@@ -87,9 +87,34 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 10px 12px;
+  padding: 6px 10px 8px;
+}
+/* 召喚師之名顯示 — Quickstart 寫的 cfg.user.name,點一下回 Quickstart 編輯 */
+.mori-sidebar-user {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  padding: 2px 10px 10px;
+  margin: 0;
+  border: none;
+  background: transparent;
   border-bottom: 1px solid var(--c-divider);
   margin-bottom: 8px;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+  width: 100%;
+}
+.mori-sidebar-user:hover { background: var(--c-sidebar-hover-bg); }
+.mori-sidebar-user-label {
+  font-size: 10px;
+  color: var(--c-text-soft);
+  letter-spacing: 0.3px;
+}
+.mori-sidebar-user-name {
+  font-size: 12px;
+  color: var(--c-brand-text);
+  font-weight: 500;
 }
 .mori-sidebar-brand-icon {
   /* badge logo: 深綠盤 + cream 描邊,在深 sidebar 上可見度最佳 */

--- a/src/tabs/ConfigTab.tsx
+++ b/src/tabs/ConfigTab.tsx
@@ -2085,6 +2085,7 @@ function ConfigTab({
 
           {/* ── Annuli(vault-backed reflection engine) ────── */}
           {subTab === "annuli" && <>
+          <AnnuliStatusBanner />
           <Section
             title={t("config_tab.sections.annuli_connection")}
             hint={t("config_tab.sections.annuli_connection_hint")}
@@ -2493,6 +2494,117 @@ function WakeWordModelPicker() {
         )}
       </div>
     </FormRow>
+  );
+}
+
+// ─── Annuli status banner(Config tab Annuli 段頭) ───────────────────
+//
+// 顯示當前 annuli 連線狀態 — endpoint / configured / reachable / soul_token /
+// supervisor 是否在跑。Save 後 annuli_reload 跑完,點重新檢查或自動 30s 一次。
+
+type AnnuliStatusBannerStatus = {
+  configured: boolean;
+  reachable: boolean;
+  endpoint: string | null;
+  spirit: string | null;
+  user_id: string | null;
+  soul_token_configured: boolean;
+  error: string | null;
+};
+
+function AnnuliStatusBanner() {
+  const [status, setStatus] = useState<AnnuliStatusBannerStatus | null>(null);
+  const [checking, setChecking] = useState(false);
+
+  const refresh = async () => {
+    setChecking(true);
+    try {
+      const st = await invoke<AnnuliStatusBannerStatus>("annuli_status");
+      setStatus(st);
+    } catch (e) {
+      console.error("[annuli status banner]", e);
+      setStatus(null);
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+    const id = setInterval(refresh, 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  // 三色狀態(對齊 --c-*-bg/text token,light/dark 都 OK):
+  // - 綠 connected: configured + reachable
+  // - 黃 unreachable: configured + !reachable(annuli 沒跑)
+  // - 灰 disabled: !configured(fallback LocalMarkdown)
+  let bg = "var(--c-input-bg)";
+  let border = "var(--c-border)";
+  let label = "(載入中…)";
+  let detail: React.ReactNode = null;
+  if (status) {
+    if (!status.configured) {
+      bg = "var(--c-input-bg)";
+      border = "var(--c-border)";
+      label = "● Disabled — 走本機 ~/.mori/memory/ fallback";
+      detail = (
+        <span style={{ color: "var(--c-text-muted)" }}>
+          打開下方 enabled + 填 endpoint/spirit/user_id,儲存後自動熱重載 client。
+        </span>
+      );
+    } else if (status.reachable) {
+      bg = "var(--c-success-bg)";
+      border = "var(--c-border-strong)";
+      label = "● Connected";
+      detail = (
+        <span style={{ color: "var(--c-text)" }}>
+          {status.endpoint} · spirit=<code>{status.spirit ?? "?"}</code> · user_id=
+          <code>{status.user_id ?? "?"}</code> · soul_token{" "}
+          {status.soul_token_configured ? "✓ 已設" : "✗ 未設(寫敏感資料會 403)"}
+        </span>
+      );
+    } else {
+      bg = "var(--c-warning-bg)";
+      border = "var(--c-warning-border)";
+      label = "● Unreachable — annuli 沒在跑 / endpoint 不對";
+      detail = (
+        <span style={{ color: "var(--c-warning-text)" }}>
+          {status.endpoint ?? "(無 endpoint)"} {status.error ? `· ${status.error}` : ""}
+          {" — Annuli tab 一鍵啟用,或 "}
+          <code>cd ~/mori-universe/annuli && python main.py admin --port 5000</code>
+        </span>
+      );
+    }
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 4,
+        padding: "10px 14px",
+        marginBottom: 12,
+        background: bg,
+        border: `1px solid ${border}`,
+        borderRadius: 6,
+        fontSize: 12.5,
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
+        <strong style={{ color: "var(--c-text-strong)" }}>{label}</strong>
+        <button
+          className="mori-btn small ghost"
+          onClick={refresh}
+          disabled={checking}
+          style={{ fontSize: 11 }}
+        >
+          {checking ? "檢查中…" : "↻ 重新檢查"}
+        </button>
+      </div>
+      {detail && <div>{detail}</div>}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

回 user 3 個提問,全在這個 PR 收掉:

| User 問題 | 之前狀態 | 此 PR |
|---|---|---|
| ConfigTab 看不出連線狀態 | 沒 status display | 加 `AnnuliStatusBanner`(三色:connected/unreachable/disabled) |
| 能不能更自動 / 少設一點 | 要 2 click(裝 + 啟用) | **Startup auto-detect** — 第一次跑 + runtime 在 → 0 click 自動啟用 |
| 啟用/停用會連帶 spawn/kill annuli 嗎 | **不會**(`annuli_reload` 故意不動 supervisor)| `annuli_reload` 改成接管 supervisor,enable↔disable 對稱 |

## 細節

### 1. `sync_supervisor_to_config` helper(新)

`annuli_reload` + `annuli_quick_enable` 共用:

- 想 enabled + supervisor 不 healthy → drop 舊 + `AnnuliSupervisor::maybe_spawn`(內部 `/health` check,跑兩次安全)
- 想 disabled + supervisor 是「我們 spawn」(`spawned` / `spawned-not-ready`)→ drop(kill_on_drop 帶走 annuli child)
- 想 disabled + supervisor 是 `already-running`(外部 annuli)→ **不動**(尊重 user 自己跑的)

### 2. Startup auto-detect

setup 載 `annuli_cfg` 後插入:
1. config.json 內 `annuli` key 從沒設過(user 沒明示過)
2. `~/mori-universe/annuli/.venv/bin/python` + `main.py` 存在
3. 兩者皆是 → 自動寫 sane defaults(`enabled=true` / `endpoint=http://localhost:5000` / `spirit_name=mori` / `user_id=$USER`)
4. 後續正常 supervisor `maybe_spawn` 跑起來

**只觸發一次** — user 設過 `enabled=false` 就尊重,不會被覆寫。

### 3. ConfigTab `AnnuliStatusBanner`

Annuli subtab 頭部:
- 綠 ● Connected:configured + reachable;endpoint / spirit / user_id / soul_token 狀態列出
- 黃 ● Unreachable:configured 但 `/health` 不回 → 提示「Annuli tab 一鍵啟用」或 manual 指令
- 灰 ● Disabled:!configured → 提示「走 LocalMarkdown fallback,儲存後熱重載」
- ↻ 重新檢查 + 30s 自動 polling
- 全 `--c-*` token,light/dark OK

### 4. i18n hint 修

原本「改完要重啟 mori-desktop 才會切換 client」**錯**(熱重載早就 work)— 改成正確描述,點到 Annuli tab 一鍵啟用替代手填這頁。zh-TW + en 同步。

## Migration

無 breaking change。已有 `annuli` 設定的 user 不受 startup auto-detect 影響。

## Test plan

- [x] `cargo check -p mori-tauri` 通過
- [x] `bash scripts/verify.sh` 全綠
- [x] `npm run build` 通過
- [ ] 手動驗:**全新 install**(刪 ~/.mori/config.json 內 `annuli` 段)+ `~/mori-universe/annuli/.venv` 在 → 啟動後 config 應該自動有 annuli 段
- [ ] 手動驗:ConfigTab Annuli subtab 應該頂部有 status banner,顯示 Connected/Unreachable/Disabled 三色
- [ ] 手動驗:Config 把 enabled 改 false 存 → AnnuliTab 看 supervisor 應該變 disabled,annuli child process 應該被殺(`pgrep -f "annuli.*admin"` 應該沒結果)
- [ ] 手動驗:Config 改回 enabled 存 → annuli 應該重新 spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)