### PR TITLE
feat(skill): AnthropicScriptSkill + python_runner + skills flatten (DF-2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3020,6 +3020,7 @@ dependencies = [
  "tauri-plugin-global-shortcut",
  "tauri-plugin-single-instance",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/mori-core/src/skill/anthropic_skill.rs
+++ b/crates/mori-core/src/skill/anthropic_skill.rs
@@ -42,12 +42,13 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::Value;
 use thiserror::Error;
 
+use super::python_runner::{run_python_script, RunError};
 use super::{ExecutionTarget, Privacy, Skill, SkillOutput};
 use crate::context::Context;
 
@@ -158,11 +159,26 @@ pub fn load_skill_from_path(path: &Path) -> Result<AnthropicSkill, LoadError> {
     })
 }
 
+/// 掃出來的單個 skill descriptor。
+///
+/// `scripts_dir` 為 `Some(path)` 表示 skill 目錄底下有 `scripts/`(可執行型),
+/// 主 module 看到這條會額外註冊一個 [`AnthropicScriptSkill`]。
+/// `None` 表示純 prompt-augmentation skill,只有 SKILL.md。
+#[derive(Debug, Clone)]
+pub struct DiscoveredSkill {
+    pub skill: AnthropicSkill,
+    pub scripts_dir: Option<PathBuf>,
+}
+
 /// 掃 `skills_dir/<name>/SKILL.md`,parse 成功的全收。
 ///
 /// 失敗的個別 skill(壞 frontmatter / IO error)會 log warning 跳過,不會 crash
 /// 整個 discover。`skills_dir` 不存在直接回空 vec(對齊「沒裝 skill 是正常狀態」)。
-pub fn discover_skills(skills_dir: &Path) -> Vec<AnthropicSkill> {
+///
+/// **DF-2 升級**:回 [`DiscoveredSkill`] 而非裸 [`AnthropicSkill`],額外帶
+/// `scripts_dir`(若 skill 目錄含 `scripts/` 子資料夾)。caller 可以判斷是否該
+/// 另外註冊一個 [`AnthropicScriptSkill`] 給 LLM 跑 Python script。
+pub fn discover_skills(skills_dir: &Path) -> Vec<DiscoveredSkill> {
     let entries = match fs::read_dir(skills_dir) {
         Ok(e) => e,
         Err(e) => {
@@ -178,6 +194,8 @@ pub fn discover_skills(skills_dir: &Path) -> Vec<AnthropicSkill> {
     let mut out = Vec::new();
     for entry in entries.flatten() {
         let path = entry.path();
+        // path.is_dir() follows symlinks(對齊 DF-1 install flatten:Anthropic
+        // skills 是 symlink → 也算 dir)。
         if !path.is_dir() {
             continue;
         }
@@ -187,8 +205,21 @@ pub fn discover_skills(skills_dir: &Path) -> Vec<AnthropicSkill> {
         }
         match load_skill_from_path(&skill_md) {
             Ok(skill) => {
-                tracing::debug!(name = %skill.name, "loaded anthropic skill");
-                out.push(skill);
+                let scripts_path = path.join("scripts");
+                let scripts_dir = if scripts_path.is_dir() {
+                    Some(scripts_path)
+                } else {
+                    None
+                };
+                tracing::debug!(
+                    name = %skill.name,
+                    has_scripts = scripts_dir.is_some(),
+                    "loaded anthropic skill"
+                );
+                out.push(DiscoveredSkill {
+                    skill,
+                    scripts_dir,
+                });
             }
             Err(e) => {
                 tracing::warn!(
@@ -286,6 +317,213 @@ impl Skill for AnthropicPromptSkill {
             data: Some(serde_json::json!({
                 "skill": self.leaked_name,
                 "kind": "anthropic_prompt",
+            })),
+        })
+    }
+}
+
+// ─── AnthropicScriptSkill ──────────────────────────────────────────
+
+/// 把 Anthropic skill 內的 `scripts/` 子資料夾暴露成單一可呼叫 LLM tool。
+///
+/// # 跟 [`AnthropicPromptSkill`] 並存,不取代
+///
+/// 一個 Anthropic skill 可能有兩種互補形態:
+/// 1. **SKILL.md body**:給 LLM 「讀」的指引(`AnthropicPromptSkill`)
+/// 2. **scripts/**:給 LLM 「跑」的 Python 程式(本 struct)
+///
+/// 兩個都會註冊到 [`SkillRegistry`](super::SkillRegistry)。LLM 在 tool list
+/// 同時看到:
+/// - `pdf` — Use this skill when working with PDFs.(prompt-augmentation)
+/// - `anthropic_script_pdf` — [scripts] Use this skill when working with PDFs.
+///   (subprocess execution)
+///
+/// LLM 流程通常:先 invoke `pdf`(讀指引,知道有哪些 script、用法),再 invoke
+/// `anthropic_script_pdf` 加 `script: "merge_pdfs.py", args: [...]`。
+///
+/// # 為什麼 name 加 `anthropic_script_` prefix?
+///
+/// 避免跟 prompt skill 同名 collision(都來自同一個 SKILL.md 的 `name` 欄,例
+/// `pdf`)。SkillRegistry 名字 unique;同名後註冊會 warn + replace,行為亂跳。
+///
+/// # 參數 schema
+///
+/// LLM 拿到一個 generic 的「跑某 script」介面:
+/// - `script`(required):script 檔名,例 `extract_text.py`
+/// - `args`(optional):CLI argv list
+/// - `stdin`(optional):餵給 script stdin 的內容
+///
+/// SKILL.md body 內會描述 `scripts/` 內各 script 的用法,LLM 從那邊學;這個
+/// schema 故意保簡單,不替 individual script 編 wrapper(那是 follow-up)。
+///
+/// # 安全 / 信任邊界
+///
+/// 走 `python3` direct subprocess,沒沙箱、沒 venv。user 安裝官方 Anthropic
+/// skill 即同意跑(對齊 DF-1 install 邏輯:user 點 install button = 同意)。
+/// 自訂 skill 放進 `~/.mori/skills/<name>/scripts/` 也會被 expose;user 對自己
+/// 的 ~/.mori 內容負責。
+pub struct AnthropicScriptSkill {
+    /// 原 SKILL.md 解析結果。保留 `body` / `name` / `description` 給 introspection。
+    skill: AnthropicSkill,
+    /// `<skill_dir>/scripts/` 絕對路徑。execute 時 join script filename。
+    scripts_dir: PathBuf,
+    /// `anthropic_script_<name>`,leaked 成 `'static`(對齊 `McpToolSkill` /
+    /// `AnthropicPromptSkill` pattern)。
+    leaked_name: &'static str,
+    /// `[scripts] <description>`,leaked 成 `'static`。
+    leaked_description: &'static str,
+}
+
+impl AnthropicScriptSkill {
+    /// Build wrapper。`leak` name / description 到 `'static`。
+    pub fn new(skill: AnthropicSkill, scripts_dir: PathBuf) -> Self {
+        let name_string = format!("anthropic_script_{}", skill.name);
+        let desc_string = format!("[scripts] {}", skill.description);
+        let leaked_name: &'static str = Box::leak(name_string.into_boxed_str());
+        let leaked_description: &'static str = Box::leak(desc_string.into_boxed_str());
+        Self {
+            skill,
+            scripts_dir,
+            leaked_name,
+            leaked_description,
+        }
+    }
+
+    /// Convenience constructor — 包成 `Arc<dyn Skill>` 給 main.rs 註冊。
+    pub fn into_arc_skill(self) -> Arc<dyn Skill> {
+        Arc::new(self)
+    }
+
+    /// 給 introspection / debug 用:回 scripts dir path。
+    pub fn scripts_dir(&self) -> &Path {
+        &self.scripts_dir
+    }
+
+    /// 給 introspection / debug 用:回原 Anthropic skill name(無 prefix)。
+    pub fn skill_name(&self) -> &str {
+        &self.skill.name
+    }
+}
+
+#[async_trait]
+impl Skill for AnthropicScriptSkill {
+    fn name(&self) -> &'static str {
+        self.leaked_name
+    }
+
+    fn description(&self) -> &'static str {
+        self.leaked_description
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "script": {
+                    "type": "string",
+                    "description": "Script filename inside the skill's scripts/ directory (e.g. `extract_text.py`)."
+                },
+                "args": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Optional CLI arguments forwarded to the script (sys.argv[1:])."
+                },
+                "stdin": {
+                    "type": "string",
+                    "description": "Optional stdin content piped into the script."
+                }
+            },
+            "required": ["script"],
+            "additionalProperties": false
+        })
+    }
+
+    fn target_capability(&self) -> ExecutionTarget {
+        // python3 subprocess 跑在本機 — 不像 prompt-augmentation 那樣
+        // device-agnostic。對齊 ShellSkill / ReadFileSkill 等 process-bound skill。
+        ExecutionTarget::Local
+    }
+
+    fn privacy(&self) -> Privacy {
+        // script 輸出會餵回 LLM 做 multi-turn(LLM 接著解 result);user 想完全
+        // local 自己選 local provider。
+        Privacy::Cloud
+    }
+
+    async fn execute(&self, args: Value, _context: &Context) -> Result<SkillOutput> {
+        let script = args
+            .get("script")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("missing required argument `script`"))?;
+
+        // 防 path traversal:script 不能含 `..` 或絕對路徑(LLM 不該跳出 scripts_dir)。
+        if script.contains("..") || Path::new(script).is_absolute() {
+            return Err(anyhow!(
+                "invalid script path `{script}` (no `..` or absolute paths allowed)"
+            ));
+        }
+
+        let cli_args: Vec<String> = args
+            .get("args")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let stdin = args
+            .get("stdin")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let script_path = self.scripts_dir.join(script);
+        if !script_path.is_file() {
+            return Err(anyhow!(
+                "script not found: {} (under {})",
+                script,
+                self.scripts_dir.display()
+            ));
+        }
+
+        tracing::info!(
+            skill = self.leaked_name,
+            script = %script,
+            args_count = cli_args.len(),
+            has_stdin = stdin.is_some(),
+            "anthropic script dispatch",
+        );
+
+        let output = run_python_script(&script_path, &cli_args, stdin.as_deref())
+            .await
+            .map_err(|e| match e {
+                RunError::PythonMissing => anyhow!(
+                    "python3 not in PATH — install Python 3 to run Anthropic script skills"
+                ),
+                other => anyhow!("script execution failed: {other}"),
+            })?;
+
+        // user_message 給 LLM 看的:script stdout 為主。若 exit_code != 0,把
+        // stderr 一起塞進去讓 LLM 看到錯誤詳情(否則 LLM 只看到空 stdout 會困惑)。
+        let user_message = if output.exit_code == 0 {
+            output.stdout.clone()
+        } else {
+            format!(
+                "Script exited with code {}.\n\nstdout:\n{}\n\nstderr:\n{}",
+                output.exit_code, output.stdout, output.stderr
+            )
+        };
+
+        Ok(SkillOutput {
+            user_message,
+            data: Some(serde_json::json!({
+                "skill": self.skill.name,
+                "script": script,
+                "stdout": output.stdout,
+                "stderr": output.stderr,
+                "exit_code": output.exit_code,
+                "kind": "anthropic_script",
             })),
         })
     }
