### PR TITLE
chore(claude): 加 .claude/skills/ — release-patch / ship-and-verify / grep-jsonl

### DIFF
--- a/.claude/skills/grep-jsonl.md
+++ b/.claude/skills/grep-jsonl.md
@@ -1,0 +1,122 @@
+---
+description: Inspect Mori's `~/.mori/logs/mori-YYYY-MM-DD.jsonl` event log to diagnose user-reported issues — find errors, trace Hey Mori cycles, verify skill dispatches were real (not LLM hallucination), compare what claude/codex got as prompt vs what they returned. Invoke when user says "看一下 log" / "what happened" / "為什麼壞掉" / "log 有什麼" / "diagnose this error".
+---
+
+# grep-jsonl — Mori 事件 log 解讀
+
+Mori 的所有 release-mode 觀測都在 `~/.mori/logs/mori-YYYY-MM-DD.jsonl`(append-only JSONL,UTC timestamp,每日 rotate)。release build tracing 沒接 file appender,**這份 JSONL 是唯一可見路徑**。
+
+## When to invoke
+
+- User 說「看 log / 查 log / 看一下 jsonl / 看 mori 在做什麼」
+- User 報 bug「壞掉了 / 沒反應 / 沒打開 / Mori 死了」
+- 你自己想驗「我剛改的東西真的生效嗎」
+- ship-and-verify skill 的 step 4(讀 log 對照)會 dispatch 過來
+
+## Steps
+
+### 1. 拿日期 + 行數
+
+```bash
+LOG=~/.mori/logs/mori-$(date +%Y-%m-%d).jsonl
+wc -l "$LOG"
+```
+
+跨平台 `~` 都解(Git Bash on Windows / Linux bash)。timestamps 是 UTC,user 在 GMT+8 → 加 8 小時對到本地時間。
+
+### 2. 只讀「新增段」
+
+別重讀已知的行 — 浪費 context 又沒新資訊。看 conversation 上次讀到第幾行,從那行 `+1` offset 開始讀。完全沒讀過就讀全檔。
+
+### 3. 認得 event kind 的「意義」
+
+| `kind` 欄位 | 意義 | 重點欄 |
+|---|---|---|
+| `wake_listener_spawned` | 進 Listening / cycle respawn 後啟動新 Python wake-listener | `prev_mode` |
+| `wake_listener_ready` | openwakeword Model 載完(~2s after spawn) | `model` 路徑 |
+| `wake_listener_error` | Python 死於 ImportError / model load fail / mic 開不起來 | `msg` |
+| `wake_listener_respawn` | `set_phase` 每完成一輪 cycle 補位 respawn | `reason` / `phase` |
+| `wake_listener_stopped` | 離開 Listening mode → drop child | `new_mode`(切到哪) |
+| `wake_listener_diag` | Python signal-gated(`max_score > 0.3` 或 `max_rms > 0.02`)才寫,idle 不寫 | `text` |
+| `wake_word_event` | 偵測到 wake-word → 觸發錄音 | `score`(confidence) |
+| `silence_trim` | VAD silence-stop + trim 前後靜音 | `trimmed_secs` |
+| `voice_input_completed` | VoiceInput mode(非 wake)的 transcript 完成 | `target_process` / `transcript_cleaned` |
+| `skill_dispatch` | skill_server `POST /skill/<name>` 收到 + 跑完 | `skill` / `args_preview` / `ok` / `user_message_preview` |
+| `llm_call` | bash-cli-agent(claude/codex/gemini)單次 round-trip | `binary` / `ok` / `latency_ms` / `stdin_tail_preview` / `response_preview` |
+| `agent_completed` | 整段 agent pipeline(含 skill loop)完成 | `profile` / `provider` / `response_chars` / `skill_calls` |
+
+### 4. 常見 diagnose pattern
+
+#### 「Hey Mori 沒觸發 / 一次後就沒了」
+
+看 `wake_listener_*` 序列。健康的 cycle:
+
+```
+wake_listener_spawned → wake_listener_ready
+wake_word_event       ← user 喊
+silence_trim          ← 錄音 + VAD
+skill_dispatch / llm_call
+agent_completed
+wake_listener_stopped → wake_listener_spawned ← cycle 補位 respawn
+wake_listener_ready
+(下一輪 wake_word_event ...)
+```
+
+- **只看到 spawned 沒 ready** → Python 載 model 卡 / 死,看 stderr drain 的 diag
+- **ready 後完全沒 wake_word_event** → mic 沒收到聲音 / 講太小聲 / threshold 太高,看 `wake_listener_diag` 的 `max_rms` 跟 `max_score`
+- **一輪後沒下一輪 wake** → respawn 沒跑(`set_phase` 沒進 Done/Error),或 user 切走 mode(看 `wake_listener_stopped` 的 `new_mode`)
+
+#### 「Mori 說開啟了,但 Chrome 沒開 / app 沒反應」
+
+對照 `skill_dispatch` 跟 `agent_completed.response`:
+
+| 兩者都有對應的 entry | 兩者文字對齊 | 結論 |
+|---|---|---|
+| ✅ | ✅ | skill 真的跑了,問題在 OS 端(Chrome 把 URL 開背景 tab 沒 focus / Windows ShellExecute 沒生效) |
+| ✅ `skill_dispatch` 缺 | ✅ agent_completed 有「已開啟」 | **LLM 幻覺** — 沒呼叫 skill,response 是憑空編。改強系統 prompt anti-hallucination |
+| 兩者都缺 | — | agent 根本沒跑那條 skill,可能是 LLM 不認得 task / profile 沒 enable 那條 skill |
+
+#### 「codex / claude / gemini agent 壞掉」
+
+看 `llm_call` 的 `ok=false` 跟 `error` 欄:
+
+- `Not inside a trusted directory and --skip-git-repo-check was not specified` → codex CLI 預設 git repo 限制(v0.7.1 已修)
+- `command not found` / `failed to spawn` → bash-cli-agent 找不到 binary(claude / codex / gemini 不在 PATH,或 mori CLI 沒 bundled)
+- `timed out` → 上層 180s timeout(claude 卡 OAuth / network),抓 `latency_ms` 接近 180000
+
+`stdin_tail_preview` 看 claude / codex 拿到的最後幾百 chars(user message + 部分 history)。`response_preview` 看回的內容。對得起來嗎?
+
+#### 「Mori 反應變奇怪 / context 不對」
+
+`llm_call.system_prompt_chars` + `stdin_chars` 看 prompt 規模。如果突然變大 / 變小代表 context provider(時間 / 視窗 / 剪貼簿 / 反白)生壞 context。
+
+### 5. 報告
+
+別整段 dump JSONL 給 user — context 浪費。用表格 / 條列摘要關鍵 events + timestamps + 解讀。pattern 例:
+
+```
+時間軸(UTC):
+
+03:18:12  wake_listener_spawned (進 Listening)
+03:18:14  wake_listener_ready
+03:18:16  wake_word_event score=0.96  ← 1st wake
+03:18:21  silence_trim
+03:18:33  skill_dispatch open_url ok=true   ← Chrome 真有開
+03:18:33  agent_completed "已開啟 https://..."  ← 跟 dispatch 對齊
+03:18:33  wake_listener_respawn → spawned → ready ← cycle 補位
+03:18:41  wake_word_event score=0.91  ← 2nd wake ✓
+
+結論:Hey Mori + Chrome 兩條都對。N 輪後不靜默 bug 沒重現。
+```
+
+## Cross-platform
+
+- 路徑 `~/.mori/logs/` 全平台同 layout(`HOME`/`USERPROFILE` 解析)。
+- `date +%Y-%m-%d` 跨平台 bash 都吃。
+- JSONL utf-8,中文不會壞。
+
+## 失敗 recovery
+
+- **找不到當天 log** — 確認 Mori 真的有跑過(`~/.mori/runtime.json` 有沒有今天 timestamp)。Mori 沒啟動過 → 沒 log。
+- **時區對不上 user 說的時間** — JSONL 是 UTC,user 在 GMT+8 → log timestamp + 8h = local。別搞錯 day boundary。
+- **行數太多** — 用 `Read` tool 的 offset+limit 切段讀,別整檔吞。

