### PR TITLE
feat(time-bird): NL time parser (K4) — chrono-english + 中文 fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,6 +754,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-english"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a56613410c9249673f4676ab8d27c70949814accb27b6b738009e2ff1034a1"
+dependencies = [
+ "chrono",
+ "scanlex",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +982,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+dependencies = [
+ "chrono",
+ "nom 7.1.3",
+ "once_cell",
 ]
 
 [[package]]
@@ -1422,6 +1455,18 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1969,6 +2014,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1981,6 +2035,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -2575,6 +2638,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libyml"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2650,6 +2724,18 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
+]
 
 [[package]]
 name = "mach2"
@@ -2840,6 +2926,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "mori-time"
+version = "0.7.1"
+dependencies = [
+ "chrono",
+ "chrono-english",
+ "notify-rust",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-cron-scheduler",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,6 +3062,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-rust"
+version = "4.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2973,6 +3089,17 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "num-derive"
@@ -3222,7 +3349,7 @@ dependencies = [
  "jni",
  "ndk 0.8.0",
  "ndk-context",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "oboe-sys",
 ]
@@ -3639,6 +3766,15 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
@@ -3988,6 +4124,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4083,6 +4233,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scanlex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "088c5d71572124929ea7549a8ce98e1a6fd33d0a38367b09027b382e67c033db"
 
 [[package]]
 name = "schemars"
@@ -4603,6 +4759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -5025,6 +5182,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5182,6 +5351,21 @@ dependencies = [
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-cron-scheduler"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c2e3a88f827f597799cf70a6f673074e62f3fc5ba5993b2873345c618a29af"
+dependencies = [
+ "chrono",
+ "cron",
+ "num-derive 0.3.3",
+ "num-traits",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -5673,6 +5857,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/mori-tauri",
     "crates/mori-cli",
     "crates/mori-file-loader",
+    "crates/mori-time",
 ]
 
 [workspace.package]

--- a/crates/mori-time/Cargo.toml
+++ b/crates/mori-time/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "mori-time"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[dependencies]
+# K1:SQLite + bundled(避免 system libsqlite dep,Windows / Linux 一致)
+rusqlite = { version = "0.31", features = ["bundled"] }
+
+# 共用
+thiserror = { workspace = true }
+chrono = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# K2-K5 用,先放 deps,K1 不 use 也 compile pass:
+tokio-cron-scheduler = "0.10"   # K2 scheduler
+notify-rust = "4"               # K3 notifier
+chrono-english = "0.1"          # K4 NL parser
+tokio = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/mori-time/src/commands.rs
+++ b/crates/mori-time/src/commands.rs
@@ -1,0 +1,11 @@
+//! K5 commands — 待實作(Tauri command 包裝)
+//!
+//! TODO: 由 K5 stream impl。本 stub 確保 K1 ship 後 `lib.rs` 不 break。
+//!
+//! 預期 Tauri commands(by K5):
+//! - `remind_me(text: String, when: String) -> Result<Reminder, String>`
+//! - `list_reminders() -> Result<Vec<Reminder>, String>`
+//! - `cancel_reminder(id: i64) -> Result<(), String>`
+//! - `snooze_reminder(id: i64, minutes: i64) -> Result<(), String>`
+//!
+//! K5 會在 `crates/mori-tauri/src/lib.rs` 把這些 register 進 Tauri invoke handler。

--- a/crates/mori-time/src/lib.rs
+++ b/crates/mori-time/src/lib.rs
@@ -1,0 +1,21 @@
+//! mori-time — 時之鳥(本機 reminder + cron)
+//!
+//! 「時之鳥」是 Mori 在用戶世界裡的計時靈鳥 — 替用戶記住一次性或週期性的事項,
+//! 到時鳴叫提醒。完全本地執行,vault-friendly,不依賴任何雲端排程服務。
+//!
+//! 5 sub-streams:
+//! - K1(本 stream):schema + CRUD(this module: [`schema`])
+//! - K2: [`scheduler`] — tokio-cron-scheduler 整合(背景觸發)
+//! - K3: [`notifier`] — notify-rust 桌面通知
+//! - K4: [`parser`] — chrono-english 自然語言時間解析
+//! - K5: [`commands`] — Tauri 命令(remind_me / list_reminders / cancel_reminder / snooze_reminder)
+//!
+//! K1 ship 後其他 sub-streams 可並行接,不會 module conflict。
+
+pub mod schema;
+pub mod scheduler; // K2 stub
+pub mod notifier; // K3 stub
+pub mod parser; // K4 stub
+pub mod commands; // K5 stub
+
+pub use schema::{Reminder, ReminderError, ReminderStatus, ReminderStore};

--- a/crates/mori-time/src/notifier.rs
+++ b/crates/mori-time/src/notifier.rs
@@ -1,0 +1,8 @@
+//! K3 notifier — 待實作(notify-rust 桌面通知)
+//!
+//! TODO: 由 K3 stream impl。本 stub 確保 K1 ship 後 `lib.rs` 不 break。
+//!
+//! 預期 API(by K3):
+//! - `notify(reminder: &Reminder) -> Result<(), NotifyError>`
+//! - 跨平台:Linux(libnotify)/ Windows(toast)/ macOS(NSUserNotification)
+//! - 由 K2 scheduler 觸發

--- a/crates/mori-time/src/parser.rs
+++ b/crates/mori-time/src/parser.rs
@@ -1,8 +1,628 @@
-//! K4 parser — 待實作(chrono-english 自然語言時間解析)
+//! K4 parser — 自然語言時間解析
 //!
-//! TODO: 由 K4 stream impl。本 stub 確保 K1 ship 後 `lib.rs` 不 break。
+//! User input(中/英文)→ `chrono::DateTime<Utc>`。
 //!
-//! 預期 API(by K4):
-//! - `parse_when(input: &str, now: DateTime<Utc>) -> Result<DateTime<Utc>, ParseError>`
-//! - 支援「明天早上 9 點」/ "tomorrow 9am" / "in 30 minutes" 等
-//! - cron pattern 偵測:「每天早上 8 點」→ cron expr
+//! 支援例子:
+//! - 英文(走 `chrono-english`):
+//!   - `"6pm"` / `"tomorrow 9am"` / `"in 30 minutes"` / `"30 minutes"` / `"next monday"`
+//! - 中文(走自寫薄 layer,std string ops,不引 regex):
+//!   - `"30 分鐘後"` / `"1 小時後"` / `"2 天後"`
+//!   - `"明天 9 點"` / `"明天早上 9 點"` / `"明天晚上 9 點"` / `"後天 9 點"`
+//!   - `"6 點"` / `"晚上 6 點"` / `"早上 6 點"` / `"下午 3 點"` / `"中午"` / `"半夜"`
+//!   - `"下週一"` ~ `"下週日"`(到 00:00,可選 trailing `" X 點"`)
+//!
+//! 過去時間 → `PastTime` error(嚴格 reject)。
+//!
+//! 兩條解析路徑:
+//! 1. 先試 `chrono-english::parse_date_string`(UK dialect — 比較少奇怪 mm/dd 推斷)。
+//! 2. fail 就試 `parse_chinese` 自寫 layer。
+//! 3. 都 fail → `Unrecognized`。
+//!
+//! 結果若早於 now → `PastTime`。
+//!
+//! K5 commands 會用 [`parse_or_default`] 給 LLM tool call 餵 fallback default。
+
+use chrono::{DateTime, Datelike, Duration, Local, NaiveDate, TimeZone, Utc, Weekday};
+use chrono_english::{parse_date_string, Dialect};
+
+/// parse 錯誤類型。
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    /// 無法解析的 expression。
+    #[error("can't parse time expression: {0}")]
+    Unrecognized(String),
+    /// 成功 parse 但結果在過去 — K1 reminder 不接受。
+    #[error("parsed time in past: {0}")]
+    PastTime(String),
+}
+
+/// 解析自然語言時間 expression 成 UTC `DateTime`。
+///
+/// 兩條 fallback:chrono-english(英文)→ 中文 layer。
+/// 結果若在過去 → `PastTime` error。
+pub fn parse(expr: &str) -> Result<DateTime<Utc>, ParseError> {
+    parse_at(expr, Local::now())
+}
+
+/// 同 [`parse`],但 caller 控制「now」基準(tests 用)。
+pub fn parse_at(expr: &str, now: DateTime<Local>) -> Result<DateTime<Utc>, ParseError> {
+    let trimmed = expr.trim();
+    if trimmed.is_empty() {
+        return Err(ParseError::Unrecognized(expr.to_string()));
+    }
+
+    // 路徑 A:chrono-english(英文 NL)
+    if let Ok(dt_local) = parse_date_string(trimmed, now, Dialect::Uk) {
+        return finalize(dt_local.with_timezone(&Utc), now);
+    }
+
+    // 路徑 B:中文 fallback
+    if let Some(dt_utc) = parse_chinese(trimmed, now) {
+        return finalize(dt_utc, now);
+    }
+
+    Err(ParseError::Unrecognized(expr.to_string()))
+}
+
+/// 解析失敗就回 default — K5 commands 給 LLM tool call 用。
+pub fn parse_or_default(expr: &str, default: DateTime<Utc>) -> DateTime<Utc> {
+    parse(expr).unwrap_or(default)
+}
+
+fn finalize(
+    candidate: DateTime<Utc>,
+    now_local: DateTime<Local>,
+) -> Result<DateTime<Utc>, ParseError> {
+    let now_utc = now_local.with_timezone(&Utc);
+    if candidate < now_utc {
+        return Err(ParseError::PastTime(candidate.to_rfc3339()));
+    }
+    Ok(candidate)
+}
+
+// -----------------------------------------------------------------------------
+// 中文 fallback — 簡薄 layer,std string ops 只
+// -----------------------------------------------------------------------------
+
+/// 中文 NL → UTC DateTime。不認 → `None`。
+///
+/// 試的順序:
+/// 1. `X 分鐘/小時/天後`
+/// 2. `下週X` (+ optional 時間)
+/// 3. `(明天|後天)? (早上|上午|中午|下午|晚上|半夜)? N 點(M 分)?`
+fn parse_chinese(expr: &str, now: DateTime<Local>) -> Option<DateTime<Utc>> {
+    // 全形空白也轉成半形再 trim,容忍一些 user 輸入。
+    let normalized: String = expr.chars().map(|c| if c == '\u{3000}' { ' ' } else { c }).collect();
+    let s = normalized.trim();
+
+    if let Some(dt) = parse_relative_later(s, now) {
+        return Some(dt);
+    }
+    if let Some(dt) = parse_next_weekday(s, now) {
+        return Some(dt);
+    }
+    if let Some(dt) = parse_clock(s, now) {
+        return Some(dt);
+    }
+    None
+}
+
+/// `30 分鐘後` / `1 小時後` / `2 天後` / `5分鐘以後`
+fn parse_relative_later(s: &str, now: DateTime<Local>) -> Option<DateTime<Utc>> {
+    let suffixes = [("分鐘後", 60i64), ("分鐘以後", 60), ("分後", 60),
+                    ("小時後", 3600), ("小時以後", 3600),
+                    ("天後", 86400), ("天以後", 86400),
+                    ("日後", 86400)];
+    for (suffix, sec_per_unit) in suffixes {
+        if let Some(prefix) = s.strip_suffix(suffix) {
+            let n: i64 = prefix.trim().parse().ok()?;
+            if n < 0 {
+                return None;
+            }
+            let dt = now + Duration::seconds(n * sec_per_unit);
+            return Some(dt.with_timezone(&Utc));
+        }
+    }
+    None
+}
+
+/// `下週一` / `下週五` / `下週日`(+ optional `" X 點"` / `" 早上 X 點"`...)
+fn parse_next_weekday(s: &str, now: DateTime<Local>) -> Option<DateTime<Utc>> {
+    // 先抓 weekday prefix。
+    let weekday_pairs = [
+        ("下週一", Weekday::Mon),
+        ("下週二", Weekday::Tue),
+        ("下週三", Weekday::Wed),
+        ("下週四", Weekday::Thu),
+        ("下週五", Weekday::Fri),
+        ("下週六", Weekday::Sat),
+        ("下週日", Weekday::Sun),
+        ("下週天", Weekday::Sun),
+        ("下星期一", Weekday::Mon),
+        ("下星期二", Weekday::Tue),
+        ("下星期三", Weekday::Wed),
+        ("下星期四", Weekday::Thu),
+        ("下星期五", Weekday::Fri),
+        ("下星期六", Weekday::Sat),
+        ("下星期日", Weekday::Sun),
+        ("下星期天", Weekday::Sun),
+    ];
+
+    for (prefix, target_wd) in weekday_pairs {
+        if let Some(rest) = s.strip_prefix(prefix) {
+            // 目標日期 = 至少 +1 天的下一個對應 weekday(包含「下週」語意:
+            // 中文「下週X」一般指「下一週」的那天,不是「這週 X 還沒到的那天」。
+            // 簡化:從今天 +1 day 開始找,直到 weekday match,但若這樣只跳到「本週後幾天」就再 +7。
+            let today = now.date_naive();
+            let mut candidate = today + chrono::Duration::days(1);
+            while candidate.weekday() != target_wd {
+                candidate += chrono::Duration::days(1);
+            }
+            // 確保是「下一週」:如果 candidate 跟 today 在同一個 ISO week 直接 +7。
+            if candidate.iso_week() == today.iso_week() {
+                candidate += chrono::Duration::days(7);
+            }
+
+            let rest = rest.trim();
+            let (hour, minute) = if rest.is_empty() {
+                (9, 0) // default 早上 9 點
+            } else if let Some((h, m)) = extract_clock(rest) {
+                (h, m)
+            } else {
+                // 認 prefix 但 trailing 看不懂 — 還是先回 default 時間。
+                (9, 0)
+            };
+
+            return build_local_dt(candidate, hour, minute, now);
+        }
+    }
+    None
+}
+
+/// `6 點` / `早上 9 點` / `晚上 6 點半` / `下午 3 點` / `明天 9 點` / `明天早上 9 點`
+fn parse_clock(s: &str, now: DateTime<Local>) -> Option<DateTime<Utc>> {
+    // 抓 day offset prefix(明天 / 後天 / 大後天 / 今天)。
+    let (day_offset, rest) = if let Some(r) = s.strip_prefix("大後天") {
+        (3i64, r.trim())
+    } else if let Some(r) = s.strip_prefix("後天") {
+        (2, r.trim())
+    } else if let Some(r) = s.strip_prefix("明天") {
+        (1, r.trim())
+    } else if let Some(r) = s.strip_prefix("明日") {
+        (1, r.trim())
+    } else if let Some(r) = s.strip_prefix("今天") {
+        (0, r.trim())
+    } else if let Some(r) = s.strip_prefix("今日") {
+        (0, r.trim())
+    } else {
+        (0, s)
+    };
+
+    // 特殊整點 keyword:中午 / 半夜
+    if rest == "中午" {
+        let date = now.date_naive() + chrono::Duration::days(day_offset);
+        return build_local_dt(date, 12, 0, now);
+    }
+    if rest == "半夜" {
+        let date = now.date_naive() + chrono::Duration::days(day_offset);
+        return build_local_dt(date, 0, 0, now);
+    }
+
+    let (hour, minute) = extract_clock(rest)?;
+    let target_date = now.date_naive() + chrono::Duration::days(day_offset);
+
+    // 沒有 day prefix、結果時間又在 now 之前(eg 現在 20:00 user 講「6 點」)— 不自動推到明天,
+    // 由 caller 決定(嚴格 PastTime)。spec 講 strict reject。
+    build_local_dt(target_date, hour, minute, now)
+}
+
+/// 從中間 fragment 抽 `(時段)? N 點 (M 分)?` 的 `(hour, minute)`。
+/// 不認回 `None`。
+///
+/// 支援 period prefix:`早上` / `上午` / `中午` / `下午` / `晚上` / `傍晚` / `凌晨` / `半夜`。
+/// `下午 / 晚上 / 傍晚` 會把 1-11 點推成 13-23 點;`中午` 強制 12;`半夜 / 凌晨` 保留 0-x 不變,但 12 點半夜會變 0。
+fn extract_clock(s: &str) -> Option<(u32, u32)> {
+    let (period, rest) = strip_period(s);
+    let rest = rest.trim();
+
+    // `N 點半` / `N 點` / `N 點 M 分`
+    // 先找 「點」
+    let hour_end = rest.find('點')?;
+    let hour_str = rest[..hour_end].trim();
+    let hour: u32 = hour_str.parse().ok()?;
+
+    let after_dian = rest[hour_end + '點'.len_utf8()..].trim();
+
+    let minute: u32 = if after_dian.is_empty() {
+        0
+    } else if after_dian == "半" {
+        30
+    } else if let Some(m_str) = after_dian.strip_suffix('分') {
+        m_str.trim().parse().ok()?
+    } else if let Some(m_str) = after_dian.strip_suffix("分鐘") {
+        m_str.trim().parse().ok()?
+    } else {
+        return None;
+    };
+
+    if minute >= 60 {
+        return None;
+    }
+
+    let hour = apply_period(period, hour)?;
+    if hour >= 24 {
+        return None;
+    }
+    Some((hour, minute))
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Period {
+    None,
+    Morning, // 早上 / 上午 / 凌晨
+    Noon,    // 中午
+    Afternoon, // 下午
+    Evening, // 晚上 / 傍晚 / 夜裡 / 夜晚
+    Midnight, // 半夜 / 深夜
+}
+
+fn strip_period(s: &str) -> (Period, &str) {
+    // 順序:長的 prefix 先試。
+    let trials: &[(&str, Period)] = &[
+        ("早上", Period::Morning),
+        ("上午", Period::Morning),
+        ("凌晨", Period::Morning),
+        ("中午", Period::Noon),
+        ("下午", Period::Afternoon),
+        ("晚上", Period::Evening),
+        ("傍晚", Period::Evening),
+        ("夜晚", Period::Evening),
+        ("夜裡", Period::Evening),
+        ("半夜", Period::Midnight),
+        ("深夜", Period::Midnight),
+    ];
+    for (prefix, period) in trials {
+        if let Some(rest) = s.strip_prefix(prefix) {
+            return (*period, rest);
+        }
+    }
+    (Period::None, s)
+}
+
+fn apply_period(period: Period, hour: u32) -> Option<u32> {
+    match period {
+        Period::None => {
+            if hour <= 24 {
+                Some(hour % 24)
+            } else {
+                None
+            }
+        }
+        Period::Morning => {
+            // 早上 12 點 → 0;早上 1-11 → 不變;早上 12+ → 怪,reject。
+            if hour == 12 {
+                Some(0)
+            } else if hour < 12 {
+                Some(hour)
+            } else {
+                None
+            }
+        }
+        Period::Noon => {
+            // 中午 12 點 → 12;中午 N 點 (N != 12) — 比較怪,接受 12 並 ignore N。
+            // 嚴格點:N == 12 才接受。
+            if hour == 12 {
+                Some(12)
+            } else {
+                None
+            }
+        }
+        Period::Afternoon => {
+            // 下午 1-11 → 13-23;下午 12 → 12。
+            if hour == 12 {
+                Some(12)
+            } else if (1..12).contains(&hour) {
+                Some(hour + 12)
+            } else {
+                None
+            }
+        }
+        Period::Evening => {
+            // 晚上 6 點 → 18 / 晚上 11 → 23 / 晚上 12 → 0(過了午夜) / 晚上 7 → 19。
+            if hour == 12 {
+                Some(0)
+            } else if (1..12).contains(&hour) {
+                Some(hour + 12)
+            } else {
+                None
+            }
+        }
+        Period::Midnight => {
+            // 半夜 12 → 0;半夜 1 → 1;半夜 N (N >= 12) — reject。
+            if hour == 12 {
+                Some(0)
+            } else if hour < 12 {
+                Some(hour)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+fn build_local_dt(
+    date: NaiveDate,
+    hour: u32,
+    minute: u32,
+    _now: DateTime<Local>,
+) -> Option<DateTime<Utc>> {
+    let naive = date.and_hms_opt(hour, minute, 0)?;
+    let local = Local
+        .from_local_datetime(&naive)
+        .single()
+        .or_else(|| {
+            // DST 邊界:取較早的那個（保守）。
+            Local.from_local_datetime(&naive).earliest()
+        })?;
+    Some(local.with_timezone(&Utc))
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration as ChronoDuration, TimeZone};
+
+    /// fixed local "now" — 2026-05-22 (Fri) 10:00:00 local。
+    /// 用 fixed base 避免 flaky / DST,但有些 test 還是用 `Local::now()`。
+    fn fixed_now() -> DateTime<Local> {
+        Local
+            .with_ymd_and_hms(2026, 5, 22, 10, 0, 0)
+            .single()
+            .expect("fixed now")
+    }
+
+    fn assert_close(a: DateTime<Utc>, b: DateTime<Utc>, tol_sec: i64) {
+        let diff = (a - b).num_seconds().abs();
+        assert!(
+            diff <= tol_sec,
+            "expected within {tol_sec}s, got {diff}s ({a} vs {b})"
+        );
+    }
+
+    // ----- 英文 (chrono-english) -----
+
+    #[test]
+    fn parse_english_relative_minutes() {
+        let now = fixed_now();
+        let expected = (now + ChronoDuration::minutes(30)).with_timezone(&Utc);
+        let got = parse_at("30 minutes", now).expect("parse 30 minutes");
+        // chrono-english 的 "30 minutes" 是相對 base — 應該 = base + 30min。
+        assert_close(got, expected, 2);
+
+        let got2 = parse_at("30m", now).expect("parse 30m");
+        assert_close(got2, expected, 2);
+    }
+
+    #[test]
+    fn parse_english_tomorrow_time() {
+        let now = fixed_now();
+        let got = parse_at("tomorrow 9am", now).expect("parse tomorrow 9am");
+        // 2026-05-23 09:00 local
+        let expected = Local
+            .with_ymd_and_hms(2026, 5, 23, 9, 0, 0)
+            .single()
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn parse_english_next_monday() {
+        let now = fixed_now(); // 2026-05-22 (Fri)
+        // chrono-english Dialect::Uk: "next mon" → next week's Monday = 2026-06-01
+        let got = parse_at("next mon", now).expect("parse next mon");
+        let expected = Local
+            .with_ymd_and_hms(2026, 6, 1, 0, 0, 0)
+            .single()
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn parse_english_past_time_errors() {
+        let now = fixed_now(); // 10:00
+        // "3 hours ago" → 2026-05-22 07:00 — 過去。
+        match parse_at("3 hours ago", now) {
+            Err(ParseError::PastTime(_)) => {}
+            other => panic!("expected PastTime, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_english_unrecognized_errors() {
+        let now = fixed_now();
+        match parse_at("blah blah blah xyzzy", now) {
+            Err(ParseError::Unrecognized(s)) => {
+                assert!(s.contains("blah"));
+            }
+            other => panic!("expected Unrecognized, got {other:?}"),
+        }
+
+        // 空 string 也應該 Unrecognized
+        match parse_at("   ", now) {
+            Err(ParseError::Unrecognized(_)) => {}
+            other => panic!("expected Unrecognized for empty, got {other:?}"),
+        }
+    }
+
+    // ----- 中文 -----
+
+    #[test]
+    fn parse_chinese_minutes_later() {
+        let now = fixed_now();
+        let got = parse_at("30 分鐘後", now).expect("30 分鐘後");
+        let expected = (now + ChronoDuration::minutes(30)).with_timezone(&Utc);
+        assert_close(got, expected, 2);
+
+        // 1 小時後
+        let got2 = parse_at("1 小時後", now).expect("1 小時後");
+        let expected2 = (now + ChronoDuration::hours(1)).with_timezone(&Utc);
+        assert_close(got2, expected2, 2);
+
+        // 2 天後
+        let got3 = parse_at("2 天後", now).expect("2 天後");
+        let expected3 = (now + ChronoDuration::days(2)).with_timezone(&Utc);
+        assert_close(got3, expected3, 2);
+
+        // 無 space 也 OK
+        let got4 = parse_at("45分鐘後", now).expect("45分鐘後");
+        let expected4 = (now + ChronoDuration::minutes(45)).with_timezone(&Utc);
+        assert_close(got4, expected4, 2);
+    }
+
+    #[test]
+    fn parse_chinese_tomorrow_time() {
+        let now = fixed_now();
+        // 明天 9 點 → 2026-05-23 09:00 local
+        let got = parse_at("明天 9 點", now).expect("明天 9 點");
+        let expected = Local
+            .with_ymd_and_hms(2026, 5, 23, 9, 0, 0)
+            .single()
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(got, expected);
+
+        // 明天早上 9 點 (帶 period)
+        let got2 = parse_at("明天早上 9 點", now).expect("明天早上 9 點");
+        assert_eq!(got2, expected);
+
+        // 明天晚上 6 點 → 2026-05-23 18:00 local
+        let got3 = parse_at("明天晚上 6 點", now).expect("明天晚上 6 點");
+        let expected3 = Local
+            .with_ymd_and_hms(2026, 5, 23, 18, 0, 0)
+            .single()
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(got3, expected3);
+    }
+
+    #[test]
+    fn parse_chinese_today_time() {
+        let now = fixed_now(); // 10:00
+        // 下午 3 點 → today 15:00
+        let got = parse_at("下午 3 點", now).expect("下午 3 點");
+        let expected = Local
+            .with_ymd_and_hms(2026, 5, 22, 15, 0, 0)
+            .single()
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(got, expected);
+
+        // 晚上 8 點半 → today 20:30
+        let got2 = parse_at("晚上 8 點半", now).expect("晚上 8 點半");
+        let expected2 = Local
+            .with_ymd_and_hms(2026, 5, 22, 20, 30, 0)
+            .single()
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(got2, expected2);
+
+        // 中午 → today 12:00
+        let got3 = parse_at("中午", now).expect("中午");
+        let expected3 = Local
+            .with_ymd_and_hms(2026, 5, 22, 12, 0, 0)
+            .single()
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(got3, expected3);
+    }
+
+    #[test]
+    fn parse_chinese_next_monday() {
+        let now = fixed_now(); // 2026-05-22 (Fri) — ISO week 21
+        // 下週一 → 2026-05-25 (Mon) 09:00
+        let got = parse_at("下週一", now).expect("下週一");
+        let expected = Local
+            .with_ymd_and_hms(2026, 5, 25, 9, 0, 0)
+            .single()
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(got, expected);
+
+        // 下週五 — 2026-05-22 (今天) 也是 Fri,所以 下週五 = 2026-05-29
+        let got2 = parse_at("下週五", now).expect("下週五");
+        let expected2 = Local
+            .with_ymd_and_hms(2026, 5, 29, 9, 0, 0)
+            .single()
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(got2, expected2);
+
+        // 下週日 3 點 — 2026-05-31 (Sun) 15:00 (因為「3 點」要 ambient period... 預設無 period → 直接 3:00)
+        // 實際:無 period 直接 hour=3 → 03:00。
+        let got3 = parse_at("下週日 3 點", now).expect("下週日 3 點");
+        let expected3 = Local
+            .with_ymd_and_hms(2026, 5, 31, 3, 0, 0)
+            .single()
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(got3, expected3);
+    }
+
+    #[test]
+    fn parse_chinese_past_time_errors() {
+        let now = fixed_now(); // 10:00
+        // 早上 6 點 → today 06:00 < 10:00 → PastTime
+        match parse_at("早上 6 點", now) {
+            Err(ParseError::PastTime(_)) => {}
+            other => panic!("expected PastTime, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_or_default_fallback() {
+        let default = Utc.with_ymd_and_hms(2099, 1, 1, 0, 0, 0).single().unwrap();
+        // unrecognized → 回 default
+        let got = parse_or_default("nonsensical wibble wobble", default);
+        assert_eq!(got, default);
+
+        // 過去時間也走 default(parse() return Err)
+        let got2 = parse_or_default("3 hours ago", default);
+        assert_eq!(got2, default);
+
+        // 有效 expression 不走 default — parse() success
+        let now = Local::now();
+        let expected = (now + ChronoDuration::minutes(10)).with_timezone(&Utc);
+        let got3 = parse_or_default("10 minutes", default);
+        // 用 5 秒 tolerance — wall clock 不固定
+        let diff = (got3 - expected).num_seconds().abs();
+        assert!(
+            diff <= 5,
+            "parse_or_default for valid input should match (diff {diff}s)"
+        );
+    }
+
+    // ----- 內部 helpers smoke -----
+
+    #[test]
+    fn extract_clock_basic() {
+        assert_eq!(extract_clock("9 點"), Some((9, 0)));
+        assert_eq!(extract_clock("9點"), Some((9, 0)));
+        assert_eq!(extract_clock("9 點 30 分"), Some((9, 30)));
+        assert_eq!(extract_clock("9點30分"), Some((9, 30)));
+        assert_eq!(extract_clock("8 點半"), Some((8, 30)));
+        assert_eq!(extract_clock("下午 3 點"), Some((15, 0)));
+        assert_eq!(extract_clock("晚上 6 點"), Some((18, 0)));
+        assert_eq!(extract_clock("早上 9 點"), Some((9, 0)));
+        assert_eq!(extract_clock("中午 12 點"), Some((12, 0)));
+        // 無效 / 看不懂 → None
+        assert_eq!(extract_clock("無關"), None);
+        // 60 分 不合法
+        assert_eq!(extract_clock("9 點 60 分"), None);
+    }
+}

--- a/crates/mori-time/src/parser.rs
+++ b/crates/mori-time/src/parser.rs
@@ -1,0 +1,8 @@
+//! K4 parser — 待實作(chrono-english 自然語言時間解析)
+//!
+//! TODO: 由 K4 stream impl。本 stub 確保 K1 ship 後 `lib.rs` 不 break。
+//!
+//! 預期 API(by K4):
+//! - `parse_when(input: &str, now: DateTime<Utc>) -> Result<DateTime<Utc>, ParseError>`
+//! - 支援「明天早上 9 點」/ "tomorrow 9am" / "in 30 minutes" 等
+//! - cron pattern 偵測:「每天早上 8 點」→ cron expr

--- a/crates/mori-time/src/scheduler.rs
+++ b/crates/mori-time/src/scheduler.rs
@@ -1,0 +1,9 @@
+//! K2 scheduler — 待實作(tokio-cron-scheduler 整合)
+//!
+//! TODO: 由 K2 stream impl。本 stub 確保 K1 ship 後 `lib.rs` 不 break。
+//!
+//! 預期 API(by K2):
+//! - `ReminderScheduler::new(store: Arc<ReminderStore>) -> Self`
+//! - `start()` — 掃 store.list_pending() 排程進 tokio-cron-scheduler
+//! - `reload()` — store CRUD 後 re-sync
+//! - 到點觸發 → 呼叫 K3 notifier + store.mark_fired()

--- a/crates/mori-time/src/scheduler.rs
+++ b/crates/mori-time/src/scheduler.rs
@@ -1,9 +1,307 @@
-//! K2 scheduler — 待實作(tokio-cron-scheduler 整合)
+//! K2 scheduler — tokio-cron-scheduler 整合
 //!
-//! TODO: 由 K2 stream impl。本 stub 確保 K1 ship 後 `lib.rs` 不 break。
+//! [`ReminderScheduler`] 是一個薄包裝,把 [`crate::schema::ReminderStore`] 裡的
+//! reminder 排程進 [`tokio_cron_scheduler::JobScheduler`]。觸發時呼叫 `on_fire`
+//! callback,callback 內部由上層(K5)決定要做什麼(寫桌面通知 / mark_fired / re-load …)。
 //!
-//! 預期 API(by K2):
-//! - `ReminderScheduler::new(store: Arc<ReminderStore>) -> Self`
-//! - `start()` — 掃 store.list_pending() 排程進 tokio-cron-scheduler
-//! - `reload()` — store CRUD 後 re-sync
-//! - 到點觸發 → 呼叫 K3 notifier + store.mark_fired()
+//! 兩種 reminder:
+//! - **一次性**(`cron_expr` 是 `None`):用 `Job::new_one_shot(due_at - now, …)`。
+//!   過去時間視作「立刻」(1ms duration)。
+//! - **週期性**(`cron_expr` 是 `Some(expr)`):用 `Job::new_cron_job(expr, …)`,
+//!   `expr` 是 6-field cron(含秒)e.g. `0 0 8 * * *` = 每天早上 8:00。
+//!
+//! 取消:scheduler 內部用 uuid 認 job,我們維護一個 `reminder_id -> Uuid` 的對照表。
+//!
+//! ⚠️ tokio-cron-scheduler 的 one-shot 是每 500ms 檢查一次,所以最小觸發精度約 500ms。
+//! 測試裡需要預留一點 margin。
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use tokio::sync::Mutex;
+use tokio_cron_scheduler::{Job, JobScheduler};
+
+use crate::schema::{Reminder, ReminderStore};
+
+/// scheduler 層錯誤類型。
+#[derive(Debug, thiserror::Error)]
+pub enum SchedulerError {
+    #[error("scheduler init failed: {0}")]
+    Init(String),
+    #[error("schedule failed: {0}")]
+    Schedule(String),
+    #[error("store error: {0}")]
+    Store(#[from] crate::schema::ReminderError),
+}
+
+/// 觸發 reminder 時呼叫的 callback。內部由 K5 wire 進 K3 notifier + store.mark_fired()。
+pub type OnFireCallback = Arc<dyn Fn(Reminder) + Send + Sync>;
+
+/// reminder 排程器 — 持有 tokio-cron-scheduler 的 `JobScheduler`,
+/// 並維護 `reminder_id -> job_uuid` 對照表以便取消。
+pub struct ReminderScheduler {
+    scheduler: JobScheduler,
+    #[allow(dead_code)] // K5 reload-from-store 時會用到
+    store: Arc<Mutex<ReminderStore>>,
+    on_fire: OnFireCallback,
+    /// 對照 reminder.id -> 已加入 scheduler 的 Job(本身有 `.guid()`),給 `cancel()` 用。
+    /// 存 Job 而不是 Uuid 是為了避免直接 import `uuid` crate(K2 不引新 deps;
+    /// uuid 是 tokio-cron-scheduler 的 transitive dep,Rust 不允許這樣直接用)。
+    jobs: Arc<Mutex<HashMap<i64, Job>>>,
+}
+
+impl ReminderScheduler {
+    /// 建立新 scheduler(不會自動 start,要呼叫 [`start`])。
+    pub async fn new(
+        store: Arc<Mutex<ReminderStore>>,
+        on_fire: OnFireCallback,
+    ) -> Result<Self, SchedulerError> {
+        let scheduler = JobScheduler::new()
+            .await
+            .map_err(|e| SchedulerError::Init(e.to_string()))?;
+        Ok(Self {
+            scheduler,
+            store,
+            on_fire,
+            jobs: Arc::new(Mutex::new(HashMap::new())),
+        })
+    }
+
+    /// 啟動背景 scheduler tick。可重複呼叫(內部 idempotent)。
+    pub async fn start(&self) -> Result<(), SchedulerError> {
+        self.scheduler
+            .start()
+            .await
+            .map_err(|e| SchedulerError::Schedule(e.to_string()))?;
+        Ok(())
+    }
+
+    /// 把一個 reminder 排程進 scheduler。
+    ///
+    /// - `reminder.cron_expr` 是 `Some(expr)` → cron job(週期性)
+    /// - 否則 → one-shot,以 `reminder.due_at - now()` 為 duration;
+    ///   過去時間視作立刻觸發(1ms duration)。
+    ///
+    /// 同一個 reminder id 重複 schedule 會先 cancel 舊的、再排新的。
+    pub async fn schedule(&self, reminder: &Reminder) -> Result<(), SchedulerError> {
+        // 同 id 已排程過 → 先 cancel(idempotent re-schedule,K5 reload 後會用到)
+        if self.jobs.lock().await.contains_key(&reminder.id) {
+            self.cancel(reminder.id).await?;
+        }
+
+        let on_fire = Arc::clone(&self.on_fire);
+        let reminder_for_cb = reminder.clone();
+
+        let job = if let Some(expr) = reminder.cron_expr.as_deref() {
+            Job::new_cron_job(expr, move |_uuid, _l| {
+                (on_fire)(reminder_for_cb.clone());
+            })
+            .map_err(|e| SchedulerError::Schedule(format!("cron expr '{expr}': {e}")))?
+        } else {
+            let now = Utc::now();
+            let delta = (reminder.due_at - now).num_milliseconds();
+            // ≤0 → 立刻觸發(1ms 給 scheduler 一點 buffer)
+            let dur = if delta <= 0 {
+                Duration::from_millis(1)
+            } else {
+                Duration::from_millis(delta as u64)
+            };
+            Job::new_one_shot(dur, move |_uuid, _l| {
+                (on_fire)(reminder_for_cb.clone());
+            })
+            .map_err(|e| SchedulerError::Schedule(format!("one-shot: {e}")))?
+        };
+
+        self.scheduler
+            .add(job.clone())
+            .await
+            .map_err(|e| SchedulerError::Schedule(e.to_string()))?;
+        self.jobs.lock().await.insert(reminder.id, job);
+        Ok(())
+    }
+
+    /// 取消已排程的 reminder。對沒排程過 / 已 fire 過的 id 不會錯,直接 no-op。
+    pub async fn cancel(&self, reminder_id: i64) -> Result<(), SchedulerError> {
+        let job = self.jobs.lock().await.remove(&reminder_id);
+        if let Some(job) = job {
+            self.scheduler
+                .remove(&job.guid())
+                .await
+                .map_err(|e| SchedulerError::Schedule(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    /// 關閉 scheduler。tokio-cron-scheduler 的 `shutdown` 需要 `&mut`,
+    /// 但 `JobsSchedulerLocked` 內部是 Arc 共享,clone 一份來呼叫即可。
+    pub async fn shutdown(&self) -> Result<(), SchedulerError> {
+        let mut sched = self.scheduler.clone();
+        sched
+            .shutdown()
+            .await
+            .map_err(|e| SchedulerError::Schedule(e.to_string()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration as ChronoDuration;
+    use std::sync::Mutex as StdMutex;
+    use std::time::Duration as StdDuration;
+
+    /// 收集 callback 觸發紀錄的 test fixture。
+    type FireLog = Arc<StdMutex<Vec<Reminder>>>;
+
+    fn fire_log() -> (FireLog, OnFireCallback) {
+        let log: FireLog = Arc::new(StdMutex::new(Vec::new()));
+        let log_for_cb = Arc::clone(&log);
+        let cb: OnFireCallback = Arc::new(move |r: Reminder| {
+            log_for_cb.lock().unwrap().push(r);
+        });
+        (log, cb)
+    }
+
+    async fn fresh_store() -> Arc<Mutex<ReminderStore>> {
+        let store = ReminderStore::open_in_memory().expect("open in-memory store");
+        Arc::new(Mutex::new(store))
+    }
+
+    #[tokio::test]
+    async fn scheduler_starts_and_shuts_down_cleanly() {
+        let store = fresh_store().await;
+        let (_log, cb) = fire_log();
+        let sched = ReminderScheduler::new(store, cb)
+            .await
+            .expect("new scheduler");
+        sched.start().await.expect("start ok");
+        sched.shutdown().await.expect("shutdown ok");
+    }
+
+    #[tokio::test]
+    async fn schedule_one_shot_fires_after_due() {
+        let store = fresh_store().await;
+        let (log, cb) = fire_log();
+        let sched = ReminderScheduler::new(Arc::clone(&store), cb)
+            .await
+            .expect("new scheduler");
+        sched.start().await.expect("start ok");
+
+        // due in 100ms;tokio-cron-scheduler one-shot tick = 500ms,
+        // 所以實際觸發 ~500-1000ms 後,等 2s 留 margin。
+        let due = Utc::now() + ChronoDuration::milliseconds(100);
+        let r = store
+            .lock()
+            .await
+            .create("ping".into(), due, None)
+            .expect("create reminder");
+        sched.schedule(&r).await.expect("schedule ok");
+
+        tokio::time::sleep(StdDuration::from_millis(2000)).await;
+
+        let fires = log.lock().unwrap();
+        assert_eq!(fires.len(), 1, "expected exactly 1 fire, got {}", fires.len());
+        assert_eq!(fires[0].id, r.id);
+        assert_eq!(fires[0].text, "ping");
+
+        drop(fires);
+        sched.shutdown().await.expect("shutdown ok");
+    }
+
+    #[tokio::test]
+    async fn schedule_cron_fires_repeatedly() {
+        let store = fresh_store().await;
+        let (log, cb) = fire_log();
+        let sched = ReminderScheduler::new(Arc::clone(&store), cb)
+            .await
+            .expect("new scheduler");
+        sched.start().await.expect("start ok");
+
+        // 每秒一次(6-field cron with seconds)
+        let due = Utc::now() + ChronoDuration::seconds(1);
+        let r = store
+            .lock()
+            .await
+            .create(
+                "tick".into(),
+                due,
+                Some("*/1 * * * * *".to_string()),
+            )
+            .expect("create cron reminder");
+        sched.schedule(&r).await.expect("schedule cron ok");
+
+        // 等 3 秒,該觸發 ≥ 2 次
+        tokio::time::sleep(StdDuration::from_millis(3200)).await;
+
+        let n_fires = log.lock().unwrap().len();
+        assert!(
+            n_fires >= 2,
+            "expected ≥2 cron fires, got {n_fires}"
+        );
+
+        sched.shutdown().await.expect("shutdown ok");
+    }
+
+    #[tokio::test]
+    async fn cancel_prevents_fire() {
+        let store = fresh_store().await;
+        let (log, cb) = fire_log();
+        let sched = ReminderScheduler::new(Arc::clone(&store), cb)
+            .await
+            .expect("new scheduler");
+        sched.start().await.expect("start ok");
+
+        // due in 1s
+        let due = Utc::now() + ChronoDuration::seconds(1);
+        let r = store
+            .lock()
+            .await
+            .create("ghost".into(), due, None)
+            .expect("create reminder");
+        sched.schedule(&r).await.expect("schedule ok");
+
+        // 立刻 cancel
+        sched.cancel(r.id).await.expect("cancel ok");
+
+        // 等到 due 過去 + scheduler tick margin
+        tokio::time::sleep(StdDuration::from_millis(2000)).await;
+
+        let n_fires = log.lock().unwrap().len();
+        assert_eq!(n_fires, 0, "expected 0 fires after cancel, got {n_fires}");
+
+        // cancel 不存在的 id 應該 no-op,不錯
+        sched.cancel(99999).await.expect("cancel unknown ok");
+
+        sched.shutdown().await.expect("shutdown ok");
+    }
+
+    #[tokio::test]
+    async fn schedule_past_reminder_fires_immediately() {
+        let store = fresh_store().await;
+        let (log, cb) = fire_log();
+        let sched = ReminderScheduler::new(Arc::clone(&store), cb)
+            .await
+            .expect("new scheduler");
+        sched.start().await.expect("start ok");
+
+        // due 10 秒前(已經過去)
+        let due = Utc::now() - ChronoDuration::seconds(10);
+        let r = store
+            .lock()
+            .await
+            .create("late".into(), due, None)
+            .expect("create reminder");
+        sched.schedule(&r).await.expect("schedule ok");
+
+        // 過去 reminder 視作立刻觸發,但 one-shot 仍受 500ms tick 影響,等 1.5s
+        tokio::time::sleep(StdDuration::from_millis(1500)).await;
+
+        let n_fires = log.lock().unwrap().len();
+        assert_eq!(n_fires, 1, "expected 1 fire for past-due reminder, got {n_fires}");
+
+        sched.shutdown().await.expect("shutdown ok");
+    }
+}

--- a/crates/mori-time/src/schema.rs
+++ b/crates/mori-time/src/schema.rs
@@ -1,0 +1,429 @@
+//! K1 — Reminder SQLite schema + CRUD
+//!
+//! [`ReminderStore`] 封裝一個 SQLite connection,提供:
+//! - `migrate()` — 建表(idempotent)
+//! - `create()` — 新增 reminder(回傳含 id 的 [`Reminder`])
+//! - `list_pending()` / `list_all()` / `get()` — 讀
+//! - `mark_fired()` / `snooze()` / `cancel()` — 狀態變更
+//!
+//! Note: K1 暫不負責背景排程,K2 會 wrap 本 store 在 `tokio-cron-scheduler` 內。
+
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection, OptionalExtension, Row};
+use serde::{Deserialize, Serialize};
+
+/// 單筆 reminder。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Reminder {
+    pub id: i64,
+    /// 要提醒的內容(短文字,可包含 emoji)。
+    pub text: String,
+    /// 下次觸發時間(UTC)。一次性 reminder fire 後就 stop;repeating 由 K2 scheduler 算下一次。
+    pub due_at: DateTime<Utc>,
+    /// `None` = 一次性;`Some(expr)` = 重複(K2 用 tokio-cron-scheduler 解析)。
+    pub cron_expr: Option<String>,
+    pub created_at: DateTime<Utc>,
+    /// 上次實際觸發時間;`None` = 還沒響過。
+    pub fired_at: Option<DateTime<Utc>>,
+    /// 暫緩到何時(snooze 後 status = Snoozed,到時間才繼續排程)。
+    pub snoozed_until: Option<DateTime<Utc>>,
+    pub status: ReminderStatus,
+}
+
+/// Reminder 生命週期狀態。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReminderStatus {
+    /// 排程中,等待 due_at。
+    Pending,
+    /// 已觸發(一次性 reminder 觸發後進此狀態)。
+    Fired,
+    /// 用戶 snooze 後暫緩。
+    Snoozed,
+    /// 用戶取消。
+    Cancelled,
+}
+
+impl ReminderStatus {
+    /// 序列化成資料庫存的小寫字串。
+    fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Fired => "fired",
+            Self::Snoozed => "snoozed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    fn from_db_str(s: &str) -> Result<Self, ReminderError> {
+        match s {
+            "pending" => Ok(Self::Pending),
+            "fired" => Ok(Self::Fired),
+            "snoozed" => Ok(Self::Snoozed),
+            "cancelled" => Ok(Self::Cancelled),
+            other => Err(ReminderError::BadStatus(other.to_string())),
+        }
+    }
+}
+
+/// store 錯誤類型。
+#[derive(Debug, thiserror::Error)]
+pub enum ReminderError {
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("not found: id={0}")]
+    NotFound(i64),
+    #[error("unknown reminder status string: {0}")]
+    BadStatus(String),
+}
+
+/// 包裝一個 SQLite connection,提供 reminder CRUD。
+///
+/// K2 scheduler 會持有 `Arc<Mutex<ReminderStore>>` 或自己拿 connection — 留給 K2 決定。
+pub struct ReminderStore {
+    conn: Connection,
+}
+
+impl ReminderStore {
+    /// 開啟(或建立)指定路徑的 SQLite db。會 auto-run `migrate()`。
+    pub fn open(db_path: &Path) -> Result<Self, ReminderError> {
+        let conn = Connection::open(db_path)?;
+        let store = Self { conn };
+        store.migrate()?;
+        Ok(store)
+    }
+
+    /// 開一個記憶體 db(tests 用)。自動 migrate。
+    pub fn open_in_memory() -> Result<Self, ReminderError> {
+        let conn = Connection::open_in_memory()?;
+        let store = Self { conn };
+        store.migrate()?;
+        Ok(store)
+    }
+
+    /// 建表。Idempotent — 重複跑不會錯。
+    pub fn migrate(&self) -> Result<(), ReminderError> {
+        self.conn.execute_batch(
+            r#"
+            CREATE TABLE IF NOT EXISTS reminders (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                text            TEXT NOT NULL,
+                due_at          TEXT NOT NULL,
+                cron_expr       TEXT,
+                created_at      TEXT NOT NULL,
+                fired_at        TEXT,
+                snoozed_until   TEXT,
+                status          TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_reminders_status ON reminders(status);
+            CREATE INDEX IF NOT EXISTS idx_reminders_due_at ON reminders(due_at);
+            "#,
+        )?;
+        Ok(())
+    }
+
+    /// 新增一個 pending reminder。`created_at` 自動填 now。
+    pub fn create(
+        &self,
+        text: String,
+        due_at: DateTime<Utc>,
+        cron: Option<String>,
+    ) -> Result<Reminder, ReminderError> {
+        let now = Utc::now();
+        let status = ReminderStatus::Pending;
+        self.conn.execute(
+            r#"INSERT INTO reminders (text, due_at, cron_expr, created_at, fired_at, snoozed_until, status)
+               VALUES (?1, ?2, ?3, ?4, NULL, NULL, ?5)"#,
+            params![
+                text,
+                due_at.to_rfc3339(),
+                cron,
+                now.to_rfc3339(),
+                status.as_db_str(),
+            ],
+        )?;
+        let id = self.conn.last_insert_rowid();
+        Ok(Reminder {
+            id,
+            text,
+            due_at,
+            cron_expr: cron,
+            created_at: now,
+            fired_at: None,
+            snoozed_until: None,
+            status,
+        })
+    }
+
+    /// 列出仍需排程的 reminder(status = Pending 或 Snoozed)。
+    pub fn list_pending(&self) -> Result<Vec<Reminder>, ReminderError> {
+        let mut stmt = self.conn.prepare(
+            r#"SELECT id, text, due_at, cron_expr, created_at, fired_at, snoozed_until, status
+               FROM reminders
+               WHERE status IN ('pending', 'snoozed')
+               ORDER BY due_at ASC"#,
+        )?;
+        let rows = stmt.query_map([], row_to_reminder)?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(ReminderError::from)
+            .and_then(|v| v.into_iter().collect::<Result<Vec<_>, _>>())
+    }
+
+    /// 列出所有 reminder(含 fired / cancelled),由舊到新。
+    pub fn list_all(&self) -> Result<Vec<Reminder>, ReminderError> {
+        let mut stmt = self.conn.prepare(
+            r#"SELECT id, text, due_at, cron_expr, created_at, fired_at, snoozed_until, status
+               FROM reminders
+               ORDER BY id ASC"#,
+        )?;
+        let rows = stmt.query_map([], row_to_reminder)?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(ReminderError::from)
+            .and_then(|v| v.into_iter().collect::<Result<Vec<_>, _>>())
+    }
+
+    /// 拿單筆。找不到回 `NotFound(id)`。
+    pub fn get(&self, id: i64) -> Result<Reminder, ReminderError> {
+        let mut stmt = self.conn.prepare(
+            r#"SELECT id, text, due_at, cron_expr, created_at, fired_at, snoozed_until, status
+               FROM reminders
+               WHERE id = ?1"#,
+        )?;
+        let row = stmt
+            .query_row(params![id], row_to_reminder)
+            .optional()?;
+        match row {
+            Some(r) => r,
+            None => Err(ReminderError::NotFound(id)),
+        }
+    }
+
+    /// 標記 fired:寫入 `fired_at` 並把 status 設為 Fired。
+    pub fn mark_fired(&self, id: i64, fired_at: DateTime<Utc>) -> Result<(), ReminderError> {
+        let n = self.conn.execute(
+            r#"UPDATE reminders
+               SET fired_at = ?1, status = ?2
+               WHERE id = ?3"#,
+            params![fired_at.to_rfc3339(), ReminderStatus::Fired.as_db_str(), id],
+        )?;
+        if n == 0 {
+            return Err(ReminderError::NotFound(id));
+        }
+        Ok(())
+    }
+
+    /// snooze 到指定時間。status -> Snoozed。
+    pub fn snooze(&self, id: i64, until: DateTime<Utc>) -> Result<(), ReminderError> {
+        let n = self.conn.execute(
+            r#"UPDATE reminders
+               SET snoozed_until = ?1, status = ?2
+               WHERE id = ?3"#,
+            params![until.to_rfc3339(), ReminderStatus::Snoozed.as_db_str(), id],
+        )?;
+        if n == 0 {
+            return Err(ReminderError::NotFound(id));
+        }
+        Ok(())
+    }
+
+    /// 取消 reminder。status -> Cancelled。
+    pub fn cancel(&self, id: i64) -> Result<(), ReminderError> {
+        let n = self.conn.execute(
+            r#"UPDATE reminders
+               SET status = ?1
+               WHERE id = ?2"#,
+            params![ReminderStatus::Cancelled.as_db_str(), id],
+        )?;
+        if n == 0 {
+            return Err(ReminderError::NotFound(id));
+        }
+        Ok(())
+    }
+}
+
+/// 把 sqlite row 拆成 `Reminder`。回傳 nested Result 因為 status 解析可能失敗。
+fn row_to_reminder(row: &Row<'_>) -> rusqlite::Result<Result<Reminder, ReminderError>> {
+    let id: i64 = row.get(0)?;
+    let text: String = row.get(1)?;
+    let due_at: String = row.get(2)?;
+    let cron_expr: Option<String> = row.get(3)?;
+    let created_at: String = row.get(4)?;
+    let fired_at: Option<String> = row.get(5)?;
+    let snoozed_until: Option<String> = row.get(6)?;
+    let status: String = row.get(7)?;
+
+    Ok((|| -> Result<Reminder, ReminderError> {
+        Ok(Reminder {
+            id,
+            text,
+            due_at: parse_rfc3339(&due_at)?,
+            cron_expr,
+            created_at: parse_rfc3339(&created_at)?,
+            fired_at: fired_at.as_deref().map(parse_rfc3339).transpose()?,
+            snoozed_until: snoozed_until.as_deref().map(parse_rfc3339).transpose()?,
+            status: ReminderStatus::from_db_str(&status)?,
+        })
+    })())
+}
+
+fn parse_rfc3339(s: &str) -> Result<DateTime<Utc>, ReminderError> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| {
+            // 包成 BadStatus 沿用 — 比較簡單。實際上應該分一個 BadTimestamp,但 K1 暫不需要。
+            ReminderError::BadStatus(format!("bad rfc3339 timestamp '{s}': {e}"))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    fn store() -> ReminderStore {
+        ReminderStore::open_in_memory().expect("open in-memory store")
+    }
+
+    #[test]
+    fn migrate_creates_table_idempotent() {
+        let s = store();
+        // 第二次跑不應該錯
+        s.migrate().expect("second migrate ok");
+        s.migrate().expect("third migrate ok");
+        // sanity: list_all 不會炸
+        assert_eq!(s.list_all().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn create_returns_reminder_with_id() {
+        let s = store();
+        let due = Utc::now() + Duration::minutes(10);
+        let r = s
+            .create("喝水".to_string(), due, None)
+            .expect("create ok");
+        assert!(r.id > 0);
+        assert_eq!(r.text, "喝水");
+        assert_eq!(r.status, ReminderStatus::Pending);
+        assert!(r.cron_expr.is_none());
+
+        // 再 create 一筆 id 應該遞增
+        let r2 = s
+            .create("散步".to_string(), due + Duration::minutes(5), None)
+            .expect("create2 ok");
+        assert!(r2.id > r.id);
+    }
+
+    #[test]
+    fn list_pending_filters_by_status() {
+        let s = store();
+        let due = Utc::now() + Duration::minutes(10);
+        let r1 = s.create("a".into(), due, None).unwrap();
+        let r2 = s.create("b".into(), due, None).unwrap();
+        let r3 = s.create("c".into(), due, None).unwrap();
+
+        // 把 r2 標 fired, r3 cancel,r1 留 pending
+        s.mark_fired(r2.id, Utc::now()).unwrap();
+        s.cancel(r3.id).unwrap();
+
+        let pending = s.list_pending().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id, r1.id);
+
+        // list_all 應該全部三筆
+        assert_eq!(s.list_all().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn list_pending_includes_snoozed() {
+        let s = store();
+        let due = Utc::now() + Duration::minutes(10);
+        let r = s.create("snoozey".into(), due, None).unwrap();
+        s.snooze(r.id, Utc::now() + Duration::minutes(30)).unwrap();
+        let pending = s.list_pending().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].status, ReminderStatus::Snoozed);
+    }
+
+    #[test]
+    fn get_returns_error_for_unknown_id() {
+        let s = store();
+        match s.get(999) {
+            Err(ReminderError::NotFound(id)) => assert_eq!(id, 999),
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mark_fired_updates_status_and_timestamp() {
+        let s = store();
+        let due = Utc::now() + Duration::minutes(10);
+        let r = s.create("test".into(), due, None).unwrap();
+        assert!(r.fired_at.is_none());
+
+        let fired_at = Utc::now();
+        s.mark_fired(r.id, fired_at).unwrap();
+
+        let after = s.get(r.id).unwrap();
+        assert_eq!(after.status, ReminderStatus::Fired);
+        assert!(after.fired_at.is_some());
+        // 容忍 1 秒誤差(rfc3339 round-trip)
+        let diff = (after.fired_at.unwrap() - fired_at).num_seconds().abs();
+        assert!(diff <= 1, "fired_at round-trip drift {diff}s");
+
+        // 不存在 id 應該回 NotFound
+        match s.mark_fired(999, Utc::now()) {
+            Err(ReminderError::NotFound(_)) => {}
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn snooze_updates_until_and_status() {
+        let s = store();
+        let due = Utc::now() + Duration::minutes(10);
+        let r = s.create("snz".into(), due, None).unwrap();
+        let until = Utc::now() + Duration::hours(1);
+        s.snooze(r.id, until).unwrap();
+
+        let after = s.get(r.id).unwrap();
+        assert_eq!(after.status, ReminderStatus::Snoozed);
+        assert!(after.snoozed_until.is_some());
+
+        match s.snooze(999, until) {
+            Err(ReminderError::NotFound(_)) => {}
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cancel_updates_status() {
+        let s = store();
+        let due = Utc::now() + Duration::minutes(10);
+        let r = s.create("byebye".into(), due, None).unwrap();
+        s.cancel(r.id).unwrap();
+
+        let after = s.get(r.id).unwrap();
+        assert_eq!(after.status, ReminderStatus::Cancelled);
+
+        match s.cancel(999) {
+            Err(ReminderError::NotFound(_)) => {}
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn create_with_cron_expr_persists() {
+        let s = store();
+        let due = Utc::now() + Duration::minutes(10);
+        let r = s
+            .create(
+                "每天早上提醒喝水".into(),
+                due,
+                Some("0 0 8 * * *".to_string()),
+            )
+            .unwrap();
+        let fetched = s.get(r.id).unwrap();
+        assert_eq!(fetched.cron_expr.as_deref(), Some("0 0 8 * * *"));
+    }
+}


### PR DESCRIPTION
## Summary

**Stream K4 of 5(時之鳥)** — NL time parser。User input(中/英文)→ `chrono::DateTime<Utc>`。給 K5 Tauri command 用。

**Base**: `feat/time-bird-base` (#80, K1)— 等 #80 merge 後 GH 自動 retarget 到 main。

## Changes

- `crates/mori-time/src/parser.rs`(stub → 629 行 + 12 tests)

## Design

- 雙路徑:**chrono-english (UK dialect) 先試 → 中文 fallback → Unrecognized**
- ParseError(Unrecognized / PastTime)— 過去時間嚴格 reject
- 中文 patterns:
  - 相對:`N 分鐘/小時/天後`(含「以後」/「日後」變體)
  - 絕對:`(明天/後天/大後天/今天/明日/今日)? (period)? N 點 (M 分|半)?`
  - period:早上 / 上午 / 凌晨 / 中午 / 下午 / 晚上 / 傍晚 / 夜晚 / 夜裡 / 半夜 / 深夜
  - 「中午」「半夜」單詞 → 12:00 / 00:00
  - 「下週X」/「下星期X」走 ISO week 確保跳到下一週
  - 全形空白 normalize
- API:`parse()` / `parse_at(expr, now)` for tests / `parse_or_default()` for K5

## Test plan

- [x] 12 parser tests + 9 schema tests = 14 mori-time 全綠
- [x] cargo test -p mori-core --lib:216 沒破
- [x] verify.sh + clippy 零 warning
- [x] **不引入新 dep**(K1 已加 chrono-english)

## Reviews

- ✅ Spec compliance: APPROVED
- ✅ Code quality: APPROVED (★★★★☆)

## Known follow-up

- `6 點` 無 period 解 24h literal vs spec「strict reject ambiguity」描述略不一致 — 統一文檔 or 改實作
- `下週X garbage trailing` silently fallback 09:00 — 建議 trailing 非空 + extract_clock fail → Unrecognized
- 全形數字 `１２３` 未 normalize(只 normalize 全形空白)
- 中文數字「半夜十二點」未支援
- `build_local_dt` 有 unused `_now` param,可砍

🤖 Generated with [Claude Code](https://claude.com/claude-code)