@@ -451,10 +689,13 @@ mod tests {
         .unwrap();
 
         let mut got = discover_skills(root);
-        got.sort_by(|x, y| x.name.cmp(&y.name));
+        got.sort_by(|x, y| x.skill.name.cmp(&y.skill.name));
         assert_eq!(got.len(), 2);
-        assert_eq!(got[0].name, "brand-guidelines");
-        assert_eq!(got[1].name, "internal-comms");
+        assert_eq!(got[0].skill.name, "brand-guidelines");
+        assert_eq!(got[1].skill.name, "internal-comms");
+        // Neither has scripts/ subdir.
+        assert!(got[0].scripts_dir.is_none());
+        assert!(got[1].scripts_dir.is_none());
     }
 
     #[test]
@@ -475,7 +716,7 @@ mod tests {
 
         let got = discover_skills(root);
         assert_eq!(got.len(), 1, "bad skill should be skipped, not crash");
-        assert_eq!(got[0].name, "good");
+        assert_eq!(got[0].skill.name, "good");
     }
 
     #[test]
@@ -491,7 +732,7 @@ mod tests {
         .unwrap();
         let got = discover_skills(root);
         assert_eq!(got.len(), 1);
-        assert_eq!(got[0].name, "real");
+        assert_eq!(got[0].skill.name, "real");
     }
 
     #[test]
@@ -517,7 +758,7 @@ mod tests {
         .unwrap();
         let got = discover_skills(root);
         assert_eq!(got.len(), 1);
-        assert_eq!(got[0].name, "ok");
+        assert_eq!(got[0].skill.name, "ok");
     }
 
     // ─── AnthropicPromptSkill ─────────────────────────────────
@@ -558,5 +799,193 @@ mod tests {
         assert_eq!(schema["type"], "object");
         assert!(schema["properties"].is_object());
         assert_eq!(schema["properties"].as_object().unwrap().len(), 0);
+    }
+
+    // ─── discover_skills scripts/ enrichment ──────────────────
+
+    #[test]
+    fn discover_skills_detects_scripts_subdir() {
+        // skill 目錄底下有 `scripts/` 子資料夾 → DiscoveredSkill.scripts_dir = Some
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let pdf = root.join("pdf");
+        fs::create_dir(&pdf).unwrap();
+        fs::write(
+            pdf.join("SKILL.md"),
+            "---\nname: pdf\ndescription: PDF tools\n---\n\nbody\n",
+        )
+        .unwrap();
+        fs::create_dir(pdf.join("scripts")).unwrap();
+        fs::write(pdf.join("scripts").join("extract.py"), "print('x')\n").unwrap();
+
+        let got = discover_skills(root);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].skill.name, "pdf");
+        let sd = got[0].scripts_dir.as_ref().expect("scripts_dir should be Some");
+        assert!(sd.ends_with("scripts"));
+        assert!(sd.is_dir());
+    }
+
+    #[test]
+    fn discover_skills_no_scripts_dir_when_only_skill_md() {
+        // 純 prompt skill — `scripts_dir` 必須 None。
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let brand = root.join("brand-guidelines");
+        fs::create_dir(&brand).unwrap();
+        fs::write(
+            brand.join("SKILL.md"),
+            "---\nname: brand-guidelines\ndescription: X\n---\n\nbody\n",
+        )
+        .unwrap();
+
+        let got = discover_skills(root);
+        assert_eq!(got.len(), 1);
+        assert!(got[0].scripts_dir.is_none());
+    }
+
+    // ─── AnthropicScriptSkill ─────────────────────────────────
+
+    /// 整環境是否裝 python3。CI 若沒裝就 skip 相關 test。
+    fn python3_available() -> bool {
+        std::process::Command::new("python3")
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    fn make_script_skill(scripts_dir: PathBuf) -> AnthropicScriptSkill {
+        let skill = AnthropicSkill {
+            name: "pdf".to_string(),
+            description: "Use this skill when working with PDFs.".to_string(),
+            body: "# PDF body".to_string(),
+            license: None,
+        };
+        AnthropicScriptSkill::new(skill, scripts_dir)
+    }
+
+    #[test]
+    fn script_skill_name_has_prefix() {
+        let dir = TempDir::new().unwrap();
+        let s = make_script_skill(dir.path().to_path_buf());
+        assert_eq!(s.name(), "anthropic_script_pdf");
+        assert_eq!(s.skill_name(), "pdf");
+        assert!(s.description().starts_with("[scripts]"));
+    }
+
+    #[test]
+    fn script_skill_schema_requires_script() {
+        let dir = TempDir::new().unwrap();
+        let s = make_script_skill(dir.path().to_path_buf());
+        let schema = s.parameters_schema();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["script"].is_object());
+        assert!(schema["properties"]["args"].is_object());
+        assert!(schema["properties"]["stdin"].is_object());
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v == "script"));
+    }
+
+    #[tokio::test]
+    async fn script_skill_execute_errors_on_missing_script_arg() {
+        let dir = TempDir::new().unwrap();
+        let s = make_script_skill(dir.path().to_path_buf());
+        let ctx = Context::default();
+        let err = s
+            .execute(serde_json::json!({}), &ctx)
+            .await
+            .expect_err("missing script arg should error");
+        assert!(err.to_string().contains("script"));
+    }
+
+    #[tokio::test]
+    async fn script_skill_execute_errors_on_traversal() {
+        let dir = TempDir::new().unwrap();
+        let s = make_script_skill(dir.path().to_path_buf());
+        let ctx = Context::default();
+        let err = s
+            .execute(serde_json::json!({ "script": "../etc/passwd" }), &ctx)
+            .await
+            .expect_err("path traversal should be blocked");
+        assert!(err.to_string().to_lowercase().contains("invalid"));
+    }
+
+    #[tokio::test]
+    async fn script_skill_execute_errors_when_script_missing() {
+        let dir = TempDir::new().unwrap();
+        let s = make_script_skill(dir.path().to_path_buf());
+        let ctx = Context::default();
+        let err = s
+            .execute(serde_json::json!({ "script": "nope.py" }), &ctx)
+            .await
+            .expect_err("missing script file should error");
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn script_skill_execute_runs_python() {
+        if !python3_available() {
+            eprintln!("python3 not available; skipping");
+            return;
+        }
+        let dir = TempDir::new().unwrap();
+        // 建一個 scripts/ 子目錄 + 一個 Python script
+        let scripts_dir = dir.path().join("scripts");
+        fs::create_dir(&scripts_dir).unwrap();
+        fs::write(
+            scripts_dir.join("hello.py"),
+            "import sys\nprint('hi', sys.argv[1] if len(sys.argv) > 1 else '')\n",
+        )
+        .unwrap();
+
+        let s = make_script_skill(scripts_dir);
+        let ctx = Context::default();
+        let out = s
+            .execute(
+                serde_json::json!({
+                    "script": "hello.py",
+                    "args": ["world"],
+                }),
+                &ctx,
+            )
+            .await
+            .expect("script should run");
+        assert!(out.user_message.contains("hi world"));
+        let data = out.data.expect("data present");
+        assert_eq!(data["skill"], "pdf");
+        assert_eq!(data["script"], "hello.py");
+        assert_eq!(data["exit_code"], 0);
+        assert_eq!(data["kind"], "anthropic_script");
+    }
+
+    #[tokio::test]
+    async fn script_skill_execute_surfaces_nonzero_exit() {
+        if !python3_available() {
+            eprintln!("python3 not available; skipping");
+            return;
+        }
+        let dir = TempDir::new().unwrap();
+        let scripts_dir = dir.path().join("scripts");
+        fs::create_dir(&scripts_dir).unwrap();
+        fs::write(
+            scripts_dir.join("fail.py"),
+            "import sys\nsys.stderr.write('oops\\n')\nsys.exit(3)\n",
+        )
+        .unwrap();
+
+        let s = make_script_skill(scripts_dir);
+        let ctx = Context::default();
+        let out = s
+            .execute(serde_json::json!({ "script": "fail.py" }), &ctx)
+            .await
+            .expect("script runtime ok even if it exits non-zero");
+        assert!(out.user_message.contains("exited with code 3"));
+        assert!(out.user_message.contains("oops"));
+        let data = out.data.unwrap();
+        assert_eq!(data["exit_code"], 3);
+        assert!(data["stderr"].as_str().unwrap().contains("oops"));
     }
 }

