### PR TITLE
feat(file-loader): Tauri command + LLM Skill — 「萬卷之口」整合

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2626,6 +2626,7 @@ dependencies = [
  "hound",
  "image",
  "mori-core",
+ "mori-file-loader",
  "parking_lot",
  "rand 0.8.6",
  "raw-window-handle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2590,6 +2590,7 @@ dependencies = [
  "chrono",
  "futures-util",
  "hound",
+ "mori-file-loader",
  "regex",
  "reqwest 0.12.28",
  "schemars 0.8.22",

--- a/crates/mori-core/Cargo.toml
+++ b/crates/mori-core/Cargo.toml
@@ -36,5 +36,10 @@ hound = "3.5"
 # (tracing-subscriber / reqwest 都用),這裡顯式宣告便於直接 use。
 regex = "1"
 
+# Stream E:`read_file_text` LLM-callable skill(`skill/read_file.rs`)包
+# mori-file-loader 公開 API。純 path dep,無 cycle 風險 — mori-file-loader
+# 自身只依 thiserror,不 depend mori-core。
+mori-file-loader = { path = "../mori-file-loader" }
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/mori-core/src/skill/mod.rs
+++ b/crates/mori-core/src/skill/mod.rs
@@ -182,6 +182,9 @@ mod paste_selection;
 // Phase 3B: URL 偵測 + 抓網址內容
 mod fetch_url;
 
+// Stream E:「萬卷之口」— 讀本地檔案為 LLM-callable tool
+mod read_file;
+
 pub use echo::EchoSkill;
 pub use edit::EditMemorySkill;
 pub use forget::ForgetMemorySkill;
@@ -197,6 +200,7 @@ pub use set_mode::SetModeSkill;
 pub use paste_selection::PasteSelectionBackSkill;
 
 pub use fetch_url::FetchUrlSkill;
+pub use read_file::ReadFileSkill;
 
 // ─── 共用 helpers(memory-related skills 用)────────────────────────
 

--- a/crates/mori-core/src/skill/read_file.rs
+++ b/crates/mori-core/src/skill/read_file.rs
@@ -1,0 +1,228 @@
+//! ReadFileSkill — LLM 可呼叫的「讀檔案」工具,接 `mori-file-loader::read_file_text`。
+//!
+//! # 為什麼存在
+//!
+//! `mori-file-loader` 公開 API 已經就緒,Tauri side 也有 `read_file_text_cmd`
+//! 給前端 JS 呼叫,但 **LLM 看 system prompt 知道有 `read_file_text` 工具卻
+//! 沒有實作路徑** — 走 LLM tool dispatch 的入口是 `SkillRegistry::dispatch`,
+//! 必須對應一個 `Skill` impl。這個 skill 就是那個缺口。
+//!
+//! # 行為
+//!
+//! - 吃 `{"path": "<absolute or relative path>"}` 參數
+//! - 呼叫 `mori_file_loader::read_file_text` 拿純文字內容
+//! - 成功:`SkillOutput.user_message` = 檔案內容,`data` 帶 `{ path, chars, bytes }`
+//! - 失敗(檔不存在 / 副檔名不支援 / 非 UTF-8 / IO):透過 `anyhow!` 往上拋
+//!
+//! 副檔名支援由 mori-file-loader 決定:現階段 `.txt` / `.md`;後續加 `.pdf` /
+//! `.docx` / `.xlsx` 等 reader 時這邊**不用改**,自動跟著支援。
+//!
+//! # 平台 / 隱私
+//!
+//! 讀本地檔案 → `ExecutionTarget::Local`,`Privacy::Cloud`(讀到的內容可能要餵
+//! 回 LLM 做 multi-turn,所以不限制 LocalOnly;若使用者擔心,自己選 LocalOnly
+//! provider 即可)。
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use serde_json::Value;
+use std::path::PathBuf;
+
+use super::{ExecutionTarget, Privacy, Skill, SkillOutput};
+use crate::context::Context;
+
+pub struct ReadFileSkill;
+
+#[async_trait]
+impl Skill for ReadFileSkill {
+    fn name(&self) -> &'static str {
+        "read_file_text"
+    }
+
+    fn description(&self) -> &'static str {
+        "讀檔案內容回傳純文字。使用者提到「這份檔案 / 這個文件 / 幫我看看 <path>」\
+         之類需求且有具體路徑時呼叫。支援 .txt / .md;mori-file-loader 後續加 \
+         .pdf / .docx / .xlsx reader 時會自動跟著支援。\
+         路徑可絕對可相對(相對於 mori-tauri 的 cwd)。"
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "檔案路徑,絕對或相對。副檔名(.txt / .md 等)會用來 dispatch reader。"
+                }
+            },
+            "required": ["path"]
+        })
+    }
+
+    fn target_capability(&self) -> ExecutionTarget {
+        ExecutionTarget::Local
+    }
+
+    fn privacy(&self) -> Privacy {
+        Privacy::Cloud
+    }
+
+    async fn execute(&self, args: Value, _context: &Context) -> Result<SkillOutput> {
+        let path_str = args
+            .get("path")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("missing path"))?
+            .trim()
+            .to_string();
+
+        if path_str.is_empty() {
+            return Err(anyhow!("path is empty"));
+        }
+
+        let path = PathBuf::from(&path_str);
+        tracing::info!(path = %path.display(), "read_file_text skill");
+
+        // mori-file-loader 是 sync(純 std::fs::read_to_string,讀本地檔案
+        // 不適合丟 tokio 線程池;檔案 IO 量級小,直接 inline call。若未來加
+        // .pdf / 大檔解析 reader,可改 spawn_blocking。
+        let text = mori_file_loader::read_file_text(&path)
+            .map_err(|e| anyhow!("read_file_text failed: {e}"))?;
+
+        let chars = text.chars().count();
+        let bytes = text.len();
+
+        Ok(SkillOutput {
+            user_message: text.clone(),
+            data: Some(serde_json::json!({
+                "path": path_str,
+                "chars": chars,
+                "bytes": bytes,
+                "text": text,
+            })),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Skill-level integration tests — 拼 SkillCall args,確認 dispatch 路徑活著。
+    //! mori-file-loader 自身的 reader 行為 unit tests 不重複(那邊的 crate
+    //! `tests/integration.rs` 跟內部 mod tests 已覆蓋)。
+
+    use super::*;
+    use crate::context::Context;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn empty_context() -> Context {
+        Context::default()
+    }
+
+    #[tokio::test]
+    async fn name_and_description_present() {
+        let skill = ReadFileSkill;
+        assert_eq!(skill.name(), "read_file_text");
+        // description 不空、明確指向讀檔案語義
+        let desc = skill.description();
+        assert!(!desc.is_empty());
+        assert!(desc.contains("檔案") || desc.contains("file"));
+    }
+
+    #[tokio::test]
+    async fn parameters_schema_requires_path() {
+        let skill = ReadFileSkill;
+        let schema = skill.parameters_schema();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["path"].is_object());
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v == "path"));
+    }
+
+    #[tokio::test]
+    async fn read_file_skill_returns_text() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("hello.txt");
+        fs::write(&p, "Hello, Mori").unwrap();
+
+        let skill = ReadFileSkill;
+        let args = serde_json::json!({ "path": p.to_str().unwrap() });
+        let ctx = empty_context();
+        let out = skill.execute(args, &ctx).await.expect("read should succeed");
+
+        assert_eq!(out.user_message, "Hello, Mori");
+        let data = out.data.expect("data present");
+        assert_eq!(data["chars"], 11);
+        assert_eq!(data["bytes"], 11);
+        assert_eq!(data["text"], "Hello, Mori");
+    }
+
+    #[tokio::test]
+    async fn read_file_skill_supports_md() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("notes.md");
+        fs::write(&p, "# Title\n\nbody").unwrap();
+
+        let skill = ReadFileSkill;
+        let args = serde_json::json!({ "path": p.to_str().unwrap() });
+        let out = skill.execute(args, &empty_context()).await.expect("read md");
+        assert!(out.user_message.contains("Title"));
+        assert!(out.user_message.contains("body"));
+    }
+
+    #[tokio::test]
+    async fn read_file_skill_returns_error_for_missing() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("does_not_exist.txt");
+
+        let skill = ReadFileSkill;
+        let args = serde_json::json!({ "path": p.to_str().unwrap() });
+        let err = skill
+            .execute(args, &empty_context())
+            .await
+            .expect_err("missing file should error");
+
+        let msg = err.to_string();
+        // mori-file-loader 回 NotFound,被 anyhow 包成 "read_file_text failed: file not found: ..."
+        assert!(
+            msg.contains("not found") || msg.contains("NotFound"),
+            "expected NotFound message, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_file_skill_returns_error_for_unsupported_ext() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("data.pdf");
+        fs::write(&p, b"%PDF-fake").unwrap();
+
+        let skill = ReadFileSkill;
+        let args = serde_json::json!({ "path": p.to_str().unwrap() });
+        let err = skill
+            .execute(args, &empty_context())
+            .await
+            .expect_err("pdf not supported yet");
+        assert!(err.to_string().contains("unsupported"));
+    }
+
+    #[tokio::test]
+    async fn read_file_skill_errors_on_missing_path_arg() {
+        let skill = ReadFileSkill;
+        let args = serde_json::json!({});
+        let err = skill
+            .execute(args, &empty_context())
+            .await
+            .expect_err("missing path arg");
+        assert!(err.to_string().contains("missing path"));
+    }
+
+    #[tokio::test]
+    async fn read_file_skill_errors_on_empty_path() {
+        let skill = ReadFileSkill;
+        let args = serde_json::json!({ "path": "   " });
+        let err = skill
+            .execute(args, &empty_context())
+            .await
+            .expect_err("empty path");
+        assert!(err.to_string().contains("empty"));
+    }
+}

