### PR TITLE
feat(file-loader): 新 crate mori-file-loader skeleton + .txt/.md baseline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2603,6 +2603,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "mori-file-loader"
+version = "0.7.1"
+dependencies = [
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "mori-tauri"
 version = "0.7.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/mori-core",
     "crates/mori-tauri",
     "crates/mori-cli",
+    "crates/mori-file-loader",
 ]
 
 [workspace.package]

--- a/crates/mori-file-loader/Cargo.toml
+++ b/crates/mori-file-loader/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mori-file-loader"
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+description = "Mori 的「萬卷之口」 — 統一文件讀取(.txt / .md baseline,Wave 2 起加 pdf / docx / xlsx 等格式)。"
+
+[dependencies]
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/mori-file-loader/src/lib.rs
+++ b/crates/mori-file-loader/src/lib.rs
@@ -1,23 +1,160 @@
-//! 統一文件讀取 stub — 還沒實作。
+//! `mori-file-loader` — 統一文件讀取(「萬卷之口」)。
 //!
-//! 真正 API spec 見 tests/integration.rs。
+//! 給 Mori 一個對外穩定的入口讀使用者塞過來的文件;副檔名 dispatch 給對應實作。
+//!
+//! 本 crate 是 **skeleton**:現階段(E-base)只支援純文字格式 — `.txt` / `.md`,
+//! 兩者都走 [`std::fs::read_to_string`]。後續 Wave 2 才會加 `.pdf` / `.docx` /
+//! `.xlsx` 等 binary 格式,屆時把對應的 `FileFormatReader` 加進 [`dispatch`] 即可,
+//! 公開 API([`read_file_text`])保持不變。
+//!
+//! # 公開 API
+//!
+//! 對外只有兩個型別:
+//! - [`read_file_text`] — 入口函式,吃 [`std::path::Path`],回 `String`
+//! - [`FileLoaderError`] — error enum
+//!
+//! `FileFormatReader` trait 跟內部 reader struct **目前不公開** — 等 Wave 2
+//! 真的需要外部 crate 註冊 format 再開放,避免 over-design。
+//!
+//! # 行為決策
+//!
+//! - 副檔名比對 **case-insensitive**:`SHOUT.TXT` / `notes.MD` 都會被正確 dispatch
+//! - 副檔名一律以 lowercase 形式回給 [`FileLoaderError::UnsupportedExtension`]
+//! - 無副檔名 → [`FileLoaderError::UnsupportedExtension`]`("")`
+//! - 檔案不存在 → [`FileLoaderError::NotFound`]
+//! - 非 UTF-8 內容 → [`FileLoaderError::InvalidUtf8`](不 panic,不做 lossy decode)
+//!
+//! # Example
+//!
+//! ```no_run
+//! use std::path::Path;
+//! use mori_file_loader::read_file_text;
+//!
+//! let text = read_file_text(Path::new("notes.md")).expect("read");
+//! println!("{text}");
+//! ```
 
 use std::path::{Path, PathBuf};
 
-/// File loader 錯誤型別。
+/// `mori-file-loader` 的錯誤型別。
 #[derive(Debug, thiserror::Error)]
 pub enum FileLoaderError {
+    /// 路徑指到的檔案不存在。
     #[error("file not found: {0}")]
     NotFound(PathBuf),
+
+    /// 副檔名目前還沒有對應的 reader(eg `.pdf` 要等 Wave 2)。
+    /// 內含的字串是 **lowercase** 副檔名;無副檔名時為空字串。
     #[error("unsupported extension: {0}")]
     UnsupportedExtension(String),
+
+    /// 底層 IO 失敗(非 NotFound — 例如權限不足、磁碟錯誤)。
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// 檔案內容不是合法 UTF-8。
     #[error("invalid utf-8 in file: {0}")]
     InvalidUtf8(PathBuf),
 }
 