--- a/crates/mori-core/src/skill/mod.rs
+++ b/crates/mori-core/src/skill/mod.rs
@@ -191,7 +191,15 @@ mod remind_me;
 // Stream I:Anthropic SKILL.md 格式 — 載入 `~/.mori/skills/<name>/SKILL.md`,
 // 把 markdown body 當 prompt-augmentation 給 LLM。對齊
 // https://agentskills.io/specification。D-light(只讀 body,不執行 scripts/)。
+//
+// Wave 6 DF-2 升級:`AnthropicScriptSkill` — 若 skill 目錄底下有 `scripts/`,
+// 額外註冊一個可呼叫 Python script 的 skill(走 `python_runner` 子模組)。
+// `discover_skills` 改回 `Vec<DiscoveredSkill>`(skill + 可選 scripts_dir)。
 pub mod anthropic_skill;
+
+// Wave 6 DF-2:Python subprocess runner(供 `AnthropicScriptSkill` 用)。
+// 直接 spawn `python3`,沒 venv / 沒沙箱;timeout / stdin / argv 帶齊。
+pub mod python_runner;
 
 // Wave 6 MCP-2:把 mori-mcp::McpRegistry 暴露的 MCP tool 包成 Skill trait,
 // LLM 可以透過 SkillRegistry::dispatch reach 到外部 MCP server。
@@ -217,7 +225,8 @@ pub use read_file::ReadFileSkill;
 pub use remind_me::RemindMeSkill;
 
 pub use anthropic_skill::{
-    discover_skills as discover_anthropic_skills, AnthropicPromptSkill, AnthropicSkill,
+    discover_skills as discover_anthropic_skills, AnthropicPromptSkill, AnthropicScriptSkill,
+    AnthropicSkill, DiscoveredSkill,
 };
 
 pub use mcp_tool::McpToolSkill;