--- a/crates/mori-tauri/Cargo.toml
+++ b/crates/mori-tauri/Cargo.toml
@@ -12,6 +12,10 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 mori-core = { workspace = true }
+# 「萬卷之口」— 統一文件讀取 lib，本 crate 透過 file_loader_cmd::read_file_text_cmd
+# 把它包成 Tauri command，讓 LLM 經 system prompt 工具描述能讀使用者丟的 .txt/.md
+# （Wave 2 起 .pdf/.docx/.xlsx 等 reader merge 後自動可用，dispatch by extension）。
+mori-file-loader = { path = "../mori-file-loader" }
 tauri = { version = "2", features = ["tray-icon", "image-png", "devtools"] }
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-global-shortcut = "2"

--- a/crates/mori-tauri/src/file_loader_cmd.rs
+++ b/crates/mori-tauri/src/file_loader_cmd.rs
@@ -1,0 +1,58 @@
+//! Tauri command bridging [`mori_file_loader::read_file_text`] 到 IPC / LLM tool。
+//!
+//! 「萬卷之口」整合層:`mori-file-loader` 是純 lib，這層把它包成
+//! `#[tauri::command]`，LLM 透過 system prompt 內的工具描述（見
+//! `build_system_prompt`）就能叫到它。
+//!
+//! 失敗一律收成 `String` — Tauri IPC 需要 `Serialize` error，且 LLM 端拿到
+//! 文字訊息比 typed enum 更可讀。內部完整型別在 [`mori_file_loader::FileLoaderError`]，
+//! 走 `Display`(`#[error(..)]`)轉字串。
+
+use std::path::PathBuf;
+
+use mori_file_loader::read_file_text;
+
+/// LLM-visible name = `read_file_text`。Rust 函式加 `_cmd` 對齊 `transcribe_*_cmd`
+/// 既有風格（區分「Tauri 入口」vs「底層 lib 函式」）。
+#[tauri::command]
+pub fn read_file_text_cmd(path: String) -> Result<String, String> {
+    let p = PathBuf::from(path);
+    read_file_text(&p).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tauri runtime mock 麻煩，這層直接 unit-test pure function `read_file_text_cmd`
+    //! 本身（`#[tauri::command]` 只是註冊 macro，不影響直接 call）。
+    //!
+    //! PDF / DOCX / XLSX 真檔案 E2E 等對應 reader merge 後另開 follow-up，
+    //! 這裡只覆蓋 baseline `.txt` 成功 + 兩條 error path。
+
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn reads_txt_via_cmd() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("test.txt");
+        fs::write(&p, "Hello, Mori").unwrap();
+        let result = read_file_text_cmd(p.to_string_lossy().to_string());
+        assert_eq!(result.unwrap(), "Hello, Mori");
+    }
+
+    #[test]
+    fn returns_error_for_missing_file() {
+        let result = read_file_text_cmd("/nonexistent/path.txt".to_string());
+        assert!(result.is_err(), "expected error for missing file");
+    }
+
+    #[test]
+    fn returns_error_for_unsupported_extension() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path().join("test.zzz");
+        fs::write(&p, "anything").unwrap();
+        let result = read_file_text_cmd(p.to_string_lossy().to_string());
+        assert!(result.is_err(), "expected error for unsupported extension");
+    }
+}

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -8,6 +8,7 @@ mod annuli_supervisor;
 mod character_pack;
 mod context_provider;
 mod deps;