-/// Stub — 永遠回 unsupported 讓 tests 確實 fail。
-pub fn read_file_text(_path: &Path) -> Result<String, FileLoaderError> {
-    Err(FileLoaderError::UnsupportedExtension(String::from("stub")))
+/// 內部 trait:每個支援的副檔名對應一個 reader。
+///
+/// **目前不公開** — Wave 2 加新 format 時再決定要不要對外開放(plugin registry)。
+/// 現階段 [`dispatch`] 用 hardcoded match,結構單純,易刪易加。
+trait FileFormatReader {
+    fn read(&self, path: &Path) -> Result<String, FileLoaderError>;
+}
+
+/// `.txt` / `.md` 共用:純 UTF-8 文字檔。
+struct PlainTextReader;
+
+impl FileFormatReader for PlainTextReader {
+    fn read(&self, path: &Path) -> Result<String, FileLoaderError> {
+        match std::fs::read_to_string(path) {
+            Ok(s) => Ok(s),
+            Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
+                // `read_to_string` 在內容非 UTF-8 時回 InvalidData。
+                Err(FileLoaderError::InvalidUtf8(path.to_path_buf()))
+            }
+            Err(e) => Err(FileLoaderError::Io(e)),
+        }
+    }
+}
+
+/// 把 lowercase 副檔名 dispatch 到對應 reader。
+///
+/// Wave 2 加新 format 在這邊加 arm 即可。
+fn dispatch(ext_lower: &str) -> Option<Box<dyn FileFormatReader>> {
+    match ext_lower {
+        "txt" | "md" => Some(Box::new(PlainTextReader)),
+        _ => None,
+    }
+}
+
+/// 讀檔回文字內容。對外的主要入口。
+///
+/// 依副檔名(case-insensitive)dispatch 給對應 reader。現階段只支援 `.txt` / `.md`。
+///
+/// # Errors
+///
+/// 看 [`FileLoaderError`] 各 variant 的 doc。
+pub fn read_file_text(path: &Path) -> Result<String, FileLoaderError> {
+    // 1. file exists?
+    //    用 `try_exists` 避免 broken symlink false-negative,但 IO error
+    //    要原樣往上拋(權限不足 etc)。
+    match path.try_exists() {
+        Ok(true) => {}
+        Ok(false) => return Err(FileLoaderError::NotFound(path.to_path_buf())),
+        Err(e) => return Err(FileLoaderError::Io(e)),
+    }
+
+    // 2. extension(lowercase,無副檔名 → "")
+    let ext_lower = path
+        .extension()
+        .and_then(|os| os.to_str())
+        .map(|s| s.to_ascii_lowercase())
+        .unwrap_or_default();
+
+    // 3. dispatch
+    match dispatch(&ext_lower) {
+        Some(reader) => reader.read(path),
+        None => Err(FileLoaderError::UnsupportedExtension(ext_lower)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! 內部 unit tests — 覆蓋公開 integration tests 難測的邊界(eg non-UTF-8 bytes、
+    //! 無副檔名)。public API 行為的主測試在 `tests/integration.rs`。
+
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn invalid_utf8_in_txt_returns_invalid_utf8() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("garbled.txt");
+        // 0xFF 0xFE 0xFD 不是合法 UTF-8 start byte。
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(&[0xFF, 0xFE, 0xFD]).unwrap();
+
+        let err = read_file_text(&path).expect_err("expect InvalidUtf8");
+        match err {
+            FileLoaderError::InvalidUtf8(p) => assert_eq!(p, path),
+            other => panic!("expected InvalidUtf8, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_extension_returns_unsupported_with_empty_string() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("NO_EXT");
+        std::fs::write(&path, b"whatever").unwrap();
+
+        let err = read_file_text(&path).expect_err("expect UnsupportedExtension");
+        match err {
+            FileLoaderError::UnsupportedExtension(ext) => assert_eq!(ext, ""),
+            other => panic!("expected UnsupportedExtension, got {other:?}"),
+        }
+    }
 }

--- a/crates/mori-file-loader/src/lib.rs
+++ b/crates/mori-file-loader/src/lib.rs
@@ -1,0 +1,23 @@
+//! 統一文件讀取 stub — 還沒實作。
+//!
+//! 真正 API spec 見 tests/integration.rs。
+
+use std::path::{Path, PathBuf};
+
+/// File loader 錯誤型別。
+#[derive(Debug, thiserror::Error)]
+pub enum FileLoaderError {
+    #[error("file not found: {0}")]
+    NotFound(PathBuf),
+    #[error("unsupported extension: {0}")]
+    UnsupportedExtension(String),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("invalid utf-8 in file: {0}")]
+    InvalidUtf8(PathBuf),
+}
+
+/// Stub — 永遠回 unsupported 讓 tests 確實 fail。
+pub fn read_file_text(_path: &Path) -> Result<String, FileLoaderError> {
+    Err(FileLoaderError::UnsupportedExtension(String::from("stub")))
+}

--- a/crates/mori-file-loader/tests/integration.rs
+++ b/crates/mori-file-loader/tests/integration.rs
@@ -1,0 +1,89 @@
+//! `mori-file-loader` integration tests。
+//!
+//! 跑 `read_file_text(path)` 的公開行為:`.txt` / `.md` baseline、未支援副檔名、
+//! missing file、UTF-8 邊界、case-insensitive 副檔名。
+//!
+//! 之後 Wave 2 各 format crate 加 impl 時,這層 baseline 不該被打破。
+
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+use mori_file_loader::{read_file_text, FileLoaderError};
+use tempfile::TempDir;
+
+/// Helper:寫一個 named file 到 tempdir,回傳路徑。
+fn write_file(dir: &TempDir, name: &str, content: &[u8]) -> PathBuf {
+    let path = dir.path().join(name);
+    let mut f = fs::File::create(&path).expect("create tempfile");
+    f.write_all(content).expect("write tempfile");
+    path
+}
+
+#[test]
+fn read_file_text_reads_txt() {
+    let dir = TempDir::new().unwrap();
+    let path = write_file(&dir, "sample.txt", b"hello world");
+
+    let got = read_file_text(&path).expect("read .txt");
+    assert_eq!(got, "hello world");
+}
+
+#[test]
+fn read_file_text_reads_md() {
+    let dir = TempDir::new().unwrap();
+    let path = write_file(
+        &dir,
+        "sample.md",
+        b"# Title\n\nA paragraph with **bold**.\n",
+    );
+
+    let got = read_file_text(&path).expect("read .md");
+    assert_eq!(got, "# Title\n\nA paragraph with **bold**.\n");
+}
+
+#[test]
+fn read_file_text_returns_not_found_for_missing() {
+    let dir = TempDir::new().unwrap();
+    let missing = dir.path().join("nope.txt");
+
+    let err = read_file_text(&missing).expect_err("expect NotFound");
+    match err {
+        FileLoaderError::NotFound(p) => assert_eq!(p, missing),
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+}
+
+#[test]
+fn read_file_text_returns_unsupported_for_pdf() {
+    let dir = TempDir::new().unwrap();
+    // 寫一個假 .pdf — 副檔名才是重點,內容無所謂
+    let path = write_file(&dir, "doc.pdf", b"%PDF-1.4 fake");
+
+    let err = read_file_text(&path).expect_err("expect UnsupportedExtension");
+    match err {
+        FileLoaderError::UnsupportedExtension(ext) => {
+            assert_eq!(ext, "pdf", "should report lowercase extension");
+        }
+        other => panic!("expected UnsupportedExtension, got {other:?}"),
+    }
+}
+
+#[test]
+fn read_file_text_handles_unicode() {
+    let dir = TempDir::new().unwrap();
+    let content = "森林裡有一隻 Mori 🌲 — 年輪不會說謊。";
+    let path = write_file(&dir, "unicode.txt", content.as_bytes());
+
+    let got = read_file_text(&path).expect("read unicode .txt");
+    assert_eq!(got, content);
+}
+
+#[test]
+fn read_file_text_extension_case_insensitive() {
+    let dir = TempDir::new().unwrap();
+    let path = write_file(&dir, "SHOUT.TXT", b"loud and clear");
+
+    let got = read_file_text(&path).expect("read .TXT");
+    assert_eq!(got, "loud and clear");
+}


### PR DESCRIPTION
## Summary

新 crate `crates/mori-file-loader/` — 「**萬卷之口**」(§5 + §9 P1)的骨架。

提供統一 `read_file_text(path) -> Result<String, FileLoaderError>` 介面 + dispatch by extension。本 PR 只做 `.txt` / `.md` baseline,為 Wave 2(PDF / DOCX / XLSX)鋪路。

完整脈絡:`docs/design/jarvis-direction-notes.md` §5「萬卷之口」+ §9 P1。

## Changes

- **新 crate** `crates/mori-file-loader/`(160 + 89 + 14 = 263 行)
  - `src/lib.rs` — `read_file_text` + `FileLoaderError` 公開 API,內部 `FileFormatReader` trait + `PlainTextReader` 私有 dispatch
  - `tests/integration.rs` — 6 integration tests
- **修 workspace `Cargo.toml`** — 加 `crates/mori-file-loader` member

**沒動**:mori-core / mori-tauri / mori-cli / spirits/ / docs/

## API

```rust
pub fn read_file_text(path: &Path) -> Result<String, FileLoaderError>;

pub enum FileLoaderError {
    NotFound(PathBuf),
    UnsupportedExtension(String),
    Io(#[from] std::io::Error),
    InvalidUtf8(PathBuf),
}
```

`FileFormatReader` trait + 具體 reader impl **私有** — Wave 2 真要 plugin registry 才公開。

## Design Decisions

- **thiserror v2 + tempfile 3**(對齊 mori-core)
- **ASCII case-fold extension**(不踩 Turkish-i 等 unicode lowercase 坑)
- **BOM / non-UTF-8 → InvalidUtf8 error**,不 lossy decode
- **`try_exists()`** 區分 NotFound vs Io 失敗
- **沒公開 `FileFormatReader` trait** — YAGNI,Wave 2 真要時再開
- **沒加 pdf-extract / docx-rs / calamine** — Wave 2 各 PR 才加

## Test plan

- [x] 9 個測試全綠(6 integration + 2 internal unit + 1 doctest)
- [x] cargo test -p mori-file-loader:passed
- [x] cargo test -p mori-core --lib:208 passed(沒打破既有)
- [x] cargo check --workspace --all-targets:clean
- [x] cargo fmt -p mori-file-loader --check:clean
- [x] cargo clippy -p mori-file-loader --all-targets:clean
- [x] bash scripts/verify.sh:全綠

TDD evidence:test commit `52e6df3`(stub `UnsupportedExtension("stub")` → 6 tests red)→ impl commit `6d6eba4`。

## Reviews(本 PR 跑 subagent-driven-development 流程)

- ✅ Spec compliance: APPROVED
- ✅ Code quality: APPROVED(★★★★☆,無 Critical)

## Known follow-up(reviewer 列的 Important,留下次 PR)

- `Box<dyn FileFormatReader>` 現只一個 impl,單路徑 dispatch 算過度 — 等 Wave 2 真有第二個 reader 再 commit `Box<dyn>` 才有兌現,或在 baseline 砍 trait 改 inline
- `UnsupportedExtension("")` 對「無副檔名」error message 讀起來像 bug,可拆 `NoExtension(PathBuf)` variant
- TOCTOU(`try_exists` 過 → 檔被刪 → `read_to_string` 回 NotFound 變成 `Io` 而非 `NotFound`)+ directory-as-path 兩個邊界沒測

🤖 Generated with [Claude Code](https://claude.com/claude-code)