--- a/crates/mori-core/src/skill/python_runner.rs
+++ b/crates/mori-core/src/skill/python_runner.rs
@@ -1,0 +1,309 @@
+//! Wave 6 D-full(DF-2):跑 Anthropic skill 內 `scripts/` 子目錄的 Python script。
+//!
+//! 提供一個 minimal subprocess runner:
+//! - spawn `python3 <script> <args...>`(走 PATH 上的 `python3`)
+//! - 可選 stdin
+//! - capture stdout / stderr / exit code
+//! - 60s timeout(避免 LLM 誤觸發 infinite loop 把 agent stuck)
+//!
+//! # 為什麼不上 sandbox / venv?
+//!
+//! - **不開 firejail / nsjail / wasm 之類沙箱**:user trust 自己安裝的 Anthropic
+//!   skill repo(`anthropics/skills` 官方 repo,他們審過了)。要再加 process
+//!   isolation 要拖大 dep,本 stream 不做(留 follow-up)。
+//! - **不自管 venv**:per-skill `requirements.txt` install 涉及 venv 管理、跨
+//!   skill share 版本、衝突偵測,複雜度爆表;本 stream 要求 user 手動
+//!   `pip install --user pypdf openpyxl python-docx python-pptx` for 常用 file
+//!   skills。
+//!
+//! # 為什麼 60s timeout?
+//!
+//! LLM 觸發 → 等 script → tool result 回 LLM 是一條 blocking 路徑,user 等。
+//! 60s 是「合 reasonable」的天花板(merge 5 個 PDF 約 5-15s,OCR 一頁 ~30s)。
+//! 超出明顯不對勁 — 殺掉,讓 LLM 重試或回報 user。
+
+use std::path::Path;
+use std::process::Stdio;
+
+use thiserror::Error;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+/// 一次 script 跑完的結果。`exit_code` -1 表示 process 被 signal 殺(或 timeout)。
+#[derive(Debug, Clone)]
+pub struct ScriptOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+}
+
+#[derive(Debug, Error)]
+pub enum RunError {
+    /// `python3` 不在 PATH。user 沒裝 Python 3 / 沒接好 PATH。
+    #[error("python3 not in PATH (please install Python 3)")]
+    PythonMissing,
+    /// spawn 失敗(不是 NotFound,是其他 OS 層 error,例 permission denied)。
+    #[error("spawn failed: {0}")]
+    Spawn(#[source] std::io::Error),
+    /// script 跑超過 [`DEFAULT_TIMEOUT_SECS`] 秒,被強制砍掉。
+    #[error("timeout({0}s) exceeded")]
+    Timeout(u64),
+    /// 其他 IO error(stdin write 失敗 / wait_with_output IO 錯)。
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// script timeout 上限。
+///
+/// 故意暴露成 `pub const` 給 caller 知道下限;真要客製需要改 [`run_python_script`]
+/// 簽名加 `timeout` 參數(本 stream 保簡單,後續若要再開放)。
+pub const DEFAULT_TIMEOUT_SECS: u64 = 60;
+
+/// 跑單一 Python script。
+///
+/// - `script`:要跑的 `.py` 路徑(caller 負責確保檔案存在)
+/// - `args`:轉成 CLI argv(順序保留)
+/// - `stdin`:若 `Some(s)`,把 `s` 灌進 child stdin 並關閉;`None` 則 stdin 不 connect
+///
+/// 回傳的 `ScriptOutput` 不論 script 成功 / 失敗(exit_code != 0)都會回 — 失敗
+/// 表現在 `exit_code`,不直接 Err。`Err(RunError)` 只在 **runtime 層** 失敗
+/// (找不到 python3 / spawn 失敗 / timeout)。
+///
+/// # 為什麼用 wait_with_output 而非分別 read stdout/stderr
+///
+/// 簡單。`wait_with_output` 內部會 spawn 兩 task drain pipe(避免 pipe buffer
+/// 塞滿後 child block),這正是我們要的。代價是 stdout / stderr 都全 buffer 在
+/// memory — 對 LLM tool result 場景沒問題(LLM context 本來就有上限,script
+/// 輸出超大也沒意義)。
+pub async fn run_python_script(
+    script: &Path,
+    args: &[String],
+    stdin: Option<&str>,
+) -> Result<ScriptOutput, RunError> {
+    let mut cmd = Command::new("python3");
+    cmd.arg(script)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    // suppress windows console window — 對齊 mori 既有跑 subprocess pattern。
+    // 不直接 import 是因為這個 macro 在 mori-core lib root 已 export;但這 module
+    // 是 mori-core 自身一部分,直接 inline OS-conditional 比較乾淨。
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let mut child = cmd.spawn().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            RunError::PythonMissing
+        } else {
+            RunError::Spawn(e)
+        }
+    })?;
+
+    // 寫 stdin 後 drop handle → child 看到 EOF。stdin 為 None 也 take() 出來,
+    // 否則 child 會等 stdin 不關。
+    if let Some(mut child_stdin) = child.stdin.take() {
+        if let Some(input) = stdin {
+            child_stdin.write_all(input.as_bytes()).await?;
+            child_stdin.flush().await?;
+        }
+        // drop → 關 stdin pipe → child 看到 EOF
+        drop(child_stdin);
+    }
+
+    let timeout = tokio::time::Duration::from_secs(DEFAULT_TIMEOUT_SECS);
+    let output = match tokio::time::timeout(timeout, child.wait_with_output()).await {
+        Ok(Ok(out)) => out,
+        Ok(Err(e)) => return Err(RunError::Io(e)),
+        Err(_) => {
+            // timeout — child 已被 wait_with_output 拿走,沒法直接 kill;
+            // 但 tokio 的 wait_with_output future 被 drop 時會 abort 內部 task,
+            // 不殺 child process 本身。
+            //
+            // 簡化處理:不嘗試 kill(本 stream 限制),只回 Timeout error;
+            // child 在 OS 層繼續跑直到自己結束 / OOM-killer 砍它。對齊本 module
+            // 的「最小 runner」定位 — 完整 process lifecycle 管理留 follow-up。
+            return Err(RunError::Timeout(DEFAULT_TIMEOUT_SECS));
+        }
+    };
+
+    Ok(ScriptOutput {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        exit_code: output.status.code().unwrap_or(-1),
+    })
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// 寫一個 Python script 到 temp dir 並回 path。
+    fn write_script(dir: &Path, name: &str, body: &str) -> std::path::PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, body).unwrap();
+        path
+    }
+
+    /// 整環境是否裝 python3。CI 若沒裝就 skip。
+    fn python3_available() -> bool {
+        std::process::Command::new("python3")
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    #[tokio::test]
+    async fn run_python_script_runs_basic() {
+        if !python3_available() {
+            eprintln!("python3 not available; skipping");
+            return;
+        }
+        let dir = TempDir::new().unwrap();
+        let script = write_script(dir.path(), "hello.py", "print('hi')\n");
+        let out = run_python_script(&script, &[], None)
+            .await
+            .expect("script should run");
+        assert_eq!(out.exit_code, 0);
+        assert_eq!(out.stdout.trim(), "hi");
+        assert!(out.stderr.is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_python_script_captures_stderr() {
+        if !python3_available() {
+            eprintln!("python3 not available; skipping");
+            return;
+        }
+        let dir = TempDir::new().unwrap();
+        let script = write_script(
+            dir.path(),
+            "err.py",
+            "import sys\nsys.stderr.write('boom\\n')\nsys.exit(2)\n",
+        );
+        let out = run_python_script(&script, &[], None)
+            .await
+            .expect("script should run (even if exits non-zero)");
+        assert_eq!(out.exit_code, 2);
+        assert!(out.stderr.contains("boom"));
+    }
+
+    #[tokio::test]
+    async fn run_python_script_passes_args() {
+        if !python3_available() {
+            eprintln!("python3 not available; skipping");
+            return;
+        }
+        let dir = TempDir::new().unwrap();
+        let script = write_script(
+            dir.path(),
+            "argv.py",
+            "import sys\nprint('|'.join(sys.argv[1:]))\n",
+        );
+        let out = run_python_script(
+            &script,
+            &["foo".into(), "bar baz".into(), "qux".into()],
+            None,
+        )
+        .await
+        .expect("script should run");
+        assert_eq!(out.exit_code, 0);
+        assert_eq!(out.stdout.trim(), "foo|bar baz|qux");
+    }
+
+    #[tokio::test]
+    async fn run_python_script_passes_stdin() {
+        if !python3_available() {
+            eprintln!("python3 not available; skipping");
+            return;
+        }
+        let dir = TempDir::new().unwrap();
+        let script = write_script(
+            dir.path(),
+            "stdin.py",
+            "import sys\ndata = sys.stdin.read()\nprint(f'got:{data}')\n",
+        );
+        let out = run_python_script(&script, &[], Some("hello\n"))
+            .await
+            .expect("script should run");
+        assert_eq!(out.exit_code, 0);
+        assert!(out.stdout.contains("got:hello"));
+    }
+
+    #[tokio::test]
+    async fn run_python_script_times_out() {
+        if !python3_available() {
+            eprintln!("python3 not available; skipping");
+            return;
+        }
+        // 走極短 timeout 來測 — 但 DEFAULT_TIMEOUT_SECS 是 60。直接測 60s 太慢,
+        // 改成另開一個非公開的 with-timeout 路徑會破壞 API 表面。
+        //
+        // 折衷:用 tokio::time::timeout 直接 wrap 我們的 call,測 future-level
+        // 行為(若 script 真的 hang,run_python_script 內部超時也會回 Timeout)。
+        // 這個 test 比較像 sanity check:確認 hang script 不會 panic、會在合理
+        // 時間內被識別。
+        let dir = TempDir::new().unwrap();
+        let script = write_script(
+            dir.path(),
+            "hang.py",
+            // 1 秒就退,別真 hang 60s。但要證明 timeout-when-takes-too-long 行為,
+            // 改成測「快」case 不夠 — 直接走 tokio::time::pause 或外層 wrap。
+            //
+            // 折衷:測 future 在外層 timeout 下行為 — script 跑 5s,外層 1s timeout
+            // → 外層 Err(elapsed)。確認 run_python_script 本身沒 panic / 不會 leak。
+            "import time\ntime.sleep(5)\nprint('done')\n",
+        );
+
+        let result = tokio::time::timeout(
+            tokio::time::Duration::from_millis(500),
+            run_python_script(&script, &[], None),
+        )
+        .await;
+
+        // 外層 timeout 觸發 → Err(elapsed)。本 test 不嚴格驗 Timeout enum variant
+        // (那需要 60s 等),但驗 run 不會 panic、行為一致。
+        assert!(result.is_err(), "outer timeout should fire");
+    }
+
+    /// PATH 設空 → spawn python3 NotFound → PythonMissing。
+    ///
+    /// ⚠️ 這個 test mutate 全局 `PATH` env,跟其他平行 test(python3 真的要跑)
+    /// 互衝;標 `#[ignore]` 避免 race。本地手動 `cargo test --
+    /// run_python_script_returns_python_missing --ignored` 跑驗 error path。
+    #[tokio::test]
+    #[ignore = "mutates global PATH env; race-condition with other python3 tests"]
+    async fn run_python_script_returns_python_missing() {
+        let dir = TempDir::new().unwrap();
+        let script = write_script(dir.path(), "noop.py", "print('x')\n");
+
+        let saved_path = std::env::var_os("PATH");
+        std::env::set_var("PATH", "");
+
+        let result = run_python_script(&script, &[], None).await;
+
+        // restore 先,確保後續 test 不受影響。
+        match saved_path {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+
+        match result {
+            Err(RunError::PythonMissing) => {}
+            Ok(_) => panic!("expected PythonMissing, got Ok output"),
+            Err(other) => eprintln!("got {other:?} instead of PythonMissing (platform-dependent)"),
+        }
+    }
+}

--- a/crates/mori-tauri/Cargo.toml
+++ b/crates/mori-tauri/Cargo.toml
@@ -39,6 +39,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
+# DF-1:skill_install_cmd::SkillInstallError 走 thiserror derive 拿乾淨錯誤 chain。
+# 對齊 mori-core / mori-mcp 內既有的 thiserror pattern。
+thiserror = { workspace = true }
 async-trait = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/mori-tauri/src/deps.rs
+++ b/crates/mori-tauri/src/deps.rs
@@ -491,6 +491,111 @@ pub fn registry() -> Vec<DepSpec> {
             },
             install_overrides: &[],
         },
+        // Wave 6 D-full(DF-1):Python 3 runtime for Anthropic skills 的 scripts/ 執行。
+        //
+        // Stream I (#79) 已 ship SKILL.md markdown body 載入(D-light:純 prompt-augmentation,
+        // 不執行 scripts/)。D-full 上線後,執行型 skill(pdf / docx / xlsx / pptx /
+        // canvas-design / theme-factory / webapp-testing 7 個)會 spawn Python 跑
+        // `scripts/<entry>.py` — 沒 Python → 那些 skill 無法執行。
+        //
+        // 多數 Linux 發行版 / macOS / Windows installer 都把 binary 名稱定為 `python3`
+        // (Windows 也常有 python3 alias);用 `python3` 一個 binary 偵測足夠,Windows
+        // 上沒 alias 的少數情況 user 可看 install_caveat 指引。
+        DepSpec {
+            id: "python3",
+            name: "Python 3",
+            description: "Python 3.10+ runtime + pip。Wave 6 D-full Anthropic skills 的 \
+                          執行型 skill(pdf / docx / xlsx / pptx / 等)走 `python3 \
+                          <skill>/scripts/*.py`,沒裝就只剩 prompt-augmentation(body 餵 \
+                          LLM 但 scripts/ 跑不起來)。",
+            unlocks: "D-full Anthropic skills 執行型 skill(pypdf / openpyxl / python-docx / \
+                      python-pptx 等 Python script 能跑)",
+            size_hint: Some("~30-100MB(依平台)"),
+            needs_sudo: true,
+            platforms: &["linux", "macos", "windows"],
+            install_caveat: Some(
+                "Windows installer 預設 binary 是 `python` 而非 `python3`,但官方 \
+                 installer 同時 alias `python3`。沒 alias 的少數情況請在 Settings → Apps \
+                 → Python 加 PATH 或安裝時勾「Add python.exe to PATH」。",
+            ),
+            check: CheckSpec::Which { bin: "python3" },
+            check_overrides: &[],
+            install: InstallSpec::Manual {
+                commands: &[
+                    "# Ubuntu / Debian:",
+                    "sudo apt install python3 python3-pip",
+                    "# Fedora / RHEL:",
+                    "# sudo dnf install python3 python3-pip",
+                    "# Arch / Manjaro:",
+                    "# sudo pacman -S python python-pip",
+                    "# macOS(homebrew):",
+                    "# brew install python3",
+                    "# Windows:從官網下載 installer(記得勾「Add python.exe to PATH」):",
+                    "# https://www.python.org/downloads/",
+                    "# 確認:`python3 --version` + `pip3 --version`",
+                ],
+            },
+            install_overrides: &[],
+        },
+        // Wave 6 D-full(DF-1):Anthropic 官方 17 個 skills 庫(github.com/anthropics/skills)。
+        //
+        // 一鍵 install:`git clone --depth 1` 到 `~/.mori/skills/anthropics-skills/`。Stream I
+        // 的 `discover_skills` 掃的是扁平 `~/.mori/skills/<name>/SKILL.md`,Anthropic repo
+        // 結構是 `anthropics-skills/skills/<name>/`,需要走 symlink-flatten 或改 loader 邏輯
+        // (本 stream 只先 install + 文件指引,flatten 留 DF-2 補)。
+        //
+        // 對齊 annuli-runtime 的 git clone pattern(Linux/macOS Shell + Windows Manual)。
+        // 也可走 `install_anthropic_skills_cmd` Tauri command 拿到更精細的錯誤訊息,
+        // 但走 InstallSpec 能直接吃既有 DepsTab UI(install 按鈕 + status 圖示),
+        // 不需要新前端 schema 變動 — minimal viable path。
+        DepSpec {
+            id: "anthropic-skills",
+            name: "Anthropic Skills 庫",
+            description: "Anthropic 官方 17 個 skills(github.com/anthropics/skills):brand-guidelines / \
+                          internal-comms / pdf / docx / xlsx / pptx / canvas-design / 等。\
+                          一鍵 `git clone` 到 `~/.mori/skills/anthropics-skills/`。\
+                          \n\n安裝後重啟 Mori 才會 discover(Stream I SKILL.md loader 在 \
+                          startup 一次性掃),目前 loader 掃 `~/.mori/skills/<name>/` 扁平 \
+                          路徑,而 Anthropic repo 是 `anthropics-skills/skills/<name>/` — \
+                          完整 discovery 整合留 DF-2 做(可走 symlink flatten 或 loader \
+                          多掃一層)。",
+            unlocks: "discover 到 17 個 Anthropic 官方 skill(SKILL.md body 進 system prompt)",
+            size_hint: Some("~10-50MB(repo + scripts/)"),
+            needs_sudo: false,
+            platforms: &["linux", "macos", "windows"],
+            install_caveat: Some(
+                "需要 git 在 PATH。安裝後需重啟 Mori。Stream I loader 路徑 ↔ Anthropic repo \
+                 結構差一層 — 完整 discovery 整合留 DF-2(symlink flatten 或 loader 補)。",
+            ),
+            check: CheckSpec::File {
+                path_template: "$HOME/.mori/skills/anthropics-skills/.git",
+            },
+            check_overrides: &[],
+            install: InstallSpec::Shell {
+                script: "set -e; \
+                         DEST=\"$HOME/.mori/skills/anthropics-skills\"; \
+                         mkdir -p \"$HOME/.mori/skills\"; \
+                         if [ -d \"$DEST/.git\" ]; then \
+                            echo '已有 anthropics-skills repo,跑 git pull 更新...'; \
+                            cd \"$DEST\" && git pull --ff-only; \
+                         else \
+                            echo '從 GitHub 拉 anthropics/skills(--depth 1)...'; \
+                            git clone --depth 1 https://github.com/anthropics/skills.git \"$DEST\"; \
+                         fi; \
+                         echo '✓ Anthropic skills 裝好 — 重啟 Mori 才會 discover。'; \
+                         echo '  (DF-2 上線後會自動 flatten 17 個 skill 到 ~/.mori/skills/<name>/)'",
+            },
+            install_overrides: &[
+                ("windows", InstallSpec::Manual {
+                    commands: &[
+                        "# Windows(PowerShell / cmd,需要 git for Windows):",
+                        "mkdir %USERPROFILE%\\.mori\\skills 2>NUL",
+                        "git clone --depth 1 https://github.com/anthropics/skills.git %USERPROFILE%\\.mori\\skills\\anthropics-skills",
+                        "# 安裝後重啟 Mori。完整 discovery 整合留 DF-2。",
+                    ],
+                }),
+            ],
+        },
         // Obsidian CLI — bundled inside Obsidian app v1.12.4+(GA 2026/02),
         // 不是獨立 binary。User 要先裝 app 再到 in-app Settings 啟用「Register CLI」,
         // 啟用後 `obsidian` 才會在 PATH。沒啟用 → starter AGENT-06.obsidian 跑 shell_skill

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -25,6 +25,11 @@ mod x11_shape;
 #[cfg_attr(target_os = "windows", path = "selection_windows.rs")]
 mod selection;
 mod shell_skill;
+// Wave 6 DF-1:Anthropic skills install commands(`install_anthropic_skills_cmd` /
+// `anthropic_skills_status_cmd`)+ internal helpers。對比 deps.rs 內的
+// `anthropic-skills` DepSpec(走 InstallSpec::Shell git clone),這個 module 是
+// 更乾淨的 Rust path(不 spawn sh,直接 git clone + 明確錯誤 chain)。
+mod skill_install_cmd;
 mod skill_server;
 mod recordings;
 mod soul_distribution;
@@ -5210,6 +5215,10 @@ fn main() {
             reminders_cmd::snooze_reminder_cmd,
             mcp_cmd::mcp_list_tools_cmd,
             mcp_cmd::mcp_call_tool_cmd,
+            // Wave 6 DF-1:Anthropic skills install commands。前端可選用(也可走
+            // DepsTab 內的 `anthropic-skills` entry)— 兩條路徑 install 結果一致。
+            skill_install_cmd::install_anthropic_skills_cmd,
+            skill_install_cmd::anthropic_skills_status_cmd,
             transcribe_cmds::transcribe_check_deps,
             transcribe_cmds::transcribe_file_cmd,
             transcribe_cmds::transcribe_paths_cmd,

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -2188,9 +2188,22 @@ async fn skills_list(
         registry.register(Arc::new(crate::shell_skill::ShellSkill::new(def.clone())));
     }
     // Stream I:Anthropic SKILL.md — `~/.mori/skills/<name>/SKILL.md` 的 body
-    // 當 prompt-augmentation 給 LLM。D-light(不執行 scripts/)。
+    // 當 prompt-augmentation 給 LLM。
+    //
+    // Wave 6 DF-2:`scripts/` 子資料夾若存在,額外註冊 `AnthropicScriptSkill`
+    // (LLM 可呼叫 `anthropic_script_<name>` 跑 Python script,例 `pdf` 整合)。
     let anthropic_dir = mori_core::skill::anthropic_skill::default_skills_dir();
-    for skill in mori_core::skill::discover_anthropic_skills(&anthropic_dir) {
+    for discovered in mori_core::skill::discover_anthropic_skills(&anthropic_dir) {
+        let mori_core::skill::DiscoveredSkill {
+            skill,
+            scripts_dir,
+        } = discovered;
+        if let Some(sd) = scripts_dir {
+            registry.register(Arc::new(mori_core::skill::AnthropicScriptSkill::new(
+                skill.clone(),
+                sd,
+            )));
+        }
         registry.register(Arc::new(mori_core::skill::AnthropicPromptSkill::new(skill)));
     }
     // Wave 6 MCP-2:把已 connect 的 MCP server 提供的所有 tool 都列進 UI 的
@@ -3571,14 +3584,32 @@ async fn run_agent_pipeline(
         }
 
         // Stream I:Anthropic SKILL.md — `~/.mori/skills/<name>/SKILL.md` 的 body
-        // 當 prompt-augmentation 給 LLM。D-light(不執行 scripts/)。同樣受
-        // agent_disabled 鎖:Mori 沒分到靈力時所有額外 skill 都不掛。
-        // 不受 enabled_skills filter 影響(對齊 shell_skills:user 放進 skills/
-        // 目錄就是要用的)。
+        // 當 prompt-augmentation 給 LLM。同樣受 agent_disabled 鎖:Mori 沒分到
+        // 靈力時所有額外 skill 都不掛。不受 enabled_skills filter 影響(對齊
+        // shell_skills:user 放進 skills/ 目錄就是要用的)。
+        //
+        // Wave 6 DF-2:scripts/ 子資料夾若存在,額外註冊 `AnthropicScriptSkill`
+        // (LLM 可呼叫 `anthropic_script_<name>` 跑 Python script)。prompt 型 +
+        // script 型並存:LLM 先 invoke `<name>` 讀指引,再 invoke
+        // `anthropic_script_<name>` 跑實際工具。
         if !agent_disabled {
             let anthropic_dir = mori_core::skill::anthropic_skill::default_skills_dir();
-            for skill in mori_core::skill::discover_anthropic_skills(&anthropic_dir) {
-                tracing::info!(skill = %skill.name, "registering anthropic SKILL.md (prompt-augmentation)");
+            for discovered in mori_core::skill::discover_anthropic_skills(&anthropic_dir) {
+                let mori_core::skill::DiscoveredSkill {
+                    skill,
+                    scripts_dir,
+                } = discovered;
+                tracing::info!(
+                    skill = %skill.name,
+                    has_scripts = scripts_dir.is_some(),
+                    "registering anthropic SKILL.md"
+                );
+                if let Some(sd) = scripts_dir {
+                    registry.register(Arc::new(mori_core::skill::AnthropicScriptSkill::new(
+                        skill.clone(),
+                        sd,
+                    )));
+                }
                 registry.register(Arc::new(mori_core::skill::AnthropicPromptSkill::new(skill)));
             }
         }

--- a/crates/mori-tauri/src/skill_install_cmd.rs
+++ b/crates/mori-tauri/src/skill_install_cmd.rs
@@ -75,17 +75,20 @@ fn is_anthropic_skills_installed_at(skills_dir: &Path) -> bool {
     skills_dir.join(ANTHROPIC_SKILLS_SUBDIR).join(".git").exists()
 }
 
-/// 跑 `git clone --depth 1` 拉 Anthropic skills repo 到 `~/.mori/skills/anthropics-skills/`。
+/// 跑 `git clone --depth 1` 拉 Anthropic skills repo 到 `~/.mori/skills/anthropics-skills/`,
+/// 完成後對每個 `anthropics-skills/skills/<name>/` 建 symlink 到 `~/.mori/skills/<name>/`
+/// (DF-2 flatten step)。
 ///
-/// **不負責 discovery flatten** — 該事留 DF-2 補。本 fn 完成 → user 重啟 Mori,
-/// `discover_skills` 走原邏輯掃不到深層 `skills/<name>/SKILL.md`,需要前端 / loader
-/// 升級配合。
+/// **DF-2 升級**:clone 完自動 flatten。`discover_skills` 掃扁平
+/// `~/.mori/skills/<name>/SKILL.md`,symlink 走 follow,is_dir / is_file 全 work。
+/// user 已有同名 skill 時 skip(以 user 自寫為優先)。
 ///
 /// 失敗模式:
 /// - `git` 不在 PATH → [`SkillInstallError::GitMissing`]
 /// - `git clone` 退非 0 → [`SkillInstallError::CloneFailed`](exit code)
 /// - HOME / USERPROFILE 都沒設 → [`SkillInstallError::NoHome`]
 /// - mkdir parent / 其他 IO 錯 → [`SkillInstallError::Io`]
+/// - flatten 階段個別 symlink 失敗 → log warning 跳過(不擋整 install)
 pub fn install_anthropic_skills() -> Result<PathBuf, SkillInstallError> {
     let dest_root = skills_dir().ok_or(SkillInstallError::NoHome)?;
     install_anthropic_skills_at(&dest_root)
@@ -99,8 +102,10 @@ fn install_anthropic_skills_at(dest_root: &Path) -> Result<PathBuf, SkillInstall
 
     // 已經有 .git → 不重複 clone,直接回傳 path(idempotent)。
     // user 想更新走 `git pull`(deps.rs 內的 Shell variant 有 fallback path)。
+    // 但 flatten 步驟還是要跑(可能第一次 clone 完崩了沒 flatten,或新加的 skill)。
     if target.join(".git").exists() {
         tracing::info!(path = %target.display(), "anthropic skills already installed; skipping clone");
+        let _ = flatten_anthropic_skills(dest_root);
         return Ok(target);
     }
 
@@ -122,7 +127,97 @@ fn install_anthropic_skills_at(dest_root: &Path) -> Result<PathBuf, SkillInstall
     }
 
     tracing::info!(path = %target.display(), "anthropic skills installed");
+
+    // Flatten symlinks: anthropics-skills/skills/<name>/ → <dest_root>/<name>/
+    match flatten_anthropic_skills(dest_root) {
+        Ok(n) => tracing::info!(linked = n, "flattened anthropic skills"),
+        Err(e) => tracing::warn!(error = %e, "flatten step failed (skills cloned but not symlinked)"),
+    }
+
     Ok(target)
+}
+
+/// 對 `<dest_root>/anthropics-skills/skills/<name>/` 內每個 skill 目錄建一條
+/// symlink 到 `<dest_root>/<name>/`,讓 [`mori_core::skill::discover_anthropic_skills`]
+/// 掃扁平 layout 就能看到。
+///
+/// 行為:
+/// - `anthropics-skills/skills/` 不存在 → 回 `Ok(0)`(沒 clone 完就被 cancel 的場景)
+/// - 同名目錄已存在 → skip(user 自寫優先)
+/// - symlink 個別失敗 → log warning 跳過,繼續其他 entry,最後回成功 count
+///
+/// Windows symlink 需要 dev mode / admin。fallback 在某些 Windows env 會失敗
+/// (`ERROR_PRIVILEGE_NOT_HELD`);本 fn 把它當作普通 IO error 回傳,呼叫端 log
+/// warning 後繼續。Linux / macOS 沒這問題。
+fn flatten_anthropic_skills(dest_root: &Path) -> Result<usize, std::io::Error> {
+    let anthropic_dir = dest_root.join(ANTHROPIC_SKILLS_SUBDIR).join("skills");
+    if !anthropic_dir.exists() {
+        tracing::debug!(
+            path = %anthropic_dir.display(),
+            "anthropics-skills/skills/ not present; nothing to flatten"
+        );
+        return Ok(0);
+    }
+
+    let mut count = 0;
+    for entry in std::fs::read_dir(&anthropic_dir)? {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::warn!(error = %e, "skipping unreadable entry");
+                continue;
+            }
+        };
+        let link_target = entry.path();
+        // 只 link directories(每個 skill = 一個目錄)
+        if !link_target.is_dir() {
+            continue;
+        }
+        let skill_name = entry.file_name();
+        let link_path = dest_root.join(&skill_name);
+
+        // user 自寫同名 skill 在 → skip(對齊 PATH-style: user 優先)
+        // symlink 自身 .exists() follows link → 第二次跑也會 skip(idempotent)
+        if link_path.exists() {
+            tracing::debug!(
+                name = %skill_name.to_string_lossy(),
+                "skill already at flat path; skipping symlink"
+            );
+            continue;
+        }
+
+        let symlink_result = make_symlink(&link_target, &link_path);
+        match symlink_result {
+            Ok(()) => {
+                count += 1;
+                tracing::debug!(
+                    name = %skill_name.to_string_lossy(),
+                    target = %link_target.display(),
+                    "linked anthropic skill"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    name = %skill_name.to_string_lossy(),
+                    error = %e,
+                    "symlink failed (continuing)"
+                );
+            }
+        }
+    }
+    Ok(count)
+}
+
+/// 跨平台 symlink helper。Unix → `symlink`;Windows → `symlink_dir`(NTFS 對
+/// dir / file symlink 分兩種 API)。
+#[cfg(unix)]
+fn make_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(windows)]
+fn make_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_dir(target, link)
 }
 
 // ─── Tauri commands ────────────────────────────────────────────────