+mod file_loader_cmd;
 mod hotkey_config;
 #[cfg(target_os = "linux")]
 mod portal_hotkey;
@@ -4440,6 +4441,22 @@ fn build_system_prompt(soul: Option<&str>, memory_index: &str, ctx: &MoriContext
     prompt.push_str("  • kind:email / message / essay / social_post / other\n");
     prompt.push_str("  • length_hint:short / medium(預設)/ long\n\n");
 
+    // 「萬卷之口」— 統一文件讀取入口。LLM 透過這個能把使用者塞過來的檔案
+    // 內容拉進 context 再處理(摘要 / 翻譯 / 回答關於檔案內容的問題)。
+    prompt.push_str("**read_file_text(path)**:讀檔案內容回傳純文字。\n");
+    prompt.push_str(
+        "  • 觸發:user 提到「讀這份 PDF / 摘要這個 docx / 看一下這個 xlsx」、丟給你檔案路徑\n",
+    );
+    prompt.push_str(
+        "  • 支援格式:.txt / .md(純文字直讀)、.pdf(若有 pdf-extract)、.docx(若有 docx-rs)、.xlsx(若有 calamine)\n",
+    );
+    prompt.push_str(
+        "  • path 是檔案絕對路徑或相對路徑(相對 user $HOME)\n",
+    );
+    prompt.push_str(
+        "  • 讀失敗會回 error message,**不要重試**或編造內容 — 直接告訴 user 失敗了\n\n",
+    );
+
     prompt.push_str(
         "**選 skill 的判斷**:閒聊或一般問答**直接答**,不要硬叫工具。\
          上面這些 text skills 是當使用者**明確要求一個動作**(翻譯 / 潤稿 / \
@@ -4930,6 +4947,7 @@ fn main() {
             character_sprite_data_url,
             character_dir,
             character_upgrade_pack_to_4x4,
+            file_loader_cmd::read_file_text_cmd,
             transcribe_cmds::transcribe_check_deps,
             transcribe_cmds::transcribe_file_cmd,
             transcribe_cmds::transcribe_paths_cmd,
@@ -6221,6 +6239,24 @@ mod tests {
         assert!(out.contains("paste_selection_back"));
         // memory_index 參數該被附在末尾
         assert!(out.contains("mem1: 用戶喜歡 Rust"));
+    }
+
+    // ─── Stream E:「萬卷之口」file_loader tool 描述注入 ──────────────────
+    //
+    // `read_file_text` Tauri command 在 file_loader_cmd 模組,但 LLM 要看得到
+    // 必須在 system prompt 內有對應描述。這個測試把「prompt 含 read_file_text
+    // 描述」當合約釘住,避免有人改 prompt 時不小心拿掉。
+    #[test]
+    fn build_system_prompt_includes_read_file_text_tool() {
+        let prompt = build_system_prompt(None, "", &empty_mori_ctx());
+        assert!(
+            prompt.contains("read_file_text"),
+            "read_file_text tool description missing from system prompt"
+        );
+        assert!(
+            prompt.contains("讀檔案"),
+            "read_file_text description tagline missing from system prompt"
+        );
     }
 
     #[test]

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -47,7 +47,8 @@ use mori_core::paste::PasteController;
 use mori_core::skill::PasteSelectionBackSkill;
 use mori_core::skill::{
     ComposeSkill, EditMemorySkill, FetchUrlSkill, ForgetMemorySkill, PolishSkill,
-    RecallMemorySkill, RememberSkill, SetModeSkill, SkillRegistry, SummarizeSkill, TranslateSkill,
+    ReadFileSkill, RecallMemorySkill, RememberSkill, SetModeSkill, SkillRegistry, SummarizeSkill,
+    TranslateSkill,
 };
 use mori_core::{PHASE, VERSION};
 use parking_lot::Mutex;
@@ -2144,6 +2145,7 @@ async fn skills_list(state: tauri::State<'_, Arc<AppState>>) -> Result<Vec<Skill
         routing.skill_provider("compose"),
     )));
     registry.register(Arc::new(FetchUrlSkill::new()));
