### PR TITLE
feat(skill-install): Python runtime + Anthropic skills install (DF-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3020,6 +3020,7 @@ dependencies = [
  "tauri-plugin-global-shortcut",
  "tauri-plugin-single-instance",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/mori-tauri/Cargo.toml
+++ b/crates/mori-tauri/Cargo.toml
@@ -39,6 +39,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
+# DF-1:skill_install_cmd::SkillInstallError 走 thiserror derive 拿乾淨錯誤 chain。
+# 對齊 mori-core / mori-mcp 內既有的 thiserror pattern。
+thiserror = { workspace = true }
 async-trait = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/mori-tauri/src/deps.rs
+++ b/crates/mori-tauri/src/deps.rs
@@ -491,6 +491,111 @@ pub fn registry() -> Vec<DepSpec> {
             },
             install_overrides: &[],
         },
+        // Wave 6 D-full(DF-1):Python 3 runtime for Anthropic skills 的 scripts/ 執行。
+        //
+        // Stream I (#79) 已 ship SKILL.md markdown body 載入(D-light:純 prompt-augmentation,
+        // 不執行 scripts/)。D-full 上線後,執行型 skill(pdf / docx / xlsx / pptx /
+        // canvas-design / theme-factory / webapp-testing 7 個)會 spawn Python 跑
+        // `scripts/<entry>.py` — 沒 Python → 那些 skill 無法執行。
+        //
+        // 多數 Linux 發行版 / macOS / Windows installer 都把 binary 名稱定為 `python3`
+        // (Windows 也常有 python3 alias);用 `python3` 一個 binary 偵測足夠,Windows
+        // 上沒 alias 的少數情況 user 可看 install_caveat 指引。
+        DepSpec {
+            id: "python3",
+            name: "Python 3",
+            description: "Python 3.10+ runtime + pip。Wave 6 D-full Anthropic skills 的 \
+                          執行型 skill(pdf / docx / xlsx / pptx / 等)走 `python3 \
+                          <skill>/scripts/*.py`,沒裝就只剩 prompt-augmentation(body 餵 \
+                          LLM 但 scripts/ 跑不起來)。",
+            unlocks: "D-full Anthropic skills 執行型 skill(pypdf / openpyxl / python-docx / \
+                      python-pptx 等 Python script 能跑)",
+            size_hint: Some("~30-100MB(依平台)"),
+            needs_sudo: true,
+            platforms: &["linux", "macos", "windows"],
+            install_caveat: Some(
+                "Windows installer 預設 binary 是 `python` 而非 `python3`,但官方 \
+                 installer 同時 alias `python3`。沒 alias 的少數情況請在 Settings → Apps \
+                 → Python 加 PATH 或安裝時勾「Add python.exe to PATH」。",
+            ),
+            check: CheckSpec::Which { bin: "python3" },
+            check_overrides: &[],
+            install: InstallSpec::Manual {
+                commands: &[
+                    "# Ubuntu / Debian:",
+                    "sudo apt install python3 python3-pip",
+                    "# Fedora / RHEL:",
+                    "# sudo dnf install python3 python3-pip",
+                    "# Arch / Manjaro:",
+                    "# sudo pacman -S python python-pip",
+                    "# macOS(homebrew):",
+                    "# brew install python3",
+                    "# Windows:從官網下載 installer(記得勾「Add python.exe to PATH」):",
+                    "# https://www.python.org/downloads/",
+                    "# 確認:`python3 --version` + `pip3 --version`",
+                ],
+            },
+            install_overrides: &[],
+        },
+        // Wave 6 D-full(DF-1):Anthropic 官方 17 個 skills 庫(github.com/anthropics/skills)。
+        //
+        // 一鍵 install:`git clone --depth 1` 到 `~/.mori/skills/anthropics-skills/`。Stream I
+        // 的 `discover_skills` 掃的是扁平 `~/.mori/skills/<name>/SKILL.md`,Anthropic repo
+        // 結構是 `anthropics-skills/skills/<name>/`,需要走 symlink-flatten 或改 loader 邏輯
+        // (本 stream 只先 install + 文件指引,flatten 留 DF-2 補)。
+        //
+        // 對齊 annuli-runtime 的 git clone pattern(Linux/macOS Shell + Windows Manual)。
+        // 也可走 `install_anthropic_skills_cmd` Tauri command 拿到更精細的錯誤訊息,
+        // 但走 InstallSpec 能直接吃既有 DepsTab UI(install 按鈕 + status 圖示),
+        // 不需要新前端 schema 變動 — minimal viable path。
+        DepSpec {
+            id: "anthropic-skills",
+            name: "Anthropic Skills 庫",
+            description: "Anthropic 官方 17 個 skills(github.com/anthropics/skills):brand-guidelines / \
+                          internal-comms / pdf / docx / xlsx / pptx / canvas-design / 等。\
+                          一鍵 `git clone` 到 `~/.mori/skills/anthropics-skills/`。\
+                          \n\n安裝後重啟 Mori 才會 discover(Stream I SKILL.md loader 在 \
+                          startup 一次性掃),目前 loader 掃 `~/.mori/skills/<name>/` 扁平 \
+                          路徑,而 Anthropic repo 是 `anthropics-skills/skills/<name>/` — \
+                          完整 discovery 整合留 DF-2 做(可走 symlink flatten 或 loader \
+                          多掃一層)。",
+            unlocks: "discover 到 17 個 Anthropic 官方 skill(SKILL.md body 進 system prompt)",
+            size_hint: Some("~10-50MB(repo + scripts/)"),
+            needs_sudo: false,
+            platforms: &["linux", "macos", "windows"],
+            install_caveat: Some(
+                "需要 git 在 PATH。安裝後需重啟 Mori。Stream I loader 路徑 ↔ Anthropic repo \
+                 結構差一層 — 完整 discovery 整合留 DF-2(symlink flatten 或 loader 補)。",
+            ),
+            check: CheckSpec::File {
+                path_template: "$HOME/.mori/skills/anthropics-skills/.git",
+            },
+            check_overrides: &[],
+            install: InstallSpec::Shell {
+                script: "set -e; \
+                         DEST=\"$HOME/.mori/skills/anthropics-skills\"; \
+                         mkdir -p \"$HOME/.mori/skills\"; \
+                         if [ -d \"$DEST/.git\" ]; then \
+                            echo '已有 anthropics-skills repo,跑 git pull 更新...'; \
+                            cd \"$DEST\" && git pull --ff-only; \
+                         else \
+                            echo '從 GitHub 拉 anthropics/skills(--depth 1)...'; \
+                            git clone --depth 1 https://github.com/anthropics/skills.git \"$DEST\"; \
+                         fi; \
+                         echo '✓ Anthropic skills 裝好 — 重啟 Mori 才會 discover。'; \
+                         echo '  (DF-2 上線後會自動 flatten 17 個 skill 到 ~/.mori/skills/<name>/)'",
+            },
+            install_overrides: &[
+                ("windows", InstallSpec::Manual {
+                    commands: &[
+                        "# Windows(PowerShell / cmd,需要 git for Windows):",
+                        "mkdir %USERPROFILE%\\.mori\\skills 2>NUL",
+                        "git clone --depth 1 https://github.com/anthropics/skills.git %USERPROFILE%\\.mori\\skills\\anthropics-skills",
+                        "# 安裝後重啟 Mori。完整 discovery 整合留 DF-2。",
+                    ],
+                }),
+            ],
+        },
         // Obsidian CLI — bundled inside Obsidian app v1.12.4+(GA 2026/02),
         // 不是獨立 binary。User 要先裝 app 再到 in-app Settings 啟用「Register CLI」,
         // 啟用後 `obsidian` 才會在 PATH。沒啟用 → starter AGENT-06.obsidian 跑 shell_skill

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -25,6 +25,11 @@ mod x11_shape;
 #[cfg_attr(target_os = "windows", path = "selection_windows.rs")]
 mod selection;
 mod shell_skill;
+// Wave 6 DF-1:Anthropic skills install commands(`install_anthropic_skills_cmd` /
+// `anthropic_skills_status_cmd`)+ internal helpers。對比 deps.rs 內的
+// `anthropic-skills` DepSpec(走 InstallSpec::Shell git clone),這個 module 是
+// 更乾淨的 Rust path(不 spawn sh,直接 git clone + 明確錯誤 chain)。
+mod skill_install_cmd;
 mod skill_server;
 mod recordings;
 mod soul_distribution;
@@ -5210,6 +5215,10 @@ fn main() {
             reminders_cmd::snooze_reminder_cmd,
             mcp_cmd::mcp_list_tools_cmd,
             mcp_cmd::mcp_call_tool_cmd,
+            // Wave 6 DF-1:Anthropic skills install commands。前端可選用(也可走
+            // DepsTab 內的 `anthropic-skills` entry)— 兩條路徑 install 結果一致。
+            skill_install_cmd::install_anthropic_skills_cmd,
+            skill_install_cmd::anthropic_skills_status_cmd,
             transcribe_cmds::transcribe_check_deps,
             transcribe_cmds::transcribe_file_cmd,
             transcribe_cmds::transcribe_paths_cmd,

--- a/crates/mori-tauri/src/skill_install_cmd.rs
+++ b/crates/mori-tauri/src/skill_install_cmd.rs
@@ -1,0 +1,274 @@
+//! Wave 6 D-full(DF-1):Anthropic skills install helper + Tauri commands。
+//!
+//! 提供一個 **更精細** 的 install 路徑(對比 DepsTab 的 `InstallSpec::Shell`):
+//! - 自家檢測 git 在不在 PATH(`SkillInstallError::GitMissing` 明確錯誤)
+//! - 自家管 destination layout(`~/.mori/skills/anthropics-skills/`)
+//! - 跨平台:不 spawn `sh`(`InstallSpec::Shell` 走 sh -c 在 Windows 需要 Git Bash),
+//!   走 `Command::new("git")` direct invoke
+//!
+//! 整合路徑:
+//! 1. 本 module 提供 [`install_anthropic_skills_cmd`] / [`anthropic_skills_status_cmd`]
+//!    兩個 Tauri commands(前端可直接呼叫,例如「Install Anthropic Skills」按鈕)
+//! 2. 也提供 internal helpers([`skills_dir`] / [`is_anthropic_skills_installed`] /
+//!    [`install_anthropic_skills`])給 main.rs / 其他 module 用
+//! 3. install 完成後 Stream I (#79) 的 `discover_skills` 會掃到 — 注意 Anthropic
+//!    repo 結構是 `anthropics-skills/skills/<name>/`,而 loader 掃 `~/.mori/skills/<name>/`
+//!    扁平路徑,完整 discovery 整合(symlink flatten / loader 補)留 DF-2 做。
+//!
+//! 對應 deps.rs 內的 `anthropic-skills` DepSpec entry:那條走 `InstallSpec::Shell`
+//! 直接跑 `git clone`,這份 module 是「更乾淨的 Rust path」— 兩條路徑同時存在,user
+//! 走任一條都能成功。
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use thiserror::Error;
+
+/// Anthropic 官方 skills repo。
+const ANTHROPIC_SKILLS_REPO: &str = "https://github.com/anthropics/skills.git";
+
+/// Anthropic skills 在本機的安裝子目錄(相對於 [`skills_dir`])。
+const ANTHROPIC_SKILLS_SUBDIR: &str = "anthropics-skills";
+
+#[derive(Debug, Error)]
+pub enum SkillInstallError {
+    #[error("git not found in PATH (please install git first)")]
+    GitMissing,
+    #[error("git clone failed (exit {0:?})")]
+    CloneFailed(Option<i32>),
+    #[error("home dir not found (HOME / USERPROFILE both unset)")]
+    NoHome,
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// `~/.mori/skills/` — 跟 [`mori_core::skill::anthropic_skill::default_skills_dir`]
+/// 對齊,但本 module 不 depend mori-core(避免循環),自己組同樣 path。
+///
+/// 回 `None` 表示 HOME / USERPROFILE 都沒設(極稀有,容器 / 純 minimal env 才會)。
+pub fn skills_dir() -> Option<PathBuf> {
+    skills_dir_with_home(home_dir())
+}
+
+/// 取 home dir — HOME 優先,fallback USERPROFILE(Windows)。
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+/// 純 functional helper,給 test 注入 home dir 用。`None` 入 → `None` 出。
+fn skills_dir_with_home(home: Option<PathBuf>) -> Option<PathBuf> {
+    home.map(|h| h.join(".mori").join("skills"))
+}
+
+/// 檢查 Anthropic skills 是否已 install — 看 `~/.mori/skills/anthropics-skills/.git`
+/// 是否存在(`git clone` 完一定有 `.git` 目錄)。
+pub fn is_anthropic_skills_installed() -> bool {
+    skills_dir()
+        .map(|dir| is_anthropic_skills_installed_at(&dir))
+        .unwrap_or(false)
+}
+
+/// 純 functional helper,給 test 注入 skills dir 用。
+fn is_anthropic_skills_installed_at(skills_dir: &Path) -> bool {
+    skills_dir.join(ANTHROPIC_SKILLS_SUBDIR).join(".git").exists()
+}
+
+/// 跑 `git clone --depth 1` 拉 Anthropic skills repo 到 `~/.mori/skills/anthropics-skills/`。
+///
+/// **不負責 discovery flatten** — 該事留 DF-2 補。本 fn 完成 → user 重啟 Mori,
+/// `discover_skills` 走原邏輯掃不到深層 `skills/<name>/SKILL.md`,需要前端 / loader
+/// 升級配合。
+///
+/// 失敗模式:
+/// - `git` 不在 PATH → [`SkillInstallError::GitMissing`]
+/// - `git clone` 退非 0 → [`SkillInstallError::CloneFailed`](exit code)
+/// - HOME / USERPROFILE 都沒設 → [`SkillInstallError::NoHome`]
+/// - mkdir parent / 其他 IO 錯 → [`SkillInstallError::Io`]
+pub fn install_anthropic_skills() -> Result<PathBuf, SkillInstallError> {
+    let dest_root = skills_dir().ok_or(SkillInstallError::NoHome)?;
+    install_anthropic_skills_at(&dest_root)
+}
+
+/// 內部 helper:把 install destination 注入,給 test 用(同時也是 prod path 的
+/// 真正實作)。
+fn install_anthropic_skills_at(dest_root: &Path) -> Result<PathBuf, SkillInstallError> {
+    std::fs::create_dir_all(dest_root)?;
+    let target = dest_root.join(ANTHROPIC_SKILLS_SUBDIR);
+
+    // 已經有 .git → 不重複 clone,直接回傳 path(idempotent)。
+    // user 想更新走 `git pull`(deps.rs 內的 Shell variant 有 fallback path)。
+    if target.join(".git").exists() {
+        tracing::info!(path = %target.display(), "anthropic skills already installed; skipping clone");
+        return Ok(target);
+    }
+
+    let mut cmd = Command::new("git");
+    cmd.args(["clone", "--depth", "1", ANTHROPIC_SKILLS_REPO])
+        .arg(&target);
+    mori_core::suppress_console_on_windows!(cmd);
+
+    let status = cmd.status().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            SkillInstallError::GitMissing
+        } else {
+            SkillInstallError::Io(e)
+        }
+    })?;
+
+    if !status.success() {
+        return Err(SkillInstallError::CloneFailed(status.code()));
+    }
+
+    tracing::info!(path = %target.display(), "anthropic skills installed");
+    Ok(target)
+}
+
+// ─── Tauri commands ────────────────────────────────────────────────
+
+/// 前端「Install Anthropic Skills」按鈕呼叫。spawn_blocking 內跑 — `git clone`
+/// 可能跑數十秒(網路 + repo size),不該擋 async runtime。
+#[tauri::command]
+pub async fn install_anthropic_skills_cmd() -> Result<String, String> {
+    let path = tokio::task::spawn_blocking(install_anthropic_skills)
+        .await
+        .map_err(|e| format!("install join: {e}"))?
+        .map_err(|e| e.to_string())?;
+    Ok(format!("Installed to {}", path.display()))
+}
+
+/// 前端「is installed?」狀態查詢。同步 — 只看一個檔案存不存在,微秒級。
+#[tauri::command]
+pub fn anthropic_skills_status_cmd() -> bool {
+    is_anthropic_skills_installed()
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    // ─── skills_dir_with_home ─────────────────────────────────
+
+    #[test]
+    fn skills_dir_with_home_returns_some_when_home_set() {
+        let home = PathBuf::from("/home/test");
+        let got = skills_dir_with_home(Some(home.clone())).expect("should be Some");
+        assert_eq!(got, home.join(".mori").join("skills"));
+    }
+
+    #[test]
+    fn skills_dir_with_home_returns_none_when_home_absent() {
+        assert!(skills_dir_with_home(None).is_none());
+    }
+
+    // ─── is_anthropic_skills_installed_at ─────────────────────
+
+    #[test]
+    fn is_installed_returns_false_when_dir_missing() {
+        let dir = TempDir::new().unwrap();
+        let skills_root = dir.path().join("skills");
+        // skills_root 不存在 — `.git` 路徑解析會成功(不存在的 join),
+        // 但 .exists() 回 false。
+        assert!(!is_anthropic_skills_installed_at(&skills_root));
+    }
+
+    #[test]
+    fn is_installed_returns_false_when_subdir_present_but_no_git() {
+        // anthropics-skills/ 在但沒 .git → 不算 installed(可能是 user 手動建空目錄)。
+        let dir = TempDir::new().unwrap();
+        let skills_root = dir.path().to_path_buf();
+        std::fs::create_dir_all(skills_root.join(ANTHROPIC_SKILLS_SUBDIR)).unwrap();
+        assert!(!is_anthropic_skills_installed_at(&skills_root));
+    }
+
+    #[test]
+    fn is_installed_returns_true_when_git_subdir_exists() {
+        // mock git clone 後的狀態:anthropics-skills/.git/ 存在。
+        let dir = TempDir::new().unwrap();
+        let skills_root = dir.path().to_path_buf();
+        let git_dir = skills_root.join(ANTHROPIC_SKILLS_SUBDIR).join(".git");
+        std::fs::create_dir_all(&git_dir).unwrap();
+        assert!(is_anthropic_skills_installed_at(&skills_root));
+    }
+
+    #[test]
+    fn is_installed_accepts_git_file_or_dir() {
+        // git worktree / submodule 下 `.git` 可能是 file 而非 dir。.exists() 兩者皆 true。
+        let dir = TempDir::new().unwrap();
+        let skills_root = dir.path().to_path_buf();
+        let subdir = skills_root.join(ANTHROPIC_SKILLS_SUBDIR);
+        std::fs::create_dir_all(&subdir).unwrap();
+        std::fs::write(subdir.join(".git"), "gitdir: ../../somewhere\n").unwrap();
+        assert!(is_anthropic_skills_installed_at(&skills_root));
+    }
+
+    // ─── install_anthropic_skills_at ──────────────────────────
+
+    #[test]
+    fn install_short_circuits_when_already_present() {
+        // pre-create .git → install 不該再 spawn git(就算 PATH 沒 git 也要回 Ok)。
+        let dir = TempDir::new().unwrap();
+        let skills_root = dir.path().to_path_buf();
+        let target = skills_root.join(ANTHROPIC_SKILLS_SUBDIR);
+        std::fs::create_dir_all(target.join(".git")).unwrap();
+
+        let got = install_anthropic_skills_at(&skills_root).expect("idempotent install");
+        assert_eq!(got, target);
+    }
+
+    #[test]
+    fn install_creates_parent_dirs() {
+        // dest_root 深層巢狀不存在 → create_dir_all 要先把它建出來(才好 clone)。
+        // 不實際跑 clone(會打網路),用 short-circuit 路徑驗:預先 mock .git 後,
+        // 確認 install 不會 fail / 不會清掉父目錄。
+        let dir = TempDir::new().unwrap();
+        let deep = dir.path().join("a").join("b").join("c");
+        // pre-create .git 走 short-circuit(跳過 git clone)
+        let target = deep.join(ANTHROPIC_SKILLS_SUBDIR);
+        std::fs::create_dir_all(target.join(".git")).unwrap();
+
+        let got = install_anthropic_skills_at(&deep).expect("should succeed");
+        assert!(got.exists());
+        assert!(deep.exists(), "parent dir should be preserved");
+    }
+
+    #[test]
+    fn install_returns_git_missing_when_git_not_in_path() {
+        // 走真正的 spawn path,但 PATH 設成空 → `git` 找不到 → GitMissing。
+        // 注意:set_var 是 process-global,單測會跟其他並行 test 互干擾;這個 test
+        // 故意只測 install_anthropic_skills_at(不碰 skills_dir / env),改動完
+        // 立刻 restore。
+        let dir = TempDir::new().unwrap();
+        let skills_root = dir.path().to_path_buf();
+
+        // Save + clear PATH
+        let saved_path = std::env::var_os("PATH");
+        std::env::set_var("PATH", "");
+
+        let result = install_anthropic_skills_at(&skills_root);
+
+        // Restore PATH 先,免得後續 test 受影響。
+        match saved_path {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+
+        match result {
+            Err(SkillInstallError::GitMissing) => {}
+            other => panic!("expected GitMissing, got {other:?}"),
+        }
+    }
+
+    // ─── ANTHROPIC_SKILLS_SUBDIR constant ─────────────────────
+
+    #[test]
+    fn anthropic_skills_subdir_is_stable() {
+        // Stream I loader 跟 deps.rs 內的 check path_template 都依賴這個常數值。
+        // 改了這個 = 同步要改 deps.rs 的 `$HOME/.mori/skills/anthropics-skills/.git`。
+        assert_eq!(ANTHROPIC_SKILLS_SUBDIR, "anthropics-skills");
+    }
+}


### PR DESCRIPTION
## Summary

**Wave 6 DF-1** — Python runtime detect + Anthropic skills install 流程。為 DF-2(script execution + AnthropicSkill upgrade)鋪路。

## Changes

- `crates/mori-tauri/src/deps.rs`(+105):
  - 新 DepSpec `python3`(Which detect + Manual install)
  - 新 DepSpec `anthropic-skills`(File .git check + Shell `git clone` install,Windows override 走 Manual)
- `crates/mori-tauri/src/skill_install_cmd.rs`(新 ~250):
  - `SkillInstallError`(GitMissing / CloneFailed / NoHome / Io)
  - `skills_dir() / is_anthropic_skills_installed() / install_anthropic_skills()` helpers
  - 2 Tauri commands:`install_anthropic_skills_cmd` / `anthropic_skills_status_cmd`
- `crates/mori-tauri/src/main.rs`:mod + invoke_handler 註冊
- `crates/mori-tauri/Cargo.toml`:+ thiserror workspace dep

## Design

- **python3 單 binary detect** — 主流 distro + macOS/Windows installer 都優先用 python3 alias
- **兩條 install 路徑並存**:DepsTab 走 `InstallSpec::Shell` git clone,Tauri command 也提供(Windows 不依賴 Git Bash)
- **install idempotent**:pre-existing `.git` → short-circuit Ok(不重複 clone)
- **Discovery flatten 留 DF-2**:Anthropic 結構是 `anthropics-skills/skills/<name>/SKILL.md`(深 3 層),Stream I (#79) 是扁平掃。DF-2 處理 flatten(symlink iterate)or loader 多掃 1 層
- **schema 不動**:沒新增 `CheckSpec::TauriCommand` / `InstallSpec::TauriCommand`(會 break frontend)

## Test plan

- [x] 10 skill_install_cmd tests(skills_dir / is_installed / install / git missing)
- [x] mori-tauri:114 passed
- [x] mori-core 245 沒破
- [x] verify.sh 全綠

## Known follow-up (DF-2)

- **AnthropicSkill::execute 升級** — body 內提到 scripts/<entry>.py 時 spawn python3 跑
- **Discovery flatten** — symlink anthropics-skills/skills/<name>/ 到 ~/.mori/skills/<name>/
- **Per-skill pip install** — pypdf / openpyxl / python-docx / python-pptx preflight

🤖 Generated with [Claude Code](https://claude.com/claude-code)