### PR TITLE
feat(time-bird): mori-time crate skeleton + reminder schema (K1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,6 +754,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-english"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a56613410c9249673f4676ab8d27c70949814accb27b6b738009e2ff1034a1"
+dependencies = [
+ "chrono",
+ "scanlex",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +982,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+dependencies = [
+ "chrono",
+ "nom 7.1.3",
+ "once_cell",
 ]
 
 [[package]]
@@ -1422,6 +1455,18 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1969,6 +2014,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1981,6 +2035,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -2575,6 +2638,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libyml"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2650,6 +2724,18 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
+]
 
 [[package]]
 name = "mach2"
@@ -2840,6 +2926,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "mori-time"
+version = "0.7.1"
+dependencies = [
+ "chrono",
+ "chrono-english",
+ "notify-rust",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-cron-scheduler",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,6 +3062,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-rust"
+version = "4.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2973,6 +3089,17 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "num-derive"
@@ -3222,7 +3349,7 @@ dependencies = [
  "jni",
  "ndk 0.8.0",
  "ndk-context",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "oboe-sys",
 ]
@@ -3639,6 +3766,15 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
@@ -3988,6 +4124,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4083,6 +4233,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scanlex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "088c5d71572124929ea7549a8ce98e1a6fd33d0a38367b09027b382e67c033db"
 
 [[package]]
 name = "schemars"
@@ -4603,6 +4759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -5025,6 +5182,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5182,6 +5351,21 @@ dependencies = [
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-cron-scheduler"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c2e3a88f827f597799cf70a6f673074e62f3fc5ba5993b2873345c618a29af"
+dependencies = [
+ "chrono",
+ "cron",
+ "num-derive 0.3.3",
+ "num-traits",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -5673,6 +5857,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/mori-tauri",
     "crates/mori-cli",
     "crates/mori-file-loader",
+    "crates/mori-time",
 ]
 
 [workspace.package]

--- a/crates/mori-time/Cargo.toml
+++ b/crates/mori-time/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "mori-time"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[dependencies]
+# K1:SQLite + bundled(避免 system libsqlite dep,Windows / Linux 一致)
+rusqlite = { version = "0.31", features = ["bundled"] }
+
+# 共用
+thiserror = { workspace = true }
+chrono = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# K2-K5 用,先放 deps,K1 不 use 也 compile pass:
+tokio-cron-scheduler = "0.10"   # K2 scheduler
+notify-rust = "4"               # K3 notifier
+chrono-english = "0.1"          # K4 NL parser
+tokio = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/mori-time/src/commands.rs
+++ b/crates/mori-time/src/commands.rs
@@ -1,0 +1,11 @@
+//! K5 commands — 待實作(Tauri command 包裝)
+//!
+//! TODO: 由 K5 stream impl。本 stub 確保 K1 ship 後 `lib.rs` 不 break。
+//!
+//! 預期 Tauri commands(by K5):
+//! - `remind_me(text: String, when: String) -> Result<Reminder, String>`
+//! - `list_reminders() -> Result<Vec<Reminder>, String>`
+//! - `cancel_reminder(id: i64) -> Result<(), String>`
+//! - `snooze_reminder(id: i64, minutes: i64) -> Result<(), String>`
+//!
+//! K5 會在 `crates/mori-tauri/src/lib.rs` 把這些 register 進 Tauri invoke handler。

--- a/crates/mori-time/src/lib.rs
+++ b/crates/mori-time/src/lib.rs
@@ -1,0 +1,21 @@
+//! mori-time — 時之鳥(本機 reminder + cron)
+//!
+//! 「時之鳥」是 Mori 在用戶世界裡的計時靈鳥 — 替用戶記住一次性或週期性的事項,
+//! 到時鳴叫提醒。完全本地執行,vault-friendly,不依賴任何雲端排程服務。
+//!
+//! 5 sub-streams:
+//! - K1(本 stream):schema + CRUD(this module: [`schema`])
+//! - K2: [`scheduler`] — tokio-cron-scheduler 整合(背景觸發)
+//! - K3: [`notifier`] — notify-rust 桌面通知
+//! - K4: [`parser`] — chrono-english 自然語言時間解析
+//! - K5: [`commands`] — Tauri 命令(remind_me / list_reminders / cancel_reminder / snooze_reminder)
+//!
+//! K1 ship 後其他 sub-streams 可並行接,不會 module conflict。
+
+pub mod schema;
+pub mod scheduler; // K2 stub
+pub mod notifier; // K3 stub
+pub mod parser; // K4 stub
+pub mod commands; // K5 stub
+
+pub use schema::{Reminder, ReminderError, ReminderStatus, ReminderStore};

--- a/crates/mori-time/src/notifier.rs
+++ b/crates/mori-time/src/notifier.rs
@@ -1,0 +1,8 @@
+//! K3 notifier — 待實作(notify-rust 桌面通知)
+//!
+//! TODO: 由 K3 stream impl。本 stub 確保 K1 ship 後 `lib.rs` 不 break。
+//!
+//! 預期 API(by K3):
+//! - `notify(reminder: &Reminder) -> Result<(), NotifyError>`
+//! - 跨平台:Linux(libnotify)/ Windows(toast)/ macOS(NSUserNotification)
+//! - 由 K2 scheduler 觸發

--- a/crates/mori-time/src/parser.rs
+++ b/crates/mori-time/src/parser.rs
@@ -1,0 +1,8 @@
+//! K4 parser — 待實作(chrono-english 自然語言時間解析)
+//!
+//! TODO: 由 K4 stream impl。本 stub 確保 K1 ship 後 `lib.rs` 不 break。
+//!
+//! 預期 API(by K4):
+//! - `parse_when(input: &str, now: DateTime<Utc>) -> Result<DateTime<Utc>, ParseError>`
+//! - 支援「明天早上 9 點」/ "tomorrow 9am" / "in 30 minutes" 等
+//! - cron pattern 偵測:「每天早上 8 點」→ cron expr

--- a/crates/mori-time/src/scheduler.rs
+++ b/crates/mori-time/src/scheduler.rs
@@ -1,0 +1,9 @@
+//! K2 scheduler — 待實作(tokio-cron-scheduler 整合)
+//!
+//! TODO: 由 K2 stream impl。本 stub 確保 K1 ship 後 `lib.rs` 不 break。
+//!
+//! 預期 API(by K2):
+//! - `ReminderScheduler::new(store: Arc<ReminderStore>) -> Self`
+//! - `start()` — 掃 store.list_pending() 排程進 tokio-cron-scheduler
+//! - `reload()` — store CRUD 後 re-sync
+//! - 到點觸發 → 呼叫 K3 notifier + store.mark_fired()

--- a/crates/mori-time/src/schema.rs
+++ b/crates/mori-time/src/schema.rs
@@ -1,0 +1,429 @@
+//! K1 — Reminder SQLite schema + CRUD
+//!
+//! [`ReminderStore`] 封裝一個 SQLite connection,提供:
+//! - `migrate()` — 建表(idempotent)
+//! - `create()` — 新增 reminder(回傳含 id 的 [`Reminder`])
+//! - `list_pending()` / `list_all()` / `get()` — 讀
+//! - `mark_fired()` / `snooze()` / `cancel()` — 狀態變更
+//!
+//! Note: K1 暫不負責背景排程,K2 會 wrap 本 store 在 `tokio-cron-scheduler` 內。
+
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection, OptionalExtension, Row};
+use serde::{Deserialize, Serialize};
+
+/// 單筆 reminder。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Reminder {
+    pub id: i64,
+    /// 要提醒的內容(短文字,可包含 emoji)。
+    pub text: String,
+    /// 下次觸發時間(UTC)。一次性 reminder fire 後就 stop;repeating 由 K2 scheduler 算下一次。
+    pub due_at: DateTime<Utc>,
+    /// `None` = 一次性;`Some(expr)` = 重複(K2 用 tokio-cron-scheduler 解析)。
+    pub cron_expr: Option<String>,
+    pub created_at: DateTime<Utc>,
+    /// 上次實際觸發時間;`None` = 還沒響過。
+    pub fired_at: Option<DateTime<Utc>>,
+    /// 暫緩到何時(snooze 後 status = Snoozed,到時間才繼續排程)。
+    pub snoozed_until: Option<DateTime<Utc>>,
+    pub status: ReminderStatus,
+}
+
+/// Reminder 生命週期狀態。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReminderStatus {
+    /// 排程中,等待 due_at。
+    Pending,
+    /// 已觸發(一次性 reminder 觸發後進此狀態)。
+    Fired,
+    /// 用戶 snooze 後暫緩。
+    Snoozed,
+    /// 用戶取消。
+    Cancelled,
+}
+
+impl ReminderStatus {
+    /// 序列化成資料庫存的小寫字串。
+    fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Fired => "fired",
+            Self::Snoozed => "snoozed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    fn from_db_str(s: &str) -> Result<Self, ReminderError> {
+        match s {
+            "pending" => Ok(Self::Pending),
+            "fired" => Ok(Self::Fired),
+            "snoozed" => Ok(Self::Snoozed),
+            "cancelled" => Ok(Self::Cancelled),
+            other => Err(ReminderError::BadStatus(other.to_string())),
+        }
+    }
+}
+
+/// store 錯誤類型。
+#[derive(Debug, thiserror::Error)]
+pub enum ReminderError {
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("not found: id={0}")]
+    NotFound(i64),
+    #[error("unknown reminder status string: {0}")]
+    BadStatus(String),
+}
+
+/// 包裝一個 SQLite connection,提供 reminder CRUD。
+///
+/// K2 scheduler 會持有 `Arc<Mutex<ReminderStore>>` 或自己拿 connection — 留給 K2 決定。
+pub struct ReminderStore {
+    conn: Connection,
+}
+
+impl ReminderStore {
+    /// 開啟(或建立)指定路徑的 SQLite db。會 auto-run `migrate()`。
+    pub fn open(db_path: &Path) -> Result<Self, ReminderError> {
+        let conn = Connection::open(db_path)?;
+        let store = Self { conn };
+        store.migrate()?;
+        Ok(store)
+    }
+
+    /// 開一個記憶體 db(tests 用)。自動 migrate。
+    pub fn open_in_memory() -> Result<Self, ReminderError> {
+        let conn = Connection::open_in_memory()?;
+        let store = Self { conn };
+        store.migrate()?;
+        Ok(store)
+    }
+
+    /// 建表。Idempotent — 重複跑不會錯。
+    pub fn migrate(&self) -> Result<(), ReminderError> {
+        self.conn.execute_batch(
+            r#"
+            CREATE TABLE IF NOT EXISTS reminders (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                text            TEXT NOT NULL,
+                due_at          TEXT NOT NULL,
+                cron_expr       TEXT,
+                created_at      TEXT NOT NULL,
+                fired_at        TEXT,
+                snoozed_until   TEXT,
+                status          TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_reminders_status ON reminders(status);
+            CREATE INDEX IF NOT EXISTS idx_reminders_due_at ON reminders(due_at);
+            "#,
+        )?;
+        Ok(())
+    }
+
+    /// 新增一個 pending reminder。`created_at` 自動填 now。
+    pub fn create(
+        &self,
+        text: String,
+        due_at: DateTime<Utc>,
+        cron: Option<String>,
+    ) -> Result<Reminder, ReminderError> {
+        let now = Utc::now();
+        let status = ReminderStatus::Pending;
+        self.conn.execute(
+            r#"INSERT INTO reminders (text, due_at, cron_expr, created_at, fired_at, snoozed_until, status)
+               VALUES (?1, ?2, ?3, ?4, NULL, NULL, ?5)"#,
+            params![
+                text,
+                due_at.to_rfc3339(),
+                cron,
+                now.to_rfc3339(),
+                status.as_db_str(),
+            ],
+        )?;
+        let id = self.conn.last_insert_rowid();
+        Ok(Reminder {
+            id,
+            text,
+            due_at,
+            cron_expr: cron,
+            created_at: now,
+            fired_at: None,
+            snoozed_until: None,
+            status,
+        })
+    }
+
+    /// 列出仍需排程的 reminder(status = Pending 或 Snoozed)。
+    pub fn list_pending(&self) -> Result<Vec<Reminder>, ReminderError> {
+        let mut stmt = self.conn.prepare(
+            r#"SELECT id, text, due_at, cron_expr, created_at, fired_at, snoozed_until, status
+               FROM reminders
+               WHERE status IN ('pending', 'snoozed')
+               ORDER BY due_at ASC"#,
+        )?;
+        let rows = stmt.query_map([], row_to_reminder)?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(ReminderError::from)
+            .and_then(|v| v.into_iter().collect::<Result<Vec<_>, _>>())
+    }
+
+    /// 列出所有 reminder(含 fired / cancelled),由舊到新。
+    pub fn list_all(&self) -> Result<Vec<Reminder>, ReminderError> {
+        let mut stmt = self.conn.prepare(
+            r#"SELECT id, text, due_at, cron_expr, created_at, fired_at, snoozed_until, status
+               FROM reminders
+               ORDER BY id ASC"#,
+        )?;
+        let rows = stmt.query_map([], row_to_reminder)?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(ReminderError::from)
+            .and_then(|v| v.into_iter().collect::<Result<Vec<_>, _>>())
+    }
+
+    /// 拿單筆。找不到回 `NotFound(id)`。
+    pub fn get(&self, id: i64) -> Result<Reminder, ReminderError> {
+        let mut stmt = self.conn.prepare(
+            r#"SELECT id, text, due_at, cron_expr, created_at, fired_at, snoozed_until, status
+               FROM reminders
+               WHERE id = ?1"#,
+        )?;
+        let row = stmt
+            .query_row(params![id], row_to_reminder)
+            .optional()?;
+        match row {
+            Some(r) => r,
+            None => Err(ReminderError::NotFound(id)),
+        }
+    }
+
+    /// 標記 fired:寫入 `fired_at` 並把 status 設為 Fired。
+    pub fn mark_fired(&self, id: i64, fired_at: DateTime<Utc>) -> Result<(), ReminderError> {
+        let n = self.conn.execute(
+            r#"UPDATE reminders
+               SET fired_at = ?1, status = ?2
+               WHERE id = ?3"#,
+            params![fired_at.to_rfc3339(), ReminderStatus::Fired.as_db_str(), id],
+        )?;
+        if n == 0 {
+            return Err(ReminderError::NotFound(id));
+        }
+        Ok(())
+    }
+
+    /// snooze 到指定時間。status -> Snoozed。
+    pub fn snooze(&self, id: i64, until: DateTime<Utc>) -> Result<(), ReminderError> {
+        let n = self.conn.execute(
+            r#"UPDATE reminders
+               SET snoozed_until = ?1, status = ?2
+               WHERE id = ?3"#,
+            params![until.to_rfc3339(), ReminderStatus::Snoozed.as_db_str(), id],
+        )?;
+        if n == 0 {
+            return Err(ReminderError::NotFound(id));
+        }
+        Ok(())
+    }
+
+    /// 取消 reminder。status -> Cancelled。
+    pub fn cancel(&self, id: i64) -> Result<(), ReminderError> {
+        let n = self.conn.execute(
+            r#"UPDATE reminders
+               SET status = ?1
+               WHERE id = ?2"#,
+            params![ReminderStatus::Cancelled.as_db_str(), id],
+        )?;
+        if n == 0 {
+            return Err(ReminderError::NotFound(id));
+        }
+        Ok(())
+    }
+}
+
+/// 把 sqlite row 拆成 `Reminder`。回傳 nested Result 因為 status 解析可能失敗。
+fn row_to_reminder(row: &Row<'_>) -> rusqlite::Result<Result<Reminder, ReminderError>> {
+    let id: i64 = row.get(0)?;
+    let text: String = row.get(1)?;
+    let due_at: String = row.get(2)?;
+    let cron_expr: Option<String> = row.get(3)?;
+    let created_at: String = row.get(4)?;
+    let fired_at: Option<String> = row.get(5)?;
+    let snoozed_until: Option<String> = row.get(6)?;
+    let status: String = row.get(7)?;
+
+    Ok((|| -> Result<Reminder, ReminderError> {
+        Ok(Reminder {
+            id,
+            text,
+            due_at: parse_rfc3339(&due_at)?,
+            cron_expr,
+            created_at: parse_rfc3339(&created_at)?,
+            fired_at: fired_at.as_deref().map(parse_rfc3339).transpose()?,
+            snoozed_until: snoozed_until.as_deref().map(parse_rfc3339).transpose()?,
+            status: ReminderStatus::from_db_str(&status)?,
+        })
+    })())
+}
+
+fn parse_rfc3339(s: &str) -> Result<DateTime<Utc>, ReminderError> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| {
+            // 包成 BadStatus 沿用 — 比較簡單。實際上應該分一個 BadTimestamp,但 K1 暫不需要。
+            ReminderError::BadStatus(format!("bad rfc3339 timestamp '{s}': {e}"))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    fn store() -> ReminderStore {
+        ReminderStore::open_in_memory().expect("open in-memory store")
+    }
+
+    #[test]
+    fn migrate_creates_table_idempotent() {
+        let s = store();
+        // 第二次跑不應該錯
+        s.migrate().expect("second migrate ok");
+        s.migrate().expect("third migrate ok");
+        // sanity: list_all 不會炸
+        assert_eq!(s.list_all().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn create_returns_reminder_with_id() {
+        let s = store();
+        let due = Utc::now() + Duration::minutes(10);
+        let r = s
+            .create("喝水".to_string(), due, None)
+            .expect("create ok");
+        assert!(r.id > 0);
+        assert_eq!(r.text, "喝水");
+        assert_eq!(r.status, ReminderStatus::Pending);
+        assert!(r.cron_expr.is_none());
+
+        // 再 create 一筆 id 應該遞增
+        let r2 = s
+            .create("散步".to_string(), due + Duration::minutes(5), None)
+            .expect("create2 ok");
+        assert!(r2.id > r.id);
+    }
+
+    #[test]
+    fn list_pending_filters_by_status() {
+        let s = store();
+        let due = Utc::now() + Duration::minutes(10);
+        let r1 = s.create("a".into(), due, None).unwrap();
+        let r2 = s.create("b".into(), due, None).unwrap();
+        let r3 = s.create("c".into(), due, None).unwrap();
+
+        // 把 r2 標 fired, r3 cancel,r1 留 pending
+        s.mark_fired(r2.id, Utc::now()).unwrap();
+        s.cancel(r3.id).unwrap();
+
+        let pending = s.list_pending().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id, r1.id);
+
+        // list_all 應該全部三筆
+        assert_eq!(s.list_all().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn list_pending_includes_snoozed() {
+        let s = store();
+        let due = Utc::now() + Duration::minutes(10);
+        let r = s.create("snoozey".into(), due, None).unwrap();
+        s.snooze(r.id, Utc::now() + Duration::minutes(30)).unwrap();
+        let pending = s.list_pending().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].status, ReminderStatus::Snoozed);
+    }
+
+    #[test]
+    fn get_returns_error_for_unknown_id() {
+        let s = store();
+        match s.get(999) {
+            Err(ReminderError::NotFound(id)) => assert_eq!(id, 999),
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mark_fired_updates_status_and_timestamp() {
+        let s = store();
+        let due = Utc::now() + Duration::minutes(10);
+        let r = s.create("test".into(), due, None).unwrap();
+        assert!(r.fired_at.is_none());
+
+        let fired_at = Utc::now();
+        s.mark_fired(r.id, fired_at).unwrap();
+
+        let after = s.get(r.id).unwrap();
+        assert_eq!(after.status, ReminderStatus::Fired);
+        assert!(after.fired_at.is_some());
+        // 容忍 1 秒誤差(rfc3339 round-trip)
+        let diff = (after.fired_at.unwrap() - fired_at).num_seconds().abs();
+        assert!(diff <= 1, "fired_at round-trip drift {diff}s");
+
+        // 不存在 id 應該回 NotFound
+        match s.mark_fired(999, Utc::now()) {
+            Err(ReminderError::NotFound(_)) => {}
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn snooze_updates_until_and_status() {
+        let s = store();
+        let due = Utc::now() + Duration::minutes(10);
+        let r = s.create("snz".into(), due, None).unwrap();
+        let until = Utc::now() + Duration::hours(1);
+        s.snooze(r.id, until).unwrap();
+
+        let after = s.get(r.id).unwrap();
+        assert_eq!(after.status, ReminderStatus::Snoozed);
+        assert!(after.snoozed_until.is_some());
+
+        match s.snooze(999, until) {
+            Err(ReminderError::NotFound(_)) => {}
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cancel_updates_status() {
+        let s = store();
+        let due = Utc::now() + Duration::minutes(10);
+        let r = s.create("byebye".into(), due, None).unwrap();
+        s.cancel(r.id).unwrap();
+
+        let after = s.get(r.id).unwrap();
+        assert_eq!(after.status, ReminderStatus::Cancelled);
+
+        match s.cancel(999) {
+            Err(ReminderError::NotFound(_)) => {}
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn create_with_cron_expr_persists() {
+        let s = store();
+        let due = Utc::now() + Duration::minutes(10);
+        let r = s
+            .create(
+                "每天早上提醒喝水".into(),
+                due,
+                Some("0 0 8 * * *".to_string()),
+            )
+            .unwrap();
+        let fetched = s.get(r.id).unwrap();
+        assert_eq!(fetched.cron_expr.as_deref(), Some("0 0 8 * * *"));
+    }
+}


### PR DESCRIPTION
## Summary

**Stream K1 of 5(時之鳥)** — 建新 crate `crates/mori-time/`,本機 reminder + cron 系統。本 PR 只 ship **K1 = SQLite reminder schema + CRUD**。Sub-streams K2 (cron) / K3 (notifier) / K4 (NL parser) / K5 (Tauri commands) 各自並行 chain on this。

§9 P1 「時之鳥」`docs/roadmap.md` — 修補 Mori 「6 點提醒我」目前完全接不住的 gap。

## Changes(9 新檔)

- `crates/mori-time/Cargo.toml`(rusqlite bundled + chrono + thiserror + serde + K2-K5 預先放 deps)
- `crates/mori-time/src/lib.rs`(declares 5 modules + re-exports)
- `crates/mori-time/src/schema.rs`(K1 — Reminder / ReminderStatus / ReminderStore / ReminderError + 9 tests)
- `crates/mori-time/src/{scheduler,notifier,parser,commands}.rs`(K2-K5 stubs,純 module doc + TODO)
- workspace `Cargo.toml`(+1 member)

## Design

- **rusqlite 0.31 bundled** — 跨平台一鍵 build,不依賴 system sqlite
- **時間欄位 rfc3339 字串**(TEXT)— 可讀 + lexical 比較 = chrono 排序對
- **2 indexes**:`idx_reminders_status` / `idx_reminders_due_at`
- **ReminderStore 不持 Mutex** — 留給 K2/K5 自決(rusqlite Connection 非 Send)
- **migrate idempotent**(`CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS`)
- **Wire vs DB format 分離** — Status enum PascalCase 對外 serde / 內部小寫存 DB

## Sub-stream 隔離設計

K1 預先在 `lib.rs` declare 全部 modules + 在 Cargo.toml 加 K2-K5 deps(K1 不 use),讓 K2-K5 各自開檔不衝突 lib.rs 或 Cargo.toml。

## Test plan

- [x] 9 schema tests passing(migrate idempotent / create / list filter / get NotFound / mark_fired / snooze / cancel / cron persist)
- [x] cargo test -p mori-core --lib:216 沒破
- [x] cargo test -p mori-tauri --bin mori-tauri:84 沒破
- [x] cargo test -p mori-file-loader:12 沒破
- [x] verify.sh 全綠

## Reviews

- ✅ Spec compliance: APPROVED
- ✅ Code quality: APPROVED (★★★★☆)

## Known follow-up(code quality reviewer 列的)

- **Important**:`ReminderError::BadStatus(String)` 目前同時裝 status 解析錯 + timestamp 解析錯。應拆 `BadTimestamp(String)` variant(implementer 也標 TODO)— K2 / K5 land 前最好補,避免 breaking change
- Nits:`Cargo.toml` `version.workspace = true` scalar vs 既有 table form 風格、`#[derive(Debug, thiserror::Error)]` fully-qualified 跟既有 `use thiserror::Error;` 風格不一致
- `ReminderStore` 沒 transaction API — K2 若要 atomic 多步操作再加

🤖 Generated with [Claude Code](https://claude.com/claude-code)