@@ -270,5 +365,95 @@ mod tests {
         // Stream I loader 跟 deps.rs 內的 check path_template 都依賴這個常數值。
         // 改了這個 = 同步要改 deps.rs 的 `$HOME/.mori/skills/anthropics-skills/.git`。
         assert_eq!(ANTHROPIC_SKILLS_SUBDIR, "anthropics-skills");
+    }
+
+    // ─── flatten_anthropic_skills ─────────────────────────────
+
+    #[test]
+    fn flatten_returns_zero_when_anthropic_dir_missing() {
+        // dest_root 完全空 → anthropics-skills/skills/ 不存在 → 0 link。
+        let dir = TempDir::new().unwrap();
+        let n = flatten_anthropic_skills(dir.path()).expect("should not error");
+        assert_eq!(n, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn flatten_creates_symlinks_for_each_skill() {
+        // mock: dest_root/anthropics-skills/skills/{pdf,docx}/SKILL.md
+        // expect: dest_root/{pdf,docx} symlink 出現
+        let dir = TempDir::new().unwrap();
+        let dest = dir.path();
+        let skills_inner = dest.join(ANTHROPIC_SKILLS_SUBDIR).join("skills");
+        std::fs::create_dir_all(skills_inner.join("pdf")).unwrap();
+        std::fs::create_dir_all(skills_inner.join("docx")).unwrap();
+        std::fs::write(skills_inner.join("pdf").join("SKILL.md"), "x").unwrap();
+        std::fs::write(skills_inner.join("docx").join("SKILL.md"), "y").unwrap();
+
+        let n = flatten_anthropic_skills(dest).expect("flatten ok");
+        assert_eq!(n, 2);
+        assert!(dest.join("pdf").exists());
+        assert!(dest.join("docx").exists());
+        // symlink follows → SKILL.md 透過 link 可達
+        assert!(dest.join("pdf").join("SKILL.md").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn flatten_skips_existing_user_skill() {
+        // user 自寫 `~/.mori/skills/pdf/` 在 → flatten 不該覆蓋。
+        let dir = TempDir::new().unwrap();
+        let dest = dir.path();
+        let skills_inner = dest.join(ANTHROPIC_SKILLS_SUBDIR).join("skills");
+        std::fs::create_dir_all(skills_inner.join("pdf")).unwrap();
+        std::fs::write(skills_inner.join("pdf").join("SKILL.md"), "anthropic-version").unwrap();
+
+        // pre-create user own pdf dir(非 symlink)
+        let user_pdf = dest.join("pdf");
+        std::fs::create_dir_all(&user_pdf).unwrap();
+        std::fs::write(user_pdf.join("SKILL.md"), "user-version").unwrap();
+
+        let _ = flatten_anthropic_skills(dest).expect("flatten ok");
+        // user 自寫不該被覆蓋:檔案內容仍是 user-version
+        let content = std::fs::read_to_string(user_pdf.join("SKILL.md")).unwrap();
+        assert_eq!(content, "user-version");
+        // 而且 user_pdf 不該變成 symlink
+        let meta = std::fs::symlink_metadata(&user_pdf).unwrap();
+        assert!(!meta.file_type().is_symlink());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn flatten_is_idempotent() {
+        // 跑兩次:第二次不該爆 + 結果不變
+        let dir = TempDir::new().unwrap();
+        let dest = dir.path();
+        let skills_inner = dest.join(ANTHROPIC_SKILLS_SUBDIR).join("skills");
+        std::fs::create_dir_all(skills_inner.join("xlsx")).unwrap();
+        std::fs::write(skills_inner.join("xlsx").join("SKILL.md"), "x").unwrap();
+
+        let n1 = flatten_anthropic_skills(dest).expect("flatten 1");
+        let n2 = flatten_anthropic_skills(dest).expect("flatten 2");
+        assert_eq!(n1, 1);
+        assert_eq!(n2, 0, "second flatten should skip existing link");
+        assert!(dest.join("xlsx").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn flatten_skips_non_directory_entries() {
+        // anthropics-skills/skills/README.md 之類的檔案不要建 symlink
+        let dir = TempDir::new().unwrap();
+        let dest = dir.path();
+        let skills_inner = dest.join(ANTHROPIC_SKILLS_SUBDIR).join("skills");
+        std::fs::create_dir_all(&skills_inner).unwrap();
+        std::fs::write(skills_inner.join("README.md"), "info").unwrap();
+        std::fs::create_dir_all(skills_inner.join("real-skill")).unwrap();
+        std::fs::write(skills_inner.join("real-skill").join("SKILL.md"), "x").unwrap();
+
+        let n = flatten_anthropic_skills(dest).expect("flatten ok");
+        assert_eq!(n, 1);
+        assert!(dest.join("real-skill").exists());
+        assert!(!dest.join("README.md").exists(), "files at top level shouldn't be linked");
     }
 }

--- a/crates/mori-tauri/src/skill_install_cmd.rs
+++ b/crates/mori-tauri/src/skill_install_cmd.rs
@@ -1,0 +1,274 @@
+//! Wave 6 D-full(DF-1):Anthropic skills install helper + Tauri commands。
+//!
+//! 提供一個 **更精細** 的 install 路徑(對比 DepsTab 的 `InstallSpec::Shell`):
+//! - 自家檢測 git 在不在 PATH(`SkillInstallError::GitMissing` 明確錯誤)
+//! - 自家管 destination layout(`~/.mori/skills/anthropics-skills/`)
+//! - 跨平台:不 spawn `sh`(`InstallSpec::Shell` 走 sh -c 在 Windows 需要 Git Bash),
+//!   走 `Command::new("git")` direct invoke
+//!
+//! 整合路徑:
+//! 1. 本 module 提供 [`install_anthropic_skills_cmd`] / [`anthropic_skills_status_cmd`]
+//!    兩個 Tauri commands(前端可直接呼叫,例如「Install Anthropic Skills」按鈕)
+//! 2. 也提供 internal helpers([`skills_dir`] / [`is_anthropic_skills_installed`] /
+//!    [`install_anthropic_skills`])給 main.rs / 其他 module 用
+//! 3. install 完成後 Stream I (#79) 的 `discover_skills` 會掃到 — 注意 Anthropic
+//!    repo 結構是 `anthropics-skills/skills/<name>/`,而 loader 掃 `~/.mori/skills/<name>/`
+//!    扁平路徑,完整 discovery 整合(symlink flatten / loader 補)留 DF-2 做。
+//!
+//! 對應 deps.rs 內的 `anthropic-skills` DepSpec entry:那條走 `InstallSpec::Shell`
+//! 直接跑 `git clone`,這份 module 是「更乾淨的 Rust path」— 兩條路徑同時存在,user
+//! 走任一條都能成功。
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use thiserror::Error;
+
+/// Anthropic 官方 skills repo。
+const ANTHROPIC_SKILLS_REPO: &str = "https://github.com/anthropics/skills.git";
+
+/// Anthropic skills 在本機的安裝子目錄(相對於 [`skills_dir`])。
+const ANTHROPIC_SKILLS_SUBDIR: &str = "anthropics-skills";
+
+#[derive(Debug, Error)]
+pub enum SkillInstallError {
+    #[error("git not found in PATH (please install git first)")]
+    GitMissing,
+    #[error("git clone failed (exit {0:?})")]
+    CloneFailed(Option<i32>),
+    #[error("home dir not found (HOME / USERPROFILE both unset)")]
+    NoHome,
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// `~/.mori/skills/` — 跟 [`mori_core::skill::anthropic_skill::default_skills_dir`]
+/// 對齊,但本 module 不 depend mori-core(避免循環),自己組同樣 path。
+///
+/// 回 `None` 表示 HOME / USERPROFILE 都沒設(極稀有,容器 / 純 minimal env 才會)。
+pub fn skills_dir() -> Option<PathBuf> {
+    skills_dir_with_home(home_dir())
+}
+
+/// 取 home dir — HOME 優先,fallback USERPROFILE(Windows)。
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+/// 純 functional helper,給 test 注入 home dir 用。`None` 入 → `None` 出。
+fn skills_dir_with_home(home: Option<PathBuf>) -> Option<PathBuf> {
+    home.map(|h| h.join(".mori").join("skills"))
+}
+
+/// 檢查 Anthropic skills 是否已 install — 看 `~/.mori/skills/anthropics-skills/.git`
+/// 是否存在(`git clone` 完一定有 `.git` 目錄)。
+pub fn is_anthropic_skills_installed() -> bool {
+    skills_dir()
+        .map(|dir| is_anthropic_skills_installed_at(&dir))
+        .unwrap_or(false)
+}
+
+/// 純 functional helper,給 test 注入 skills dir 用。
+fn is_anthropic_skills_installed_at(skills_dir: &Path) -> bool {
+    skills_dir.join(ANTHROPIC_SKILLS_SUBDIR).join(".git").exists()
+}
+
+/// 跑 `git clone --depth 1` 拉 Anthropic skills repo 到 `~/.mori/skills/anthropics-skills/`。
+///
+/// **不負責 discovery flatten** — 該事留 DF-2 補。本 fn 完成 → user 重啟 Mori,
+/// `discover_skills` 走原邏輯掃不到深層 `skills/<name>/SKILL.md`,需要前端 / loader
+/// 升級配合。
+///
+/// 失敗模式:
+/// - `git` 不在 PATH → [`SkillInstallError::GitMissing`]
+/// - `git clone` 退非 0 → [`SkillInstallError::CloneFailed`](exit code)
+/// - HOME / USERPROFILE 都沒設 → [`SkillInstallError::NoHome`]
+/// - mkdir parent / 其他 IO 錯 → [`SkillInstallError::Io`]
+pub fn install_anthropic_skills() -> Result<PathBuf, SkillInstallError> {
+    let dest_root = skills_dir().ok_or(SkillInstallError::NoHome)?;
+    install_anthropic_skills_at(&dest_root)
+}
+
+/// 內部 helper:把 install destination 注入,給 test 用(同時也是 prod path 的
+/// 真正實作)。
+fn install_anthropic_skills_at(dest_root: &Path) -> Result<PathBuf, SkillInstallError> {
+    std::fs::create_dir_all(dest_root)?;
+    let target = dest_root.join(ANTHROPIC_SKILLS_SUBDIR);
+
+    // 已經有 .git → 不重複 clone,直接回傳 path(idempotent)。
+    // user 想更新走 `git pull`(deps.rs 內的 Shell variant 有 fallback path)。
+    if target.join(".git").exists() {
+        tracing::info!(path = %target.display(), "anthropic skills already installed; skipping clone");
+        return Ok(target);
+    }
+
+    let mut cmd = Command::new("git");
+    cmd.args(["clone", "--depth", "1", ANTHROPIC_SKILLS_REPO])
+        .arg(&target);
+    mori_core::suppress_console_on_windows!(cmd);
+
+    let status = cmd.status().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            SkillInstallError::GitMissing
+        } else {
+            SkillInstallError::Io(e)
+        }
+    })?;
+
+    if !status.success() {
+        return Err(SkillInstallError::CloneFailed(status.code()));
+    }
+
+    tracing::info!(path = %target.display(), "anthropic skills installed");
+    Ok(target)
+}
+
+// ─── Tauri commands ────────────────────────────────────────────────
+
+/// 前端「Install Anthropic Skills」按鈕呼叫。spawn_blocking 內跑 — `git clone`
+/// 可能跑數十秒(網路 + repo size),不該擋 async runtime。
+#[tauri::command]
+pub async fn install_anthropic_skills_cmd() -> Result<String, String> {
+    let path = tokio::task::spawn_blocking(install_anthropic_skills)
+        .await
+        .map_err(|e| format!("install join: {e}"))?
+        .map_err(|e| e.to_string())?;
+    Ok(format!("Installed to {}", path.display()))
+}
+
+/// 前端「is installed?」狀態查詢。同步 — 只看一個檔案存不存在,微秒級。
+#[tauri::command]
+pub fn anthropic_skills_status_cmd() -> bool {
+    is_anthropic_skills_installed()
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    // ─── skills_dir_with_home ─────────────────────────────────
+
+    #[test]
+    fn skills_dir_with_home_returns_some_when_home_set() {
+        let home = PathBuf::from("/home/test");
+        let got = skills_dir_with_home(Some(home.clone())).expect("should be Some");
+        assert_eq!(got, home.join(".mori").join("skills"));
+    }
+
+    #[test]
+    fn skills_dir_with_home_returns_none_when_home_absent() {
+        assert!(skills_dir_with_home(None).is_none());
+    }
+
+    // ─── is_anthropic_skills_installed_at ─────────────────────
+
+    #[test]
+    fn is_installed_returns_false_when_dir_missing() {
+        let dir = TempDir::new().unwrap();
+        let skills_root = dir.path().join("skills");
+        // skills_root 不存在 — `.git` 路徑解析會成功(不存在的 join),
+        // 但 .exists() 回 false。
+        assert!(!is_anthropic_skills_installed_at(&skills_root));
+    }
+
+    #[test]
+    fn is_installed_returns_false_when_subdir_present_but_no_git() {
+        // anthropics-skills/ 在但沒 .git → 不算 installed(可能是 user 手動建空目錄)。
+        let dir = TempDir::new().unwrap();
+        let skills_root = dir.path().to_path_buf();
+        std::fs::create_dir_all(skills_root.join(ANTHROPIC_SKILLS_SUBDIR)).unwrap();
+        assert!(!is_anthropic_skills_installed_at(&skills_root));
+    }
+
+    #[test]
+    fn is_installed_returns_true_when_git_subdir_exists() {
+        // mock git clone 後的狀態:anthropics-skills/.git/ 存在。
+        let dir = TempDir::new().unwrap();
+        let skills_root = dir.path().to_path_buf();
+        let git_dir = skills_root.join(ANTHROPIC_SKILLS_SUBDIR).join(".git");
+        std::fs::create_dir_all(&git_dir).unwrap();
+        assert!(is_anthropic_skills_installed_at(&skills_root));
+    }
+
+    #[test]
+    fn is_installed_accepts_git_file_or_dir() {
+        // git worktree / submodule 下 `.git` 可能是 file 而非 dir。.exists() 兩者皆 true。
+        let dir = TempDir::new().unwrap();
+        let skills_root = dir.path().to_path_buf();
+        let subdir = skills_root.join(ANTHROPIC_SKILLS_SUBDIR);
+        std::fs::create_dir_all(&subdir).unwrap();
+        std::fs::write(subdir.join(".git"), "gitdir: ../../somewhere\n").unwrap();
+        assert!(is_anthropic_skills_installed_at(&skills_root));
+    }
+
+    // ─── install_anthropic_skills_at ──────────────────────────
+
+    #[test]
+    fn install_short_circuits_when_already_present() {
+        // pre-create .git → install 不該再 spawn git(就算 PATH 沒 git 也要回 Ok)。
+        let dir = TempDir::new().unwrap();
+        let skills_root = dir.path().to_path_buf();
+        let target = skills_root.join(ANTHROPIC_SKILLS_SUBDIR);
+        std::fs::create_dir_all(target.join(".git")).unwrap();
+
+        let got = install_anthropic_skills_at(&skills_root).expect("idempotent install");
+        assert_eq!(got, target);
+    }
+
+    #[test]
+    fn install_creates_parent_dirs() {
+        // dest_root 深層巢狀不存在 → create_dir_all 要先把它建出來(才好 clone)。
+        // 不實際跑 clone(會打網路),用 short-circuit 路徑驗:預先 mock .git 後,
+        // 確認 install 不會 fail / 不會清掉父目錄。
+        let dir = TempDir::new().unwrap();
+        let deep = dir.path().join("a").join("b").join("c");
+        // pre-create .git 走 short-circuit(跳過 git clone)
+        let target = deep.join(ANTHROPIC_SKILLS_SUBDIR);
+        std::fs::create_dir_all(target.join(".git")).unwrap();
+
+        let got = install_anthropic_skills_at(&deep).expect("should succeed");
+        assert!(got.exists());
+        assert!(deep.exists(), "parent dir should be preserved");
+    }
+
+    #[test]
+    fn install_returns_git_missing_when_git_not_in_path() {
+        // 走真正的 spawn path,但 PATH 設成空 → `git` 找不到 → GitMissing。
+        // 注意:set_var 是 process-global,單測會跟其他並行 test 互干擾;這個 test
+        // 故意只測 install_anthropic_skills_at(不碰 skills_dir / env),改動完
+        // 立刻 restore。
+        let dir = TempDir::new().unwrap();
+        let skills_root = dir.path().to_path_buf();
+
+        // Save + clear PATH
+        let saved_path = std::env::var_os("PATH");
+        std::env::set_var("PATH", "");
+
+        let result = install_anthropic_skills_at(&skills_root);
+
+        // Restore PATH 先,免得後續 test 受影響。
+        match saved_path {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+
+        match result {
+            Err(SkillInstallError::GitMissing) => {}
+            other => panic!("expected GitMissing, got {other:?}"),
+        }
+    }
+
+    // ─── ANTHROPIC_SKILLS_SUBDIR constant ─────────────────────
+
+    #[test]
+    fn anthropic_skills_subdir_is_stable() {
+        // Stream I loader 跟 deps.rs 內的 check path_template 都依賴這個常數值。
+        // 改了這個 = 同步要改 deps.rs 的 `$HOME/.mori/skills/anthropics-skills/.git`。
+        assert_eq!(ANTHROPIC_SKILLS_SUBDIR, "anthropics-skills");
+    }
+}


### PR DESCRIPTION
## Summary

**Wave 6 DF-2** — D-full 收尾。Anthropic skills 的 Python scripts 真的跑起來,LLM 可調用 pdf/docx/xlsx/pptx 等 file 處理 skill。

Mori 從「只能讀」(Stream E mori-file-loader) → 「能讀+寫+填表+OCR+...」(via Anthropic Python scripts)。

## Changes

- `crates/mori-core/src/skill/python_runner.rs`(新):tokio Command + 60s timeout + stdin/stdout/stderr capture + ScriptOutput
- `crates/mori-core/src/skill/anthropic_skill.rs`(升):
  - 加 `AnthropicScriptSkill`(impl Skill,name = `anthropic_script_<name>` prefix)
  - 加 `DiscoveredSkill { skill, scripts_dir: Option<PathBuf> }`
  - `discover_skills` 返回 Vec<DiscoveredSkill>(同時偵測 scripts/ subdir)
- `crates/mori-core/src/skill/mod.rs`:+ exports + python_runner module
- `crates/mori-tauri/src/main.rs`:兩處 skill register — register prompt skill + 若 scripts_dir.is_some() 再 register script skill(並存 LLM 看到兩 entry)
- `crates/mori-tauri/src/skill_install_cmd.rs`:**flatten symlink helper** — install 完 iterate `anthropics-skills/skills/<name>/` → symlink 到 `~/.mori/skills/<name>/`(discover_skills 自動撿到)

## Design

- **Prompt + Script 並存**:LLM 在 tool list 看到 `<skill>`(prompt 知識)+ `anthropic_script_<skill>`(跑工具)兩個 entry — 先讀 prompt 再決定要不要叫 script
- **subprocess**:tokio + 60s timeout + stdin write+drop 關 pipe / child 看 EOF
- **Path traversal 防護**:script_path 必須在 scripts_dir 內(no `..` no absolute)
- **Symlink**:Linux/Windows OS-specific API,user-defined skill 同名優先(skip Anthropic 的)
- **idempotent install**:跨 release 加新 skill 也 flatten

## Test plan

- [x] **19 new tests**:
  - python_runner:6(basic / stderr / args / stdin / timeout / python missing[ignored])
  - anthropic_skill:8(scripts_dir 偵測 / script skill name 前綴 / schema / missing arg / path traversal / missing file / runs python / nonzero exit)
  - skill_install_cmd flatten:5(missing dir / creates symlinks / skip user skill / idempotent / non-dir entries)
- [x] mori-core 259 passed(原 245 + 新 14)
- [x] mori-tauri 15 skill_install_cmd passed
- [x] verify.sh / cargo check workspace 全綠

## Reviews

兩 stream(DF-1 + DF-2)同 batch ship,純 polish/integration 風格直接 PR。

## Known follow-up

- **per-skill pip install**(pypdf/openpyxl/python-docx/python-pptx)— user 手動,docstring 註明
- **timeout 後不殺 child**:60s sleep loop 會繼續直到自結束;非 zombie 但占資源。最小 runner 邊界
- **Windows symlink** 需 dev mode / admin,沒權限 flatten silently skip
- **沒沙箱 / venv 隔離** — 信任 user 系統。Wave 6+ 可加

🤖 Generated with [Claude Code](https://claude.com/claude-code)