+    registry.register(Arc::new(ReadFileSkill));
     registry.register(Arc::new(RememberSkill::new(mem_arc.clone())));
     registry.register(Arc::new(RecallMemorySkill::new(mem_arc.clone())));
     registry.register(Arc::new(ForgetMemorySkill::new(mem_arc.clone())));
@@ -3433,6 +3435,12 @@ async fn run_agent_pipeline(
         }
         if allows("fetch_url") {
             registry.register(Arc::new(mori_core::skill::FetchUrlSkill::new()));
+        }
+        // Stream E:「萬卷之口」 — `read_file_text` LLM tool dispatch 路徑。
+        // system prompt 已在 build_system_prompt 注入工具描述,沒這個 register
+        // LLM 知道工具存在但 reach 不到實作(SkillRegistry::dispatch 找不到 name)。
+        if allows("read_file_text") {
+            registry.register(Arc::new(mori_core::skill::ReadFileSkill));
         }
         // set_mode 永遠註冊(「晚安」「醒醒」是核心功能,無法被 disable)
         // — 但 agent_disabled 時整個 skill 系統都不掛,user 還可以用 UI 按鈕切 mode


### PR DESCRIPTION
## Summary

**Stream E-integrate** — 萬卷之口收尾。讓 `mori-file-loader::read_file_text` 同時走 **LLM tool dispatch** + **前端 JS IPC** 兩條路徑。User 可:
- 對 Mori 講「讀這份 PDF」 → LLM → ReadFileSkill → 內容回 prompt
- 前端 JS 也可透過 Tauri command 觸發(future UI 拖檔上來)

