### PR TITLE
feat(mcp): mori-mcp crate foundation — rmcp client + config + discovery (MCP-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,6 +857,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "codepage"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,7 +985,7 @@ dependencies = [
  "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
- "jni",
+ "jni 0.21.1",
  "js-sys",
  "libc",
  "mach2",
@@ -1578,6 +1609,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1652,6 +1704,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2477,6 +2530,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2891,6 +2974,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mori-mcp"
+version = "0.7.1"
+dependencies = [
+ "rmcp",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "mori-tauri"
 version = "0.7.1"
 dependencies = [
@@ -3037,6 +3133,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nom"
@@ -3353,7 +3461,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
 dependencies = [
- "jni",
+ "jni 0.21.1",
  "ndk 0.8.0",
  "ndk-context",
  "num-derive 0.4.2",
@@ -3381,6 +3489,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -3740,6 +3854,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap 2.14.0",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3815,6 +3943,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -4073,15 +4202,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4129,6 +4264,29 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "http",
+ "pin-project-lite",
+ "process-wrap",
+ "reqwest 0.13.3",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -4204,12 +4362,25 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -4223,11 +4394,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4259,6 +4458,15 @@ name = "scanlex"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "088c5d71572124929ea7549a8ce98e1a6fd33d0a38367b09027b382e67c033db"
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "schemars"
@@ -4316,6 +4524,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -4584,6 +4815,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4657,6 +4904,19 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -4845,7 +5105,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk 0.9.0",
@@ -4902,7 +5162,7 @@ dependencies = [
  "heck 0.5.0",
  "http",
  "image",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -5111,7 +5371,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -5134,7 +5394,7 @@ checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -5406,6 +5666,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -6214,6 +6485,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6348,11 +6628,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -6362,6 +6654,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6421,7 +6722,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -6488,6 +6800,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6654,6 +6976,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6979,7 +7310,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk 0.9.0",
  "objc2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/mori-cli",
     "crates/mori-file-loader",
     "crates/mori-time",
+    "crates/mori-mcp",
 ]
 
 [workspace.package]

--- a/crates/mori-mcp/Cargo.toml
+++ b/crates/mori-mcp/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "mori-mcp"
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+description = "Mori 的 MCP(Model Context Protocol)client — 連外部 MCP server,拉 tool 給 LLM 用。Wave 6 MCP-1 foundation。"
+
+[dependencies]
+# rmcp(Rust SDK for Model Context Protocol)。crates.io 最新 stable 是 1.x;
+# default features 是 server-side(`[base64, macros, server]`),client 要顯式
+# opt-in。我們只開 client 跟兩條 transport:
+#   - transport-child-process:stdio MCP server(`npx -y @modelcontextprotocol/...`)
+#   - transport-streamable-http-client-reqwest:HTTP MCP server(Streamable HTTP)
+# 關掉 default 把 server-side / macros 等都剝掉,縮 dep tree。
+rmcp = { version = "1", default-features = false, features = [
+    "client",
+    "transport-child-process",
+    "transport-streamable-http-client-reqwest",
+    "reqwest",
+] }
+
+# 共用
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/mori-mcp/src/client.rs
+++ b/crates/mori-mcp/src/client.rs
@@ -1,0 +1,271 @@
+//! [`McpClient`] — 單一 MCP server 的 connection wrapper(rmcp 包裝)。
+//!
+//! 設計重點:
+//! - **transport-agnostic API**:caller 給 `&McpServerConfig`,內部依 variant 用
+//!   `TokioChildProcess`(stdio)或 `StreamableHttpClientTransport`(http)
+//! - **不 leak rmcp 型別給 caller**:list_tools 回 our own [`McpTool`] DTO,
+//!   call_tool 回 [`McpToolResult`]。MCP-2(Skill 整合)只 import 我們的型別,
+//!   不依賴 rmcp 內部 type — 升 rmcp 不會 cascade 進 mori-core
+//! - **shutdown clean**:`shutdown()` 走 `RunningService::cancel()`,讓 background
+//!   task 收尾;rmcp 也會在 drop 時 best-effort cancel,但 explicit shutdown 才有
+//!   把握等到 transport 真的關
+//!
+//! Wave 6 MCP-1 範圍:connect / list / (call 已實作但 MCP-2 才整合進 SkillRegistry)/ shutdown。
+
+use std::sync::Arc;
+
+use rmcp::{
+    ServiceExt,
+    model::{CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation},
+    service::{RoleClient, RunningService},
+    transport::{ConfigureCommandExt, StreamableHttpClientTransport, TokioChildProcess},
+};
+use tokio::process::Command;
+
+use crate::config::{ConfigError, McpServerConfig};
+
+/// MCP client errors。包 connect / RPC / config 三條。
+///
+/// 故意把 rmcp 內部 error 字串化(`String`),避免 `rmcp::ServiceError` /
+/// `ClientInitializeError` 透到 caller。caller 只看 `Connect` / `Rpc` 大類就夠。
+#[derive(Debug, thiserror::Error)]
+pub enum McpError {
+    #[error("connect MCP server {server}: {message}")]
+    Connect { server: String, message: String },
+    #[error("rpc to MCP server {server}: {message}")]
+    Rpc { server: String, message: String },
+    #[error("config: {0}")]
+    Config(#[from] ConfigError),
+}
+
+/// 已 connect 的 MCP server handle。`Arc<RunningService<RoleClient, ()>>` 仰賴
+/// rmcp 提供的 `RunningService<RoleClient>` —— 它 wrap 了 transport + background
+/// task,deref 到 `Peer<RoleClient>`,所有 RPC method 在這上面 call。
+///
+/// `()` 是「沒 client-side handler」的占位 — MCP-1 不處理 server 主動 request
+/// (sampling / roots),走 default no-op handler。MCP-2 / Wave 6 後續若要支援
+/// sampling,可以換成自家的 `ClientHandler` struct,API 保持不變。
+pub struct McpClient {
+    name: String,
+    inner: Arc<RunningService<RoleClient, ClientInfo>>,
+}
+
+/// 一個 MCP server 暴露出來的 tool(我們的 DTO,不直接 expose rmcp 內部 `Tool`)。
+///
+/// `input_schema` 是 JSON Schema 物件,給 LLM tool-calling 用。Wave 6 MCP-2 會
+/// 把它包成 `Skill` trait 的 `parameters_schema()` 回傳。
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct McpTool {
+    /// Tool 所屬的 server name(`McpServerConfig::name`)
+    pub server: String,
+    /// Tool 名稱(MCP server 端定義,例 `"github_create_issue"`)
+    pub name: String,
+    /// 給 LLM 看的描述(可能空 — MCP server 不一定都填)
+    pub description: String,
+    /// Tool 參數 JSON Schema(直接給 LLM tool-calling 用)
+    pub input_schema: serde_json::Value,
+}
+
+/// MCP tool 執行結果 DTO。`content` 是已序列化的文字(可能是 JSON / plain text /
+/// embedded text resource);MCP-2 把它直接餵回 LLM 當 tool result。
+#[derive(Debug, Clone)]
+pub struct McpToolResult {
+    /// 給 LLM 看的文字 — MCP server 回的 `content[]` 平鋪成單一 string。
+    /// 非 Text 型別(image / audio / embedded resource)用 placeholder 表示
+    /// (e.g. `"[image: image/png, 12345 bytes]"`),避免 dump binary 給 LLM。
+    pub content: String,
+    /// MCP 協議的 `isError` 旗標。`true` 代表 tool 端報錯,但 RPC 本身 OK。
+    pub is_error: bool,
+}
+
+impl McpClient {
+    /// Connect 到一個 MCP server。依 transport variant 選 child process / HTTP。
+    ///
+    /// **timeout**:目前沒設(rmcp 預設 InitializeRequest 走 channel,不會永等)。
+    /// `discovery::McpRegistry` 層會用 `tokio::time::timeout` 包這條 call 做硬上限。
+    pub async fn connect(server: &McpServerConfig) -> Result<Self, McpError> {
+        let name = server.name().to_string();
+        // ClientInfo (= InitializeRequestParams) 是 #[non_exhaustive],只能走
+        // 公開 builder。`ClientInfo::new(caps, impl)` 是 rmcp 的標準 ctor。
+        let client_info = ClientInfo::new(
+            ClientCapabilities::default(),
+            Implementation::new("mori-mcp", env!("CARGO_PKG_VERSION")),
+        );
+
+        let running = match server {
+            McpServerConfig::Stdio {
+                command,
+                args,
+                env,
+                ..
+            } => {
+                let cmd_args = args.clone();
+                let cmd_env = env.clone();
+                let transport = TokioChildProcess::new(Command::new(command).configure(
+                    move |cmd| {
+                        cmd.args(&cmd_args);
+                        for (k, v) in &cmd_env {
+                            cmd.env(k, v);
+                        }
+                    },
+                ))
+                .map_err(|e| McpError::Connect {
+                    server: name.clone(),
+                    message: format!("spawn child: {e}"),
+                })?;
+                client_info
+                    .clone()
+                    .serve(transport)
+                    .await
+                    .map_err(|e| McpError::Connect {
+                        server: name.clone(),
+                        message: format!("stdio serve: {e}"),
+                    })?
+            }
+            McpServerConfig::Http { url, .. } => {
+                let transport = StreamableHttpClientTransport::from_uri(url.as_str());
+                client_info
+                    .clone()
+                    .serve(transport)
+                    .await
+                    .map_err(|e| McpError::Connect {
+                        server: name.clone(),
+                        message: format!("http serve: {e}"),
+                    })?
+            }
+        };
+
+        tracing::info!(
+            server = %name,
+            peer_info = ?running.peer_info().map(|p| (&p.server_info.name, &p.server_info.version)),
+            "MCP server connected",
+        );
+
+        Ok(Self {
+            name,
+            inner: Arc::new(running),
+        })
+    }
+
+    /// Server name(來自 config）。
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// List 該 server 提供的所有 tools。內部走 `list_all_tools()`(分頁自動 fold)。
+    pub async fn list_tools(&self) -> Result<Vec<McpTool>, McpError> {
+        let tools = self
+            .inner
+            .list_all_tools()
+            .await
+            .map_err(|e| McpError::Rpc {
+                server: self.name.clone(),
+                message: format!("list_tools: {e}"),
+            })?;
+        Ok(tools
+            .into_iter()
+            .map(|t| McpTool {
+                server: self.name.clone(),
+                name: t.name.to_string(),
+                description: t
+                    .description
+                    .map(|c| c.to_string())
+                    .unwrap_or_default(),
+                // rmcp Tool.input_schema 是 Arc<JsonObject> → 包成 Value::Object。
+                input_schema: serde_json::Value::Object((*t.input_schema).clone()),
+            })
+            .collect())
+    }
+
+    /// Call 該 server 上的 tool。`args` 是 JSON object(對應 `input_schema`)。
+    ///
+    /// MCP-1 已實作,但 SkillRegistry 整合留 MCP-2。MCP server 回 `isError = true`
+    /// 不算 RPC 錯誤(會走 `Ok(McpToolResult { is_error: true, ... })`),
+    /// caller 自己判斷;只有 transport / RPC 失敗才回 `Err(McpError::Rpc)`。
+    pub async fn call_tool(
+        &self,
+        name: &str,
+        args: serde_json::Value,
+    ) -> Result<McpToolResult, McpError> {
+        let mut params = CallToolRequestParams::new(name.to_string());
+        // CallToolRequestParams.arguments 是 `Option<JsonObject>`(= serde_json::Map)。
+        // 接受 null / 物件;非物件就空 args。
+        if let serde_json::Value::Object(map) = args {
+            params = params.with_arguments(map);
+        }
+        let result = self
+            .inner
+            .call_tool(params)
+            .await
+            .map_err(|e| McpError::Rpc {
+                server: self.name.clone(),
+                message: format!("call_tool {name}: {e}"),
+            })?;
+
+        // 把 content[] 平鋪成 string。text → 原文;非 text → placeholder。
+        let mut buf = String::new();
+        for (i, item) in result.content.iter().enumerate() {
+            if i > 0 {
+                buf.push('\n');
+            }
+            if let Some(text) = item.as_text() {
+                buf.push_str(&text.text);
+            } else if let Some(image) = item.as_image() {
+                buf.push_str(&format!(
+                    "[image: {}, {} bytes base64]",
+                    image.mime_type,
+                    image.data.len()
+                ));
+            } else if let Some(res) = item.as_resource() {
+                // EmbeddedResource 內可能是 text 或 blob。對 LLM 而言:
+                // - text → 直接餵內容
+                // - blob → 只表示「embedded blob」+ uri,不 dump base64
+                match &res.resource {
+                    rmcp::model::ResourceContents::TextResourceContents { uri, text, .. } => {
+                        buf.push_str(&format!("[embedded resource {uri}]\n{text}"));
+                    }
+                    rmcp::model::ResourceContents::BlobResourceContents { uri, blob, .. } => {
+                        buf.push_str(&format!(
+                            "[embedded blob resource {uri}: {} bytes base64]",
+                            blob.len()
+                        ));
+                    }
+                }
+            } else {
+                buf.push_str("[unsupported content type]");
+            }
+        }
+
+        Ok(McpToolResult {
+            content: buf,
+            is_error: result.is_error.unwrap_or(false),
+        })
+    }
+
+    /// Clean shutdown — cancel background task 等 transport 真的關。
+    ///
+    /// 拿 `self` 消費掉,避免 caller shutdown 後又 call list_tools。
+    /// Arc 在 `RunningService` 上;如果還有別人持有同一個 Arc(理論上 McpRegistry
+    /// 內部不會 share McpClient),拿不出 owned value、走 drop fallback(rmcp 也會
+    /// 在 drop 時 cancel,只是 best-effort)。
+    pub async fn shutdown(self) -> Result<(), McpError> {
+        match Arc::try_unwrap(self.inner) {
+            Ok(running) => {
+                running.cancel().await.map_err(|e| McpError::Rpc {
+                    server: self.name.clone(),
+                    message: format!("cancel: {e}"),
+                })?;
+                Ok(())
+            }
+            Err(_arc) => {
+                // 還有別人 ref — drop 我們這份,讓對方持有就好。
+                // 真正關 transport 要等所有 ref drop;不算 error。
+                tracing::debug!(
+                    server = %self.name,
+                    "McpClient shutdown skipped: another Arc holder exists, deferring to drop",
+                );
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/mori-mcp/src/config.rs
+++ b/crates/mori-mcp/src/config.rs
@@ -1,0 +1,234 @@
+//! `~/.mori/mcp.json` 設定 — 描述要 connect 的 MCP server list。
+//!
+//! 兩種 transport:
+//! - **stdio**:spawn child process(e.g. `npx -y @modelcontextprotocol/server-github`)
+//! - **http**:Streamable HTTP / SSE(remote MCP endpoint)
+//!
+//! 範例:
+//!
+//! ```json
+//! {
+//!   "servers": [
+//!     {
+//!       "name": "github",
+//!       "transport": "stdio",
+//!       "command": "npx",
+//!       "args": ["-y", "@modelcontextprotocol/server-github"],
+//!       "env": { "GITHUB_TOKEN": "..." }
+//!     },
+//!     {
+//!       "name": "remote-mcp",
+//!       "transport": "http",
+//!       "url": "https://mcp.example.com"
+//!     }
+//!   ]
+//! }
+//! ```
+//!
+//! 預設 config path 走 `~/.mori/mcp.json`(Windows fallback `%USERPROFILE%`)。
+//! 對齊既有 mori_dir pattern(`mori-tauri/src/annuli_supervisor.rs::annuli_root_dir`)。
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// MCP config root — 載入自 `~/.mori/mcp.json`。
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct McpConfig {
+    /// 要 connect 的 MCP server。空 list 等同於沒開 MCP,registry 不會嘗試連任何 server。
+    #[serde(default)]
+    pub servers: Vec<McpServerConfig>,
+}
+
+/// 單一 MCP server 的設定。`transport` 欄位 tag 區分 stdio / http 兩種。
+///
+/// 兩 variant 都有 `name` — 用來在 `McpRegistry` 內 identify、在 LLM tool dispatch 時
+/// 用 `<server>:<tool>` 命名空間(MCP-2 會用到;MCP-1 只 list)。
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "transport")]
+pub enum McpServerConfig {
+    /// stdio MCP server:spawn 子進程,server 用 stdin/stdout 講 JSON-RPC。
+    /// 主要用於官方 `@modelcontextprotocol/server-*` 系列(走 `npx -y`)。
+    #[serde(rename = "stdio")]
+    Stdio {
+        name: String,
+        /// 執行檔(`"npx"` / `"node"` / 任何 binary)
+        command: String,
+        /// 啟動參數(e.g. `["-y", "@modelcontextprotocol/server-github"]`)
+        #[serde(default)]
+        args: Vec<String>,
+        /// 環境變數(主要給 token / API key,e.g. `GITHUB_TOKEN`)
+        #[serde(default)]
+        env: HashMap<String, String>,
+    },
+    /// HTTP / Streamable HTTP MCP server。`url` 是完整 endpoint(含 path),
+    /// 不含 trailing slash 一致比較好。
+    #[serde(rename = "http")]
+    Http { name: String, url: String },
+}
+
+impl McpServerConfig {
+    /// 拿這個 server 的 name(兩 variant 都有)。
+    pub fn name(&self) -> &str {
+        match self {
+            McpServerConfig::Stdio { name, .. } => name,
+            McpServerConfig::Http { name, .. } => name,
+        }
+    }
+}
+
+/// Config 解析 / 載入錯誤。
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("read config: {0}")]
+    Read(#[from] std::io::Error),
+    #[error("parse mcp.json: {0}")]
+    Parse(#[from] serde_json::Error),
+}
+
+/// 從 path 載入 MCP config。**檔案不存在會回 IO error**(NotFound)——
+/// caller 通常會在呼叫前自己 `default_config_path().exists()` 判斷,
+/// 沒檔案視同空 config（不開任何 MCP server）。
+pub fn load_config(path: &Path) -> Result<McpConfig, ConfigError> {
+    let raw = std::fs::read_to_string(path)?;
+    let cfg: McpConfig = serde_json::from_str(&raw)?;
+    Ok(cfg)
+}
+
+/// 預設 config path:`$HOME/.mori/mcp.json`（Windows 走 `%USERPROFILE%`）。
+///
+/// 兩個 env 都讀不到回 `None`(極少見;CI / headless env 可能會碰到)。caller
+/// 拿到 None 應該當作「沒開 MCP」處理,不要 panic。
+pub fn default_config_path() -> Option<PathBuf> {
+    let home_var = if cfg!(target_os = "windows") {
+        "USERPROFILE"
+    } else {
+        "HOME"
+    };
+    let home = std::env::var(home_var).ok()?;
+    Some(PathBuf::from(home).join(".mori").join("mcp.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_stdio_server_config() {
+        let json = r#"{
+            "servers": [
+                {
+                    "name": "github",
+                    "transport": "stdio",
+                    "command": "npx",
+                    "args": ["-y", "@modelcontextprotocol/server-github"],
+                    "env": { "GITHUB_TOKEN": "ghp_xxx" }
+                }
+            ]
+        }"#;
+        let cfg: McpConfig = serde_json::from_str(json).expect("parse ok");
+        assert_eq!(cfg.servers.len(), 1);
+        match &cfg.servers[0] {
+            McpServerConfig::Stdio {
+                name,
+                command,
+                args,
+                env,
+            } => {
+                assert_eq!(name, "github");
+                assert_eq!(command, "npx");
+                assert_eq!(args, &vec!["-y".to_string(), "@modelcontextprotocol/server-github".to_string()]);
+                assert_eq!(env.get("GITHUB_TOKEN").map(String::as_str), Some("ghp_xxx"));
+            }
+            other => panic!("expected Stdio, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_http_server_config() {
+        let json = r#"{
+            "servers": [
+                { "name": "remote", "transport": "http", "url": "https://mcp.example.com/mcp" }
+            ]
+        }"#;
+        let cfg: McpConfig = serde_json::from_str(json).expect("parse ok");
+        assert_eq!(cfg.servers.len(), 1);
+        match &cfg.servers[0] {
+            McpServerConfig::Http { name, url } => {
+                assert_eq!(name, "remote");
+                assert_eq!(url, "https://mcp.example.com/mcp");
+            }
+            other => panic!("expected Http, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_mixed_config() {
+        // stdio + http 同時 coexist;同時測 stdio 的 `args` / `env` 可省略(default 空)。
+        let json = r#"{
+            "servers": [
+                { "name": "playwright", "transport": "stdio", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-playwright"] },
+                { "name": "remote", "transport": "http", "url": "https://x.example/mcp" }
+            ]
+        }"#;
+        let cfg: McpConfig = serde_json::from_str(json).expect("parse ok");
+        assert_eq!(cfg.servers.len(), 2);
+        assert_eq!(cfg.servers[0].name(), "playwright");
+        assert_eq!(cfg.servers[1].name(), "remote");
+        // stdio entry 沒給 env → 預設空 map
+        match &cfg.servers[0] {
+            McpServerConfig::Stdio { env, .. } => assert!(env.is_empty()),
+            other => panic!("expected Stdio, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn default_config_path_uses_home() {
+        // unit test 不 cross-mutate 全域 env(其他 test 可能在 parallel 跑),
+        // 改用直接 assert path shape:HOME / USERPROFILE 在我們的 CI / dev env
+        // 預設都有設,拿不到的話跳過(極少見場景)。
+        let Some(path) = default_config_path() else {
+            // headless env 沒 HOME / USERPROFILE — 視同 None 正常路徑,skip。
+            return;
+        };
+        assert!(path.ends_with(".mori/mcp.json") || path.ends_with(".mori\\mcp.json"));
+        assert!(path.is_absolute(), "expected absolute path, got {path:?}");
+    }
+
+    #[test]
+    fn load_config_returns_error_for_invalid_json() {
+        // 在 tempdir 寫一個壞 JSON,確認 load_config 回 Parse error 而非 panic。
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        std::fs::write(&path, "{ not valid json").unwrap();
+        let err = load_config(&path).expect_err("invalid json should fail");
+        assert!(
+            matches!(err, ConfigError::Parse(_)),
+            "expected Parse error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn load_config_round_trip() {
+        // 寫一份完整 config → load → 內容一致。
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        let content = r#"{
+            "servers": [
+                { "name": "fs", "transport": "stdio", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"] }
+            ]
+        }"#;
+        std::fs::write(&path, content).unwrap();
+        let cfg = load_config(&path).expect("load ok");
+        assert_eq!(cfg.servers.len(), 1);
+        assert_eq!(cfg.servers[0].name(), "fs");
+    }
+
+    #[test]
+    fn empty_servers_default() {
+        // 缺 servers 欄位 → default 空 list,不 error。讓 user 寫 `{}` 也合法。
+        let cfg: McpConfig = serde_json::from_str("{}").expect("parse ok");
+        assert!(cfg.servers.is_empty());
+    }
+}

--- a/crates/mori-mcp/src/discovery.rs
+++ b/crates/mori-mcp/src/discovery.rs
@@ -1,0 +1,265 @@
+//! [`McpRegistry`] — 對所有 config 內的 MCP server 做 connect / aggregate。
+//!
+//! 設計原則:
+//! - **個別 server fail 不擋整批**:某條 stdio command 找不到 binary / 某條 HTTP
+//!   endpoint 連不上,只 log warn skip 它,registry 仍含其他成功的 server
+//! - **Aggregate tool list**:`all_tools()` 把所有 connected server 的 tools 攤成
+//!   一條 Vec,MCP-2 直接 iterate 註冊進 SkillRegistry
+//! - **Call dispatch**:`call(server, tool, args)` 把 LLM 的 tool_call route 到
+//!   對應 McpClient(MCP-2 用)
+//!
+//! 不做(留 MCP-2):
+//! - tool name 衝突偵測(同一 server 內 unique;跨 server 由 caller 自己 namespace)
+//! - hot-reload(改 mcp.json 後 re-connect)
+//! - retry / circuit breaker(rmcp 本身 transport-level reconnect 不在範圍內)
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::client::{McpClient, McpError, McpTool, McpToolResult};
+use crate::config::McpConfig;
+
+/// MCP server registry — 持有所有 connected client。
+///
+/// 用 `Arc<McpClient>` 因為 call_tool / shutdown 可能跨 task 進入,要 share。
+/// 內部用 HashMap 以 server name 索引,O(1) dispatch。
+pub struct McpRegistry {
+    clients: HashMap<String, Arc<McpClient>>,
+}
+
+impl Default for McpRegistry {
+    fn default() -> Self {
+        Self {
+            clients: HashMap::new(),
+        }
+    }
+}
+
+impl McpRegistry {
+    /// 依 config 逐個 connect。**個別 server fail 只 log + skip**,不 propagate。
+    ///
+    /// 回傳的 registry 可能只有 partial servers — caller 用 `connected_servers()`
+    /// 或 `all_tools()` 查實際情況。
+    ///
+    /// 順序:照 `config.servers` 的順序 connect(serial,不平行 — 避免大量 child
+    /// process 同時 spawn 造成 resource spike;一般 user 只配 3-5 個 server,
+    /// serial 順序也只是 startup 時 ~1-2s 差,可接受)。
+    pub async fn from_config(config: &McpConfig) -> Self {
+        let mut clients = HashMap::new();
+        for server in &config.servers {
+            let name = server.name().to_string();
+            // 名稱碰撞 → 用後寫的,warn。
+            if clients.contains_key(&name) {
+                tracing::warn!(server = %name, "duplicate MCP server name in config — replacing");
+            }
+            match McpClient::connect(server).await {
+                Ok(client) => {
+                    clients.insert(name.clone(), Arc::new(client));
+                    tracing::info!(server = %name, "MCP server registered");
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        server = %name,
+                        error = %e,
+                        "failed to connect MCP server — skipping; other servers continue",
+                    );
+                }
+            }
+        }
+        tracing::info!(
+            connected = clients.len(),
+            configured = config.servers.len(),
+            "McpRegistry initialized",
+        );
+        Self { clients }
+    }
+
+    /// 已 connect 的 server name list。
+    pub fn connected_servers(&self) -> Vec<String> {
+        self.clients.keys().cloned().collect()
+    }
+
+    /// 列出所有 connected server 的所有 tools(攤平)。
+    ///
+    /// 每個 server 走 `client.list_tools()` 各自的 RPC;個別 fail log + skip
+    /// (同 connect 失敗策略 — 某條 server 之後變不穩,不擋其他 server 的 tools 暴露)。
+    pub async fn all_tools(&self) -> Vec<McpTool> {
+        let mut out = Vec::new();
+        for (name, client) in &self.clients {
+            match client.list_tools().await {
+                Ok(tools) => {
+                    tracing::debug!(server = %name, count = tools.len(), "listed tools");
+                    out.extend(tools);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        server = %name,
+                        error = %e,
+                        "list_tools failed — skipping this server's tools",
+                    );
+                }
+            }
+        }
+        out
+    }
+
+    /// Dispatch tool call。`server` 找不到回 `McpError::Rpc`(reuse 同 error
+    /// variant,訊息 prefix `unknown server`)。
+    pub async fn call(
+        &self,
+        server: &str,
+        tool: &str,
+        args: serde_json::Value,
+    ) -> Result<McpToolResult, McpError> {
+        let client = self.clients.get(server).ok_or_else(|| McpError::Rpc {
+            server: server.to_string(),
+            message: format!("unknown server: {server}"),
+        })?;
+        client.call_tool(tool, args).await
+    }
+
+    /// 取單一 client(MCP-2 註冊 Skill 時可能要保留 Arc)。
+    pub fn get(&self, server: &str) -> Option<Arc<McpClient>> {
+        self.clients.get(server).cloned()
+    }
+
+    /// Shutdown 全部 client。逐個 cancel;個別 fail log warn 不 abort。
+    ///
+    /// 拿 `self`(消費)— 避免 caller 拿後再 call。
+    pub async fn shutdown(self) -> Result<(), McpError> {
+        for (name, client) in self.clients {
+            match Arc::try_unwrap(client) {
+                Ok(c) => {
+                    if let Err(e) = c.shutdown().await {
+                        tracing::warn!(server = %name, error = %e, "MCP client shutdown failed");
+                    }
+                }
+                Err(_) => {
+                    tracing::debug!(server = %name, "MCP client still referenced — drop will handle");
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    //! `McpRegistry` tests 走 **真 child process,但用 stub command** —
+    //! stdio MCP server 是 spawn `cmd args...`,測試只需要:
+    //! 1. server 個別 fail 不擋整批 → 用「肯定 fail 的 command」(亂打 binary 名)
+    //! 2. shutdown clean → registry empty 也能 shutdown
+    //! 3. all_tools 在 0 server 時回空 Vec
+    //!
+    //! 為什麼不寫「能 connect 成功」的 integration test?— 那要真正 spawn
+    //! 一個 MCP server child process(`@modelcontextprotocol/server-everything`
+    //! 之類),依賴 Node.js + npx,CI / dev box 不見得有。MCP-2 / 後續會在
+    //! integration test 層補,本層只 unit 驗證行為。
+    use super::*;
+    use crate::config::McpServerConfig;
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn empty_config_returns_empty_registry() {
+        let cfg = McpConfig::default();
+        let reg = McpRegistry::from_config(&cfg).await;
+        assert!(reg.connected_servers().is_empty());
+        assert!(reg.all_tools().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn mcp_registry_handles_individual_server_failure() {
+        // 2 個 server entry,都用「絕對不存在的 binary」走 stdio。
+        // 預期 from_config 不 panic、registry 0 connected。
+        // 等於驗證「個別 server fail 不擋整批」+「全 fail 也 graceful」。
+        let cfg = McpConfig {
+            servers: vec![
+                McpServerConfig::Stdio {
+                    name: "fake-a".into(),
+                    command: "/nonexistent/mori-mcp-fake-binary-a".into(),
+                    args: vec![],
+                    env: HashMap::new(),
+                },
+                McpServerConfig::Stdio {
+                    name: "fake-b".into(),
+                    command: "/nonexistent/mori-mcp-fake-binary-b".into(),
+                    args: vec!["--never-runs".into()],
+                    env: HashMap::new(),
+                },
+            ],
+        };
+        let reg = McpRegistry::from_config(&cfg).await;
+        // 都 fail 但 from_config 仍 return,且沒 connected server。
+        assert!(
+            reg.connected_servers().is_empty(),
+            "expected 0 connected, got {:?}",
+            reg.connected_servers(),
+        );
+        // all_tools 也走 graceful path
+        assert!(reg.all_tools().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn mcp_registry_all_tools_aggregates_empty_when_no_servers() {
+        // single-failure 也走 aggregate path — all_tools 在 0 connected
+        // server 時直接回空 Vec,不 panic。
+        let cfg = McpConfig {
+            servers: vec![McpServerConfig::Stdio {
+                name: "fail-only".into(),
+                command: "/nonexistent/mori-mcp-aggregate-test".into(),
+                args: vec![],
+                env: HashMap::new(),
+            }],
+        };
+        let reg = McpRegistry::from_config(&cfg).await;
+        let tools = reg.all_tools().await;
+        assert!(tools.is_empty());
+    }
+
+    #[tokio::test]
+    async fn mcp_registry_call_unknown_server_returns_rpc_error() {
+        // dispatch 一個不存在的 server,期望 Rpc error(訊息含 unknown server)。
+        let reg = McpRegistry::from_config(&McpConfig::default()).await;
+        let err = reg
+            .call("does-not-exist", "any-tool", serde_json::json!({}))
+            .await
+            .expect_err("unknown server should error");
+        match err {
+            McpError::Rpc { server, message } => {
+                assert_eq!(server, "does-not-exist");
+                assert!(
+                    message.contains("unknown server"),
+                    "expected 'unknown server' in message, got: {message}",
+                );
+            }
+            other => panic!("expected Rpc, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn mcp_registry_shutdown_clean_on_empty() {
+        // empty registry → shutdown 不 panic,回 Ok。基線健全性。
+        let reg = McpRegistry::from_config(&McpConfig::default()).await;
+        reg.shutdown().await.expect("shutdown ok on empty");
+    }
+
+    #[tokio::test]
+    async fn mcp_registry_shutdown_clean_after_all_failed() {
+        // 連 fail 的 server registry 也能 clean shutdown(內部 0 client,
+        // 等同 empty case;確認 from_config 失敗 path 沒留 dangling state)。
+        let cfg = McpConfig {
+            servers: vec![McpServerConfig::Stdio {
+                name: "shutdown-test".into(),
+                command: "/nonexistent/mori-mcp-shutdown-test".into(),
+                args: vec![],
+                env: HashMap::new(),
+            }],
+        };
+        let reg = McpRegistry::from_config(&cfg).await;
+        reg.shutdown().await.expect("shutdown ok after fail");
+    }
+}

--- a/crates/mori-mcp/src/lib.rs
+++ b/crates/mori-mcp/src/lib.rs
@@ -1,0 +1,60 @@
+//! mori-mcp — Model Context Protocol client integration.
+//!
+//! 讓 Mori 能連外部 MCP server(chrome-devtools / Notion / GitHub / Slack /
+//! filesystem / playwright 等官方 MCP 實作),拉出 tools 餵給 LLM 用。
+//!
+//! ## Wave 6 範圍
+//!
+//! 兩個 sub-stream:
+//!
+//! - **MCP-1(本 crate,foundation)**:
+//!   - [`config`]:`~/.mori/mcp.json` schema(stdio / http)
+//!   - [`client::McpClient`]:rmcp client wrapper(connect / list_tools / call_tool / shutdown)
+//!   - [`discovery::McpRegistry`]:多 server 管理(從 config build、aggregate tools、dispatch call)
+//!
+//! - **MCP-2(接續,留待後續 PR)**:
+//!   - 把 [`McpTool`] 包成 mori-core `Skill` trait,註冊進 SkillRegistry
+//!   - mori-tauri AppState 持有 `Arc<McpRegistry>`,在 startup load config + connect
+//!   - system prompt 加 MCP tool 描述
+//!   - Deps 頁 Node.js detect(多數 MCP server 走 `npx`)
+//!
+//! ## Config 範例
+//!
+//! `~/.mori/mcp.json`:
+//!
+//! ```json
+//! {
+//!   "servers": [
+//!     {
+//!       "name": "github",
+//!       "transport": "stdio",
+//!       "command": "npx",
+//!       "args": ["-y", "@modelcontextprotocol/server-github"],
+//!       "env": { "GITHUB_TOKEN": "..." }
+//!     },
+//!     {
+//!       "name": "remote-mcp",
+//!       "transport": "http",
+//!       "url": "https://mcp.example.com/mcp"
+//!     }
+//!   ]
+//! }
+//! ```
+//!
+//! ## 為什麼 rmcp 而不是自己刻
+//!
+//! rmcp 是 MCP 官方 Rust SDK,支援:
+//! - 兩條主要 transport(child-process stdio、Streamable HTTP)
+//! - 完整 protocol model(Tool / Resource / Prompt / Sampling)
+//! - 自動 InitializeRequest / capability negotiation
+//!
+//! 我們的 wrapper 是「only expose 必要 type、隔離 rmcp 版本變動」,讓 mori-core
+//! 不直接 import rmcp(MCP-2 接 SkillRegistry 時看得最清楚)。
+
+pub mod client;
+pub mod config;
+pub mod discovery;
+
+pub use client::{McpClient, McpError, McpTool, McpToolResult};
+pub use config::{default_config_path, load_config, ConfigError, McpConfig, McpServerConfig};
+pub use discovery::McpRegistry;


### PR DESCRIPTION
## Summary

**Wave 6 MCP-1** — `mori-mcp` 新 crate foundation。MCP server 連接 + tool discovery 基礎。**tool→Skill 整合留 MCP-2**。

§9 P0 in `jarvis-direction-notes.md`:解鎖 Browser / Notion / GitHub MCP 生態。

## Changes(6 檔)

- `crates/mori-mcp/`(新 crate):`Cargo.toml` + `src/{lib, config, client, discovery}.rs`
- workspace `Cargo.toml`:+ member

## Design

- **rmcp 1.x** + `default-features = false`,只開 `client / transport-child-process / transport-streamable-http-client-reqwest / reqwest`(剝 60% 不必要 deps)
- **DTO 隔離**:`McpTool` / `McpToolResult` / `McpError` 是 mori-mcp 自己的 struct,rmcp 內部型別不流到 caller — MCP-2 接 `mori-core::Skill` 不會 cascade import rmcp,升版只動本 crate
- **個別 server fail 隔離**:`McpRegistry::from_config` 對失敗 server log warn skip,**不 propagate**;list_tools 同樣
- **Content 平鋪**:`call_tool` 把 `CallToolResult.content[]`(text / image / embedded resource)展平成單一 string,非 text 用 placeholder(`[image: mime, N bytes]`),**不 dump base64**(省 token)
- **stdio + http** 雙 transport(stdio = spawn child,http = remote MCP)
- **Default config path** = `~/.mori/mcp.json`,HOME/USERPROFILE fallback

## Config schema

```json
{
  "servers": [
    { "transport": "stdio", "name": "github", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"], "env": { "GITHUB_TOKEN": "..." } },
    { "transport": "http", "name": "remote-mcp", "url": "https://mcp.example.com" }
  ]
}
```

## Test plan

- [x] 13 tests passing(config 6 + discovery 7)
- [x] cargo test -p mori-mcp:13 passed
- [x] mori-core 237 沒破
- [x] verify.sh 全綠

## Known follow-up

- **MCP-2(下波)**:`McpToolSkill` wrapper(impl `Skill` trait)+ 兩處 SkillRegistry 註冊 + mori-tauri integration + system prompt 提示
- **Deps 頁 Node.js DepSpec**:多數官方 MCP server 走 `npx -y`,user 沒裝 Node.js 會在 connect 走「No such file or directory」失敗。MCP-2 接 mori-tauri 時應該加 Node detect entry
- **rmcp 1.x active-dev** semver:後續 minor 升級可能改 Tool/CallToolResult,DTO 層已隔離 caller,但 client.rs 內部 match 可能需 sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)