--- a/.claude/skills/release-patch.md
+++ b/.claude/skills/release-patch.md
@@ -1,0 +1,150 @@
+---
+description: Cut a patch / minor release for mori-desktop — bump version in Cargo.toml / tauri.conf.json / package.json, append CHANGELOG entry, sync roadmap, then commit. Invoke when the user says "發佈 vX.Y.Z" / "release vX.Y.Z" / "cut a patch release" / "出個小 release". Does NOT push or tag — stops at the local commit and reports next steps so user picks A (direct push) vs B (PR flow).
+---
+
+# release-patch — Mori-desktop release commit
+
+Cut a release commit locally. **Stops before push / tag** so the user makes the final call(direct push 還是走 PR 都要他決定)。
+
+## When to invoke
+
+User says any of:
+- "發佈 vX.Y.Z" / "release vX.Y.Z" / "cut a patch / minor release"
+- "出個 hotfix release" / "ship a patch"
+- Implied:剛改完 bug 想正式發,還在問怎麼 release
+
+不適用:major version bump (v1.0.0 等大改) → 那層需要 migration guide / breaking change notes 之類更多討論,別跑自動流程。
+
+## Pre-flight checks
+
+1. **Working tree** — 跑 `git status`,確認:
+   - 在 `main` branch(或 user 明確要 release 的 branch)
+   - 沒未 staged 的 fix 殘留(若有應該先 commit 進另一個 `fix(...):` commit)
+   - 注意 `examples/scripts/__pycache__/` 之類本機 byproduct,**別 stage 進 release commit**
+2. **新版號** — 從 user 訊息抓(`v0.7.1` / `0.7.1`)或讀 `Cargo.toml` `[workspace.package].version` +1 patch。問清楚不要猜。
+3. **想 release 什麼?** — `git log origin/main..HEAD --oneline` 看待 release 的 commits,跟 user 對清楚 release notes 該寫什麼。
+
+## Steps
+
+### 1. Bump version in 3 places
+
+跨平台都是純文字編輯,Edit tool 即可:
+
+| 檔 | 找這行 | 改成 |
+|---|---|---|
+| `Cargo.toml` | `[workspace.package]` 區的 `version = "X.Y.Z"` | 新版號 |
+| `crates/mori-tauri/tauri.conf.json` | `"version": "X.Y.Z",` | 新版號 |
+| `package.json` | `"version": "X.Y.Z",` | 新版號 |
+
+### 2. Refresh Cargo.lock
+
+```bash
+cargo check -p mori-tauri --message-format=short 2>&1 | tail -5
+```
+
+只跑 check 不 build。version bump 會自動寫進 Cargo.lock。**期待:** 沒新錯,既有 `unused import: CommandExt` warning(`annuli_supervisor.rs`)是 pre-existing,忽略。
+
+### 3. CHANGELOG entry
+
+Prepend 進 `CHANGELOG.md`,**在 `## v<上一版>` 之前**,結構:
+
+```markdown
+## v<版本> — <一句 tagline,跟 release body 同調>(<YYYY-MM-DD>)
+
+<Hook 2-3 句:前一版的什麼問題 / 缺口 → 這版解了什麼。讀者是 future-yazelin / contributor reviewer。>
+
+### <子主題 1 — feature 或 fix area>
+
+<細節描述。比 release body 詳,寫得到「為什麼這樣解」「dev 模式 vs release 差異」「相關 PR / commit」這層>
+
+- ...
+
+### <子主題 2>
+
+...
+
+### Verified
+
+實機跑通的 user-facing scenario,3-8 條:
+- ✅ ...
+
+### 升級
+
+無 breaking change / migration 細節 / config schema diff。沒就一行寫「無 breaking change」。
+
+---
+```
+
+風格參考最近 v0.7.1 / v0.7.0 entries — 中英混、技術細節到位、不寫廢話。
+
+### 4. Sync roadmap
+
+讀 `docs/roadmap.md`,找有沒有「該版本 ship 完後變 stale 的條目」:
+- 該標 ✅ 還沒標的
+- 「待補 / TODO」清單該移除的條目
+- 「目前不能 X」對的 X 已經能
+
+修法:就地 edit 加 ✅ / 改描述,別整段刪(歷史脈絡留著)。
+
+### 5. Stage + commit
+
+```bash
+git add Cargo.toml crates/mori-tauri/tauri.conf.json package.json CHANGELOG.md docs/roadmap.md Cargo.lock
+git diff --cached --stat   # 確認只動到這幾檔,沒誤 stage 別的
+git commit -m "$(cat <<'EOF'
+release: v<X.Y.Z> — <tagline,跟 CHANGELOG 標題一致>
+
+<2-4 行說明:這次 release 主要修了什麼。比 CHANGELOG section header
+更摘要,但比 commit subject 多一點 context。讀者是 git log 看 commit
+history 的人。>
+
+CHANGELOG 完整列改動,簡述:
+
+- <bullet 1 - feature / fix area>
+- <bullet 2>
+- ...
+
+<其他要 surface 的 — roadmap 更新 / breaking change 警告 / closes #N>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+`git commit` 用 HEREDOC 喂 message 是為了正確處理多行 + 不被 shell escape 吃掉。Git Bash on Windows 跟 Linux bash 都吃這 syntax。
+
+### 6. Report to user, stop
+
+`git log --oneline -3` 給 user 看新 commit 上去了。然後**明確告訴 user 兩條 push 路徑**:
+
+```
+v<X.Y.Z> commit 在 local 了,還沒 push。
+
+A. 直推 main + tag(快):
+   git push origin main
+   git tag v<X.Y.Z>
+   git push origin v<X.Y.Z>
+   → 觸發 .github/workflows/release.yml,CI build Linux + Windows,draft release。
+
+B. 走 PR(repo 慣例,過去 release commit 都有 (#N) 後綴):
+   git checkout -b release/v<X.Y.Z>
+   git push origin release/v<X.Y.Z>
+   gh pr create --title "release: v<X.Y.Z> — <tagline>" --body "<CHANGELOG section>"
+   → merge 後手動 tag merge commit + push tag。
+
+你選哪條?
+```
+
+**不**要自己選或自己 push — push / tag 是 destructive remote action,要 user 顯式同意。
+
+## Cross-platform notes
+
+- 所有 shell 指令用 Git Bash 跟 Linux bash 都認的 syntax(`$(cat <<'EOF' ... EOF)` / forward slash paths)。Windows native cmd / PowerShell 別跑這些 command,要用 Bash tool。
+- `cargo check` 跨平台同個指令。
+- `git` 行為相同。
+
+## 失敗 recovery
+
+- **`cargo check` fail** — 通常是版號 bump 後某 crate.toml 還沒更新,或 release commit 試圖加新 feature。停下來修,別繼續往 commit 走。
+- **CHANGELOG / roadmap edit fail** — 多半是 Edit 的 `old_string` 抓不準,改用 Read 看現況。
+- **`git commit` fail** — pre-commit hook 失敗的話**新建一個 fix commit** 別 `--amend`(避免動到還沒寫的 commit 內容)。

--- a/.claude/skills/ship-and-verify.md
+++ b/.claude/skills/ship-and-verify.md
@@ -1,0 +1,105 @@
+---
+description: Build the Mori desktop release, prompt user to install + run targeted tests, then read JSONL log to verify the changes actually work. Invoke when the user says "ship and verify" / "build + test" / "驗證一下" after a code change, especially Windows release-only behavior. Reads `~/.mori/logs/mori-YYYY-MM-DD.jsonl` to cross-check user-reported behavior against event_log truth.
+---
+
+# ship-and-verify — 邊裝邊驗,log 對照測項
+
+當你剛改完一條(或一批)會影響 release-only behavior 的 code,跑這條 skill 把「build → 提醒安裝 → 等 user 測 → 讀 log 對照」全程走一輪。
+
+## When to invoke
+
+- 改完 CREATE_NO_WINDOW / spawn / installer / release flow 相關的 code
+- 改完某個 only-in-release 才會踩到的 bug(`windows_subsystem = "windows"` GUI subsystem 限定的、MSI 裝完才出現的、tray quit 才觸發的 cleanup)
+- User 說「build 看看 / 裝起來測 / verify changes」
+
+不適用:
+- dev 模式即可重現的 bug → `npm run tauri dev` 跑就好,不必走完整 release
+- 純文件 / 純 frontend hot-reload 變動 → `npm run dev` 看 vite output 即可
+
+## Steps
+
+### 1. Build
+
+```bash
+cd <repo>
+npm run tauri build
+```
+
+**用 background mode**(`run_in_background=true`)— Tauri build Windows 完整 cycle 1-3 分鐘,不該卡 conversation。CI release.yml 在 GitHub 也跑同樣 chain。
+
+跑前提醒 user:**完全結束 Mori**(tray icon 右鍵 Quit,不只關視窗 — 要關 tray 才能釋放鎖檔)。沒關 NSIS 會跳「無法刪除某檔」。
+
+### 2. 列出 install path + 該測什麼
+
+跨平台 installer 位置(都在 `target/release/bundle/` 下):
+
+| 平台 | Output 路徑 | 建議 |
+|---|---|---|
+| Windows | `target/release/bundle/nsis/Mori_<version>_x64-setup.exe` | 推薦 NSIS(快、不要 admin) |
+| Windows | `target/release/bundle/msi/Mori_<version>_x64_en-US.msi` | 備案 |
+| Linux | `target/release/bundle/deb/mori_<version>_amd64.deb` | Ubuntu / Debian |
+| Linux | `target/release/bundle/appimage/mori_<version>_amd64.AppImage` | 其他發行版 |
+| macOS | `target/release/bundle/dmg/Mori_<version>_x64.dmg` | (殼還沒接,先 N/A) |
+
+明確列出**這次該測的 user-facing scenario**(不是 unit test 層 — 那 cargo test 跑掉了),示例:
+
+```
+裝完開 Mori → 試:
+1. <跟 code change 直接相關的 path>
+2. <相鄰 regression risk 的 path>
+3. <log 該看到什麼新 event>
+```
+
+每條都要可驗證 — 跟 log JSONL 對得起來最好。
+
+### 3. 等 user 回報
+
+User 跑完會說「裝完了」/「測完了」/「測項都 ok」/「踩到 X」。**別自己猜測通過** —— release-only behavior 有些只有實機才看得到(黑框、CFFI dialog、MSI bundling),log 不一定能驗。
+
+### 4. 讀 log 對照
+
+跨平台 log 路徑:`~/.mori/logs/mori-YYYY-MM-DD.jsonl`(`~` 在 Git Bash for Windows 跟 Linux bash 都解到 `$HOME` / `$USERPROFILE`)。
+
+```bash
+wc -l ~/.mori/logs/mori-$(date +%Y-%m-%d).jsonl
+```
+
+拿到行數,**只讀新增段**(別重讀已知的 lines 浪費 context)。比對思路:
+
+| user 報的測項 | log 該有的 event | log 該**沒**的 event |
+|---|---|---|
+| Hey Mori 觸發過 | `wake_word_event` | `wake_listener_error` |
+| codex agent 跑 | `llm_call binary=codex ok=true` | `llm_call ok=false ... Not inside a trusted directory` |
+| open_url 真的開了 | `skill_dispatch skill=open_url ok=true` | (若只有 `agent_completed.response` 寫「已開啟」但無 `skill_dispatch` → LLM 幻覺) |
+| DepsTab 重檢過 | (沒對應 event,只能憑 user 回報 UI 觀察) | — |
+| Mori 結束乾淨 | (沒對應 event;Python-CFFI dialog 是 UI 層) | — |
+
+**新欄位看一下也順手:** `llm_call.stdin_tail_preview` / `response_preview` / `system_prompt_chars` —— 確認 LLM 拿到的 context 對、回的內容對。
+
+### 5. 報告
+
+跑表格給 user 看哪些測項從 log 驗到 ✅、哪些只能憑 user 觀察 ✓、哪些沒過 ✗。風格範例:
+
+```
+| 測項 | 結果 | log 證據 |
+|---|---|---|
+| codex agent | ✅ | line 354 / 357 `llm_call binary=codex ok=true` |
+| open_url 真有開 | ✅ | line 298 `skill_dispatch skill=open_url ok=true` 跟 agent response 對齊 |
+| 黑框消失 | ✓ user 觀察 OK | log 不可見 |
+| ... | ... | ... |
+```
+
+對不上 / fail 的 → 把該段 JSONL 抓出來貼 + 解讀。
+
+## Cross-platform
+
+- `~/.mori/logs/` 路徑跨平台同邏輯。Git Bash on Windows 解 `~` → `C:\Users\<user>`,Linux 解到 `$HOME`。
+- `date +%Y-%m-%d` 跨平台 bash 都認。
+- Tauri output bundle 路徑跨平台 — `target/release/bundle/<format>/`。
+- 提示 user 結束 Mori 的方式跟平台無關(tray icon 右鍵 Quit)。
+
+## 失敗 recovery
+
+- **`npm run tauri build` 卡 / fail** — 看 `target/release/build-*.log` 跟 Tauri 自家 log。常見問題:沒網路抓 webview2 / Linux 缺 deps(`scripts/install-linux-deps.sh`)/ cargo cache 壞(`cargo clean -p mori-tauri`)。
+- **User 說「裝不上」** — `tasklist | grep -i mori`(Windows) / `pgrep -fa mori`(Linux)看有沒有舊 process 鎖檔。
+- **Log 對不上 user 講的** — 確認你看對日期的 JSONL(timestamp 是 UTC,user 時區可能差幾小時)。

--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,16 @@ Thumbs.db
 # Mori runtime data
 .mori/
 
-# Claude Code session state(不該進版本控制 — 個人 IDE-like artifact)
-.claude/
+# Claude Code 個人 session state(history / settings / cache 等不該進版本控制
+# 的 IDE-like artifact),預設整個 .claude/ 都不追。
+.claude/*
+# 但 skills 是共享 workflow 定義 — 多人協作 / 跨 device 都要拿得到,allowlist 回來。
+!.claude/skills/
+
+# Python byproduct(`python -m py_compile` 之類驗證 / examples/scripts/ 跑起來
+# 會產生,不該進 repo)。
+__pycache__/
+*.pyc
 
 # 開發用 scratch — tokenizer 測試 / 一次性實驗腳本,不進 repo。
 scratch/


### PR DESCRIPTION
## Summary

v0.7.1 那輪 session 反覆走的 3 條 workflow 抽成可重用 Claude Code skill,讓未來開 mori-desktop 的 Claude Code session 自動 list 出來,user 可 `/<name>` 觸發或 agent 自動 dispatch。

### 3 個 skill

- **`release-patch`** — bump 版號(`Cargo.toml` / `tauri.conf.json` / `package.json` 三處同步)→ refresh `Cargo.lock` → prepend `CHANGELOG.md` entry → sync `docs/roadmap.md` stale 條目 → commit。**停在 push 之前**讓 user 選 A(直推 main + tag)或 B(走 PR)。
- **`ship-and-verify`** — `npm run tauri build`(background)→ 列出 installer 路徑 + 具體該測的 user-facing scenario → 等 user 回報 → 讀 `~/.mori/logs/mori-YYYY-MM-DD.jsonl` 新增段 → 用表格對照測項跟 log 證據 → 出報告。Release-only behavior(黑框 / MSI bundle / cffi dialog)log 不可見的部份標 user 觀察。
- **`grep-jsonl`** — Mori event log JSONL 解讀。含 event kind 對照表(`wake_listener_*` / `wake_word_event` / `skill_dispatch` / `llm_call` / `agent_completed` 等)+ 常見 diagnose pattern:
  - 「Hey Mori 沒觸發 / 一次後就沒了」→ 看 `wake_listener_*` 序列
  - 「Mori 說開啟了但 Chrome 沒開」→ `skill_dispatch` 跟 `agent_completed.response` 對齊與否
  - 「agent CLI 壞掉」→ `llm_call.error` + `stdin_tail_preview`

### `.gitignore` 規則調整

- 原 `.claude/` 整目錄 ignore → 改 `.claude/*` + `!.claude/skills/`。個人 session state(history / settings / cache)仍不追,skills 共享 workflow 才進 repo。
- 加 `__pycache__/` / `*.pyc` — `examples/scripts/` 跑 `py_compile` 驗 syntax 會留 byproduct,過去 release 後 `git status` 一直浮這個。

## Cross-platform

所有 skill 內的 shell 指令用 Git Bash on Windows + Linux bash 共通 syntax(`\$(cat <<'EOF' ... EOF)` heredoc / forward slash paths / `date +%Y-%m-%d`),Windows + Linux 都跑得起來。

## Test plan

- [x] `git check-ignore -v .claude/skills/release-patch.md` 不再 match `.claude/`(allowlist 生效)
- [x] `git status` 看得到 `.claude/skills/*.md` 為 tracked,`examples/scripts/__pycache__/` 為 ignored
- [ ] 新 Claude Code session 開在 mori-desktop 後,available skills 列表會列出 `release-patch` / `ship-and-verify` / `grep-jsonl`(這條要 user 在新 session 驗)

🤖 Generated with [Claude Code](https://claude.com/claude-code)