完整脈絡:`docs/design/jarvis-direction-notes.md` §5「萬卷之口」+ §9 P1。

## Changes(2 commits)

### Commit 1 (`4baa9862`)— Tauri command + prompt

- 新 `crates/mori-tauri/src/file_loader_cmd.rs`(58 lines)— `read_file_text_cmd` Tauri command
- `mori-tauri/Cargo.toml`:+ mori-file-loader dep
- `mori-tauri/src/main.rs`:+ mod + invoke_handler + build_system_prompt 工具描述

### Commit 2 (`f71539f`)— Skill trait + register(round 1 review 抓到 LLM 不能 reach)

- 新 `crates/mori-core/src/skill/read_file.rs`(228 lines + 8 tests)— `ReadFileSkill` impl `Skill`
- `mori-core/Cargo.toml`:+ mori-file-loader dep
- `mori-core/src/skill/mod.rs`:+ exports
- `mori-tauri/src/main.rs`:兩處 registry.register(skills_list line 2148 UI 用 + agent loop line 3443 LLM dispatch)

## LLM reach path

```
user: 「讀這份 .md 給我聽」
  ↓ LLM 看 system prompt 知道有 read_file_text(path)
  ↓ LLM 發 tool_call("read_file_text", {"path": "..."})
  ↓ Mori agent loop 從 SkillRegistry 找 name="read_file_text"
  ↓ ReadFileSkill::execute
  ↓ mori_file_loader::read_file_text(&path)
  ↓ 回 SkillOutput { user_message: text, data: {chars, bytes, ...} }
  ↓ LLM 拿 text continue 對話
```

## Test plan

- [x] cargo test -p mori-core --lib:**216** passed(原 208 + 新 8 ReadFileSkill tests)
- [x] cargo test -p mori-tauri --bin mori-tauri:**84** passed(含原 SOUL 注入 3 tests + 新 4 cmd/prompt tests)
- [x] cargo test -p mori-file-loader:6 passed
- [x] cargo check --workspace --all-targets:clean
- [x] cargo fmt + clippy:clean
- [x] bash scripts/verify.sh:全綠
- [ ] **Manual**(yazelin 實機):跟 Mori 講「讀 ~/.bashrc」/「讀這份 README.md 給我」,驗證 Skill 真被 dispatch

## Reviews(subagent-driven-development 流程)

- ✅ Spec round 1: **NEEDS_FIX**(抓到 LLM 不能 reach — 只 Tauri command 沒 Skill 註冊)
- ✅ Spec round 2(fix 後):APPROVED
- ✅ Code quality: APPROVED (★★★★★,無 Critical/Important)

## Known follow-up

- system prompt 描述「.pdf(若有 pdf-extract)」對 LLM 略樂觀,等 #74/#75/#76 merge 後 prompt 拿掉「若有」變絕對
- Path traversal 沒擋(eg `../../etc/shadow`)— 跟 mori user-owned 哲學一致,可在 module doc 加註說「無 sandbox,信任 user × LLM」
- 大檔 spawn_blocking — `.txt/.md` 量級小不必,Wave 2 readers merge 後若 PDF 大檔可 6MB+ 文字再評估
- 4 個 error 訊息 contains() assertions 一個 robust(missing 用 OR)一個嚴格 — 一致性可微調

🤖 Generated with [Claude Code](https://claude.com/claude-code)