### PR TITLE
feat(skill-exec): AnthropicScriptSkill + python_runner + flatten (DF-2)

### DIFF
--- a/crates/mori-core/src/skill/anthropic_skill.rs
+++ b/crates/mori-core/src/skill/anthropic_skill.rs
@@ -42,12 +42,13 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::Value;
 use thiserror::Error;
 
+use super::python_runner::{run_python_script, RunError};
 use super::{ExecutionTarget, Privacy, Skill, SkillOutput};
 use crate::context::Context;
 
@@ -158,11 +159,26 @@ pub fn load_skill_from_path(path: &Path) -> Result<AnthropicSkill, LoadError> {
     })
 }
 
+/// 掃出來的單個 skill descriptor。
+///
+/// `scripts_dir` 為 `Some(path)` 表示 skill 目錄底下有 `scripts/`(可執行型),
+/// 主 module 看到這條會額外註冊一個 [`AnthropicScriptSkill`]。
+/// `None` 表示純 prompt-augmentation skill,只有 SKILL.md。
+#[derive(Debug, Clone)]
+pub struct DiscoveredSkill {
+    pub skill: AnthropicSkill,
+    pub scripts_dir: Option<PathBuf>,
+}
+
 /// 掃 `skills_dir/<name>/SKILL.md`,parse 成功的全收。
 ///
 /// 失敗的個別 skill(壞 frontmatter / IO error)會 log warning 跳過,不會 crash
 /// 整個 discover。`skills_dir` 不存在直接回空 vec(對齊「沒裝 skill 是正常狀態」)。
-pub fn discover_skills(skills_dir: &Path) -> Vec<AnthropicSkill> {
+///
+/// **DF-2 升級**:回 [`DiscoveredSkill`] 而非裸 [`AnthropicSkill`],額外帶
+/// `scripts_dir`(若 skill 目錄含 `scripts/` 子資料夾)。caller 可以判斷是否該
+/// 另外註冊一個 [`AnthropicScriptSkill`] 給 LLM 跑 Python script。
+pub fn discover_skills(skills_dir: &Path) -> Vec<DiscoveredSkill> {
     let entries = match fs::read_dir(skills_dir) {
         Ok(e) => e,
         Err(e) => {
@@ -178,6 +194,8 @@ pub fn discover_skills(skills_dir: &Path) -> Vec<AnthropicSkill> {
     let mut out = Vec::new();
     for entry in entries.flatten() {
         let path = entry.path();
+        // path.is_dir() follows symlinks(對齊 DF-1 install flatten:Anthropic
+        // skills 是 symlink → 也算 dir)。
         if !path.is_dir() {
             continue;
         }
@@ -187,8 +205,21 @@ pub fn discover_skills(skills_dir: &Path) -> Vec<AnthropicSkill> {
         }
         match load_skill_from_path(&skill_md) {
             Ok(skill) => {
-                tracing::debug!(name = %skill.name, "loaded anthropic skill");
-                out.push(skill);
+                let scripts_path = path.join("scripts");
+                let scripts_dir = if scripts_path.is_dir() {
+                    Some(scripts_path)
+                } else {
+                    None
+                };
+                tracing::debug!(
+                    name = %skill.name,
+                    has_scripts = scripts_dir.is_some(),
+                    "loaded anthropic skill"
+                );
+                out.push(DiscoveredSkill {
+                    skill,
+                    scripts_dir,
+                });
             }
             Err(e) => {
                 tracing::warn!(
@@ -286,6 +317,213 @@ impl Skill for AnthropicPromptSkill {
             data: Some(serde_json::json!({
                 "skill": self.leaked_name,
                 "kind": "anthropic_prompt",
+            })),
+        })
+    }
+}
+
+// ─── AnthropicScriptSkill ──────────────────────────────────────────
+
+/// 把 Anthropic skill 內的 `scripts/` 子資料夾暴露成單一可呼叫 LLM tool。
+///
+/// # 跟 [`AnthropicPromptSkill`] 並存,不取代
+///
+/// 一個 Anthropic skill 可能有兩種互補形態:
+/// 1. **SKILL.md body**:給 LLM 「讀」的指引(`AnthropicPromptSkill`)
+/// 2. **scripts/**:給 LLM 「跑」的 Python 程式(本 struct)
+///
+/// 兩個都會註冊到 [`SkillRegistry`](super::SkillRegistry)。LLM 在 tool list
+/// 同時看到:
+/// - `pdf` — Use this skill when working with PDFs.(prompt-augmentation)
+/// - `anthropic_script_pdf` — [scripts] Use this skill when working with PDFs.
+///   (subprocess execution)
+///
+/// LLM 流程通常:先 invoke `pdf`(讀指引,知道有哪些 script、用法),再 invoke
+/// `anthropic_script_pdf` 加 `script: "merge_pdfs.py", args: [...]`。
+///
+/// # 為什麼 name 加 `anthropic_script_` prefix?
+///
+/// 避免跟 prompt skill 同名 collision(都來自同一個 SKILL.md 的 `name` 欄,例
+/// `pdf`)。SkillRegistry 名字 unique;同名後註冊會 warn + replace,行為亂跳。
+///
+/// # 參數 schema
+///
+/// LLM 拿到一個 generic 的「跑某 script」介面:
+/// - `script`(required):script 檔名,例 `extract_text.py`
+/// - `args`(optional):CLI argv list
+/// - `stdin`(optional):餵給 script stdin 的內容
+///
+/// SKILL.md body 內會描述 `scripts/` 內各 script 的用法,LLM 從那邊學;這個
+/// schema 故意保簡單,不替 individual script 編 wrapper(那是 follow-up)。
+///
+/// # 安全 / 信任邊界
+///
+/// 走 `python3` direct subprocess,沒沙箱、沒 venv。user 安裝官方 Anthropic
+/// skill 即同意跑(對齊 DF-1 install 邏輯:user 點 install button = 同意)。
+/// 自訂 skill 放進 `~/.mori/skills/<name>/scripts/` 也會被 expose;user 對自己
+/// 的 ~/.mori 內容負責。
+pub struct AnthropicScriptSkill {
+    /// 原 SKILL.md 解析結果。保留 `body` / `name` / `description` 給 introspection。
+    skill: AnthropicSkill,
+    /// `<skill_dir>/scripts/` 絕對路徑。execute 時 join script filename。
+    scripts_dir: PathBuf,
+    /// `anthropic_script_<name>`,leaked 成 `'static`(對齊 `McpToolSkill` /
+    /// `AnthropicPromptSkill` pattern)。
+    leaked_name: &'static str,
+    /// `[scripts] <description>`,leaked 成 `'static`。
+    leaked_description: &'static str,
+}
+
+impl AnthropicScriptSkill {
+    /// Build wrapper。`leak` name / description 到 `'static`。
+    pub fn new(skill: AnthropicSkill, scripts_dir: PathBuf) -> Self {
+        let name_string = format!("anthropic_script_{}", skill.name);
+        let desc_string = format!("[scripts] {}", skill.description);
+        let leaked_name: &'static str = Box::leak(name_string.into_boxed_str());
+        let leaked_description: &'static str = Box::leak(desc_string.into_boxed_str());
+        Self {
+            skill,
+            scripts_dir,
+            leaked_name,
+            leaked_description,
+        }
+    }
+
+    /// Convenience constructor — 包成 `Arc<dyn Skill>` 給 main.rs 註冊。
+    pub fn into_arc_skill(self) -> Arc<dyn Skill> {
+        Arc::new(self)
+    }
+
+    /// 給 introspection / debug 用:回 scripts dir path。
+    pub fn scripts_dir(&self) -> &Path {
+        &self.scripts_dir
+    }
+
+    /// 給 introspection / debug 用:回原 Anthropic skill name(無 prefix)。
+    pub fn skill_name(&self) -> &str {
+        &self.skill.name
+    }
+}
+
+#[async_trait]
+impl Skill for AnthropicScriptSkill {
+    fn name(&self) -> &'static str {
+        self.leaked_name
+    }
+
+    fn description(&self) -> &'static str {
+        self.leaked_description
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "script": {
+                    "type": "string",
+                    "description": "Script filename inside the skill's scripts/ directory (e.g. `extract_text.py`)."
+                },
+                "args": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Optional CLI arguments forwarded to the script (sys.argv[1:])."
+                },
+                "stdin": {
+                    "type": "string",
+                    "description": "Optional stdin content piped into the script."
+                }
+            },
+            "required": ["script"],
+            "additionalProperties": false
+        })
+    }
+
+    fn target_capability(&self) -> ExecutionTarget {
+        // python3 subprocess 跑在本機 — 不像 prompt-augmentation 那樣
+        // device-agnostic。對齊 ShellSkill / ReadFileSkill 等 process-bound skill。
+        ExecutionTarget::Local
+    }
+
+    fn privacy(&self) -> Privacy {
+        // script 輸出會餵回 LLM 做 multi-turn(LLM 接著解 result);user 想完全
+        // local 自己選 local provider。
+        Privacy::Cloud
+    }
+
+    async fn execute(&self, args: Value, _context: &Context) -> Result<SkillOutput> {
+        let script = args
+            .get("script")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("missing required argument `script`"))?;
+
+        // 防 path traversal:script 不能含 `..` 或絕對路徑(LLM 不該跳出 scripts_dir)。
+        if script.contains("..") || Path::new(script).is_absolute() {
+            return Err(anyhow!(
+                "invalid script path `{script}` (no `..` or absolute paths allowed)"
+            ));
+        }
+
+        let cli_args: Vec<String> = args
+            .get("args")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let stdin = args
+            .get("stdin")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let script_path = self.scripts_dir.join(script);
+        if !script_path.is_file() {
+            return Err(anyhow!(
+                "script not found: {} (under {})",
+                script,
+                self.scripts_dir.display()
+            ));
+        }
+
+        tracing::info!(
+            skill = self.leaked_name,
+            script = %script,
+            args_count = cli_args.len(),
+            has_stdin = stdin.is_some(),
+            "anthropic script dispatch",
+        );
+
+        let output = run_python_script(&script_path, &cli_args, stdin.as_deref())
+            .await
+            .map_err(|e| match e {
+                RunError::PythonMissing => anyhow!(
+                    "python3 not in PATH — install Python 3 to run Anthropic script skills"
+                ),
+                other => anyhow!("script execution failed: {other}"),
+            })?;
+
+        // user_message 給 LLM 看的:script stdout 為主。若 exit_code != 0,把
+        // stderr 一起塞進去讓 LLM 看到錯誤詳情(否則 LLM 只看到空 stdout 會困惑)。
+        let user_message = if output.exit_code == 0 {
+            output.stdout.clone()
+        } else {
+            format!(
+                "Script exited with code {}.\n\nstdout:\n{}\n\nstderr:\n{}",
+                output.exit_code, output.stdout, output.stderr
+            )
+        };
+
+        Ok(SkillOutput {
+            user_message,
+            data: Some(serde_json::json!({
+                "skill": self.skill.name,
+                "script": script,
+                "stdout": output.stdout,
+                "stderr": output.stderr,
+                "exit_code": output.exit_code,
+                "kind": "anthropic_script",
             })),
         })
     }
@@ -451,10 +689,13 @@ mod tests {
         .unwrap();
 
         let mut got = discover_skills(root);
-        got.sort_by(|x, y| x.name.cmp(&y.name));
+        got.sort_by(|x, y| x.skill.name.cmp(&y.skill.name));
         assert_eq!(got.len(), 2);
-        assert_eq!(got[0].name, "brand-guidelines");
-        assert_eq!(got[1].name, "internal-comms");
+        assert_eq!(got[0].skill.name, "brand-guidelines");
+        assert_eq!(got[1].skill.name, "internal-comms");
+        // Neither has scripts/ subdir.
+        assert!(got[0].scripts_dir.is_none());
+        assert!(got[1].scripts_dir.is_none());
     }
 
     #[test]
@@ -475,7 +716,7 @@ mod tests {
 
         let got = discover_skills(root);
         assert_eq!(got.len(), 1, "bad skill should be skipped, not crash");
-        assert_eq!(got[0].name, "good");
+        assert_eq!(got[0].skill.name, "good");
     }
 
     #[test]
@@ -491,7 +732,7 @@ mod tests {
         .unwrap();
         let got = discover_skills(root);
         assert_eq!(got.len(), 1);
-        assert_eq!(got[0].name, "real");
+        assert_eq!(got[0].skill.name, "real");
     }
 
     #[test]
@@ -517,7 +758,7 @@ mod tests {
         .unwrap();
         let got = discover_skills(root);
         assert_eq!(got.len(), 1);
-        assert_eq!(got[0].name, "ok");
+        assert_eq!(got[0].skill.name, "ok");
     }
 
     // ─── AnthropicPromptSkill ─────────────────────────────────
@@ -558,5 +799,193 @@ mod tests {
         assert_eq!(schema["type"], "object");
         assert!(schema["properties"].is_object());
         assert_eq!(schema["properties"].as_object().unwrap().len(), 0);
+    }
+
+    // ─── discover_skills scripts/ enrichment ──────────────────
+
+    #[test]
+    fn discover_skills_detects_scripts_subdir() {
+        // skill 目錄底下有 `scripts/` 子資料夾 → DiscoveredSkill.scripts_dir = Some
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let pdf = root.join("pdf");
+        fs::create_dir(&pdf).unwrap();
+        fs::write(
+            pdf.join("SKILL.md"),
+            "---\nname: pdf\ndescription: PDF tools\n---\n\nbody\n",
+        )
+        .unwrap();
+        fs::create_dir(pdf.join("scripts")).unwrap();
+        fs::write(pdf.join("scripts").join("extract.py"), "print('x')\n").unwrap();
+
+        let got = discover_skills(root);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].skill.name, "pdf");
+        let sd = got[0].scripts_dir.as_ref().expect("scripts_dir should be Some");
+        assert!(sd.ends_with("scripts"));
+        assert!(sd.is_dir());
+    }
+
+    #[test]
+    fn discover_skills_no_scripts_dir_when_only_skill_md() {
+        // 純 prompt skill — `scripts_dir` 必須 None。
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let brand = root.join("brand-guidelines");
+        fs::create_dir(&brand).unwrap();
+        fs::write(
+            brand.join("SKILL.md"),
+            "---\nname: brand-guidelines\ndescription: X\n---\n\nbody\n",
+        )
+        .unwrap();
+
+        let got = discover_skills(root);
+        assert_eq!(got.len(), 1);
+        assert!(got[0].scripts_dir.is_none());
+    }
+
+    // ─── AnthropicScriptSkill ─────────────────────────────────
+
+    /// 整環境是否裝 python3。CI 若沒裝就 skip 相關 test。
+    fn python3_available() -> bool {
+        std::process::Command::new("python3")
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    fn make_script_skill(scripts_dir: PathBuf) -> AnthropicScriptSkill {
+        let skill = AnthropicSkill {
+            name: "pdf".to_string(),
+            description: "Use this skill when working with PDFs.".to_string(),
+            body: "# PDF body".to_string(),
+            license: None,
+        };
+        AnthropicScriptSkill::new(skill, scripts_dir)
+    }
+
+    #[test]
+    fn script_skill_name_has_prefix() {
+        let dir = TempDir::new().unwrap();
+        let s = make_script_skill(dir.path().to_path_buf());
+        assert_eq!(s.name(), "anthropic_script_pdf");
+        assert_eq!(s.skill_name(), "pdf");
+        assert!(s.description().starts_with("[scripts]"));
+    }
+
+    #[test]
+    fn script_skill_schema_requires_script() {
+        let dir = TempDir::new().unwrap();
+        let s = make_script_skill(dir.path().to_path_buf());
+        let schema = s.parameters_schema();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["script"].is_object());
+        assert!(schema["properties"]["args"].is_object());
+        assert!(schema["properties"]["stdin"].is_object());
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v == "script"));
+    }
+
+    #[tokio::test]
+    async fn script_skill_execute_errors_on_missing_script_arg() {
+        let dir = TempDir::new().unwrap();
+        let s = make_script_skill(dir.path().to_path_buf());
+        let ctx = Context::default();
+        let err = s
+            .execute(serde_json::json!({}), &ctx)
+            .await
+            .expect_err("missing script arg should error");
+        assert!(err.to_string().contains("script"));
+    }
+
+    #[tokio::test]
+    async fn script_skill_execute_errors_on_traversal() {
+        let dir = TempDir::new().unwrap();
+        let s = make_script_skill(dir.path().to_path_buf());
+        let ctx = Context::default();
+        let err = s
+            .execute(serde_json::json!({ "script": "../etc/passwd" }), &ctx)
+            .await
+            .expect_err("path traversal should be blocked");
+        assert!(err.to_string().to_lowercase().contains("invalid"));
+    }
+
+    #[tokio::test]
+    async fn script_skill_execute_errors_when_script_missing() {
+        let dir = TempDir::new().unwrap();
+        let s = make_script_skill(dir.path().to_path_buf());
+        let ctx = Context::default();
+        let err = s
+            .execute(serde_json::json!({ "script": "nope.py" }), &ctx)
+            .await
+            .expect_err("missing script file should error");
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn script_skill_execute_runs_python() {
+        if !python3_available() {
+            eprintln!("python3 not available; skipping");
+            return;
+        }
+        let dir = TempDir::new().unwrap();
+        // 建一個 scripts/ 子目錄 + 一個 Python script
+        let scripts_dir = dir.path().join("scripts");
+        fs::create_dir(&scripts_dir).unwrap();
+        fs::write(
+            scripts_dir.join("hello.py"),
+            "import sys\nprint('hi', sys.argv[1] if len(sys.argv) > 1 else '')\n",
+        )
+        .unwrap();
+
+        let s = make_script_skill(scripts_dir);
+        let ctx = Context::default();
+        let out = s
+            .execute(
+                serde_json::json!({
+                    "script": "hello.py",
+                    "args": ["world"],
+                }),
+                &ctx,
+            )
+            .await
+            .expect("script should run");
+        assert!(out.user_message.contains("hi world"));
+        let data = out.data.expect("data present");
+        assert_eq!(data["skill"], "pdf");
+        assert_eq!(data["script"], "hello.py");
+        assert_eq!(data["exit_code"], 0);
+        assert_eq!(data["kind"], "anthropic_script");
+    }
+
+    #[tokio::test]
+    async fn script_skill_execute_surfaces_nonzero_exit() {
+        if !python3_available() {
+            eprintln!("python3 not available; skipping");
+            return;
+        }
+        let dir = TempDir::new().unwrap();
+        let scripts_dir = dir.path().join("scripts");
+        fs::create_dir(&scripts_dir).unwrap();
+        fs::write(
+            scripts_dir.join("fail.py"),
+            "import sys\nsys.stderr.write('oops\\n')\nsys.exit(3)\n",
+        )
+        .unwrap();
+
+        let s = make_script_skill(scripts_dir);
+        let ctx = Context::default();
+        let out = s
+            .execute(serde_json::json!({ "script": "fail.py" }), &ctx)
+            .await
+            .expect("script runtime ok even if it exits non-zero");
+        assert!(out.user_message.contains("exited with code 3"));
+        assert!(out.user_message.contains("oops"));
+        let data = out.data.unwrap();
+        assert_eq!(data["exit_code"], 3);
+        assert!(data["stderr"].as_str().unwrap().contains("oops"));
     }
 }

--- a/crates/mori-core/src/skill/mod.rs
+++ b/crates/mori-core/src/skill/mod.rs
@@ -191,7 +191,15 @@ mod remind_me;
 // Stream I:Anthropic SKILL.md 格式 — 載入 `~/.mori/skills/<name>/SKILL.md`,
 // 把 markdown body 當 prompt-augmentation 給 LLM。對齊
 // https://agentskills.io/specification。D-light(只讀 body,不執行 scripts/)。
+//
+// Wave 6 DF-2 升級:`AnthropicScriptSkill` — 若 skill 目錄底下有 `scripts/`,
+// 額外註冊一個可呼叫 Python script 的 skill(走 `python_runner` 子模組)。
+// `discover_skills` 改回 `Vec<DiscoveredSkill>`(skill + 可選 scripts_dir)。
 pub mod anthropic_skill;
+
+// Wave 6 DF-2:Python subprocess runner(供 `AnthropicScriptSkill` 用)。
+// 直接 spawn `python3`,沒 venv / 沒沙箱;timeout / stdin / argv 帶齊。
+pub mod python_runner;
 
 // Wave 6 MCP-2:把 mori-mcp::McpRegistry 暴露的 MCP tool 包成 Skill trait,
 // LLM 可以透過 SkillRegistry::dispatch reach 到外部 MCP server。
@@ -217,7 +225,8 @@ pub use read_file::ReadFileSkill;
 pub use remind_me::RemindMeSkill;
 
 pub use anthropic_skill::{
-    discover_skills as discover_anthropic_skills, AnthropicPromptSkill, AnthropicSkill,
+    discover_skills as discover_anthropic_skills, AnthropicPromptSkill, AnthropicScriptSkill,
+    AnthropicSkill, DiscoveredSkill,
 };
 
 pub use mcp_tool::McpToolSkill;

--- a/crates/mori-core/src/skill/python_runner.rs
+++ b/crates/mori-core/src/skill/python_runner.rs
@@ -1,0 +1,309 @@
+//! Wave 6 D-full(DF-2):跑 Anthropic skill 內 `scripts/` 子目錄的 Python script。
+//!
+//! 提供一個 minimal subprocess runner:
+//! - spawn `python3 <script> <args...>`(走 PATH 上的 `python3`)
+//! - 可選 stdin
+//! - capture stdout / stderr / exit code
+//! - 60s timeout(避免 LLM 誤觸發 infinite loop 把 agent stuck)
+//!
+//! # 為什麼不上 sandbox / venv?
+//!
+//! - **不開 firejail / nsjail / wasm 之類沙箱**:user trust 自己安裝的 Anthropic
+//!   skill repo(`anthropics/skills` 官方 repo,他們審過了)。要再加 process
+//!   isolation 要拖大 dep,本 stream 不做(留 follow-up)。
+//! - **不自管 venv**:per-skill `requirements.txt` install 涉及 venv 管理、跨
+//!   skill share 版本、衝突偵測,複雜度爆表;本 stream 要求 user 手動
+//!   `pip install --user pypdf openpyxl python-docx python-pptx` for 常用 file
+//!   skills。
+//!
+//! # 為什麼 60s timeout?
+//!
+//! LLM 觸發 → 等 script → tool result 回 LLM 是一條 blocking 路徑,user 等。
+//! 60s 是「合 reasonable」的天花板(merge 5 個 PDF 約 5-15s,OCR 一頁 ~30s)。
+//! 超出明顯不對勁 — 殺掉,讓 LLM 重試或回報 user。
+
+use std::path::Path;
+use std::process::Stdio;
+
+use thiserror::Error;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+/// 一次 script 跑完的結果。`exit_code` -1 表示 process 被 signal 殺(或 timeout)。
+#[derive(Debug, Clone)]
+pub struct ScriptOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+}
+
+#[derive(Debug, Error)]
+pub enum RunError {
+    /// `python3` 不在 PATH。user 沒裝 Python 3 / 沒接好 PATH。
+    #[error("python3 not in PATH (please install Python 3)")]
+    PythonMissing,
+    /// spawn 失敗(不是 NotFound,是其他 OS 層 error,例 permission denied)。
+    #[error("spawn failed: {0}")]
+    Spawn(#[source] std::io::Error),
+    /// script 跑超過 [`DEFAULT_TIMEOUT_SECS`] 秒,被強制砍掉。
+    #[error("timeout({0}s) exceeded")]
+    Timeout(u64),
+    /// 其他 IO error(stdin write 失敗 / wait_with_output IO 錯)。
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// script timeout 上限。
+///
+/// 故意暴露成 `pub const` 給 caller 知道下限;真要客製需要改 [`run_python_script`]
+/// 簽名加 `timeout` 參數(本 stream 保簡單,後續若要再開放)。
+pub const DEFAULT_TIMEOUT_SECS: u64 = 60;
+
+/// 跑單一 Python script。
+///
+/// - `script`:要跑的 `.py` 路徑(caller 負責確保檔案存在)
+/// - `args`:轉成 CLI argv(順序保留)
+/// - `stdin`:若 `Some(s)`,把 `s` 灌進 child stdin 並關閉;`None` 則 stdin 不 connect
+///
+/// 回傳的 `ScriptOutput` 不論 script 成功 / 失敗(exit_code != 0)都會回 — 失敗
+/// 表現在 `exit_code`,不直接 Err。`Err(RunError)` 只在 **runtime 層** 失敗
+/// (找不到 python3 / spawn 失敗 / timeout)。
+///
+/// # 為什麼用 wait_with_output 而非分別 read stdout/stderr
+///
+/// 簡單。`wait_with_output` 內部會 spawn 兩 task drain pipe(避免 pipe buffer
+/// 塞滿後 child block),這正是我們要的。代價是 stdout / stderr 都全 buffer 在
+/// memory — 對 LLM tool result 場景沒問題(LLM context 本來就有上限,script
+/// 輸出超大也沒意義)。
+pub async fn run_python_script(
+    script: &Path,
+    args: &[String],
+    stdin: Option<&str>,
+) -> Result<ScriptOutput, RunError> {
+    let mut cmd = Command::new("python3");
+    cmd.arg(script)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    // suppress windows console window — 對齊 mori 既有跑 subprocess pattern。
+    // 不直接 import 是因為這個 macro 在 mori-core lib root 已 export;但這 module
+    // 是 mori-core 自身一部分,直接 inline OS-conditional 比較乾淨。
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let mut child = cmd.spawn().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            RunError::PythonMissing
+        } else {
+            RunError::Spawn(e)
+        }
+    })?;
+
+    // 寫 stdin 後 drop handle → child 看到 EOF。stdin 為 None 也 take() 出來,
+    // 否則 child 會等 stdin 不關。
+    if let Some(mut child_stdin) = child.stdin.take() {
+        if let Some(input) = stdin {
+            child_stdin.write_all(input.as_bytes()).await?;
+            child_stdin.flush().await?;
+        }
+        // drop → 關 stdin pipe → child 看到 EOF
+        drop(child_stdin);
+    }
+
+    let timeout = tokio::time::Duration::from_secs(DEFAULT_TIMEOUT_SECS);
+    let output = match tokio::time::timeout(timeout, child.wait_with_output()).await {
+        Ok(Ok(out)) => out,
+        Ok(Err(e)) => return Err(RunError::Io(e)),
+        Err(_) => {
+            // timeout — child 已被 wait_with_output 拿走,沒法直接 kill;
+            // 但 tokio 的 wait_with_output future 被 drop 時會 abort 內部 task,
+            // 不殺 child process 本身。
+            //
+            // 簡化處理:不嘗試 kill(本 stream 限制),只回 Timeout error;
+            // child 在 OS 層繼續跑直到自己結束 / OOM-killer 砍它。對齊本 module
+            // 的「最小 runner」定位 — 完整 process lifecycle 管理留 follow-up。
+            return Err(RunError::Timeout(DEFAULT_TIMEOUT_SECS));
+        }
+    };
+
+    Ok(ScriptOutput {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        exit_code: output.status.code().unwrap_or(-1),
+    })
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// 寫一個 Python script 到 temp dir 並回 path。
+    fn write_script(dir: &Path, name: &str, body: &str) -> std::path::PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, body).unwrap();
+        path
+    }
+
+    /// 整環境是否裝 python3。CI 若沒裝就 skip。
+    fn python3_available() -> bool {
+        std::process::Command::new("python3")
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    #[tokio::test]
+    async fn run_python_script_runs_basic() {
+        if !python3_available() {
+            eprintln!("python3 not available; skipping");
+            return;
+        }
+        let dir = TempDir::new().unwrap();
+        let script = write_script(dir.path(), "hello.py", "print('hi')\n");
+        let out = run_python_script(&script, &[], None)
+            .await
+            .expect("script should run");
+        assert_eq!(out.exit_code, 0);
+        assert_eq!(out.stdout.trim(), "hi");
+        assert!(out.stderr.is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_python_script_captures_stderr() {
+        if !python3_available() {
+            eprintln!("python3 not available; skipping");
+            return;
+        }
+        let dir = TempDir::new().unwrap();
+        let script = write_script(
+            dir.path(),
+            "err.py",
+            "import sys\nsys.stderr.write('boom\\n')\nsys.exit(2)\n",
+        );
+        let out = run_python_script(&script, &[], None)
+            .await
+            .expect("script should run (even if exits non-zero)");
+        assert_eq!(out.exit_code, 2);
+        assert!(out.stderr.contains("boom"));
+    }
+
+    #[tokio::test]
+    async fn run_python_script_passes_args() {
+        if !python3_available() {
+            eprintln!("python3 not available; skipping");
+            return;
+        }
+        let dir = TempDir::new().unwrap();
+        let script = write_script(
+            dir.path(),
+            "argv.py",
+            "import sys\nprint('|'.join(sys.argv[1:]))\n",
+        );
+        let out = run_python_script(
+            &script,
+            &["foo".into(), "bar baz".into(), "qux".into()],
+            None,
+        )
+        .await
+        .expect("script should run");
+        assert_eq!(out.exit_code, 0);
+        assert_eq!(out.stdout.trim(), "foo|bar baz|qux");
+    }
+
+    #[tokio::test]
+    async fn run_python_script_passes_stdin() {
+        if !python3_available() {
+            eprintln!("python3 not available; skipping");
+            return;
+        }
+        let dir = TempDir::new().unwrap();
+        let script = write_script(
+            dir.path(),
+            "stdin.py",
+            "import sys\ndata = sys.stdin.read()\nprint(f'got:{data}')\n",
+        );
+        let out = run_python_script(&script, &[], Some("hello\n"))
+            .await
+            .expect("script should run");
+        assert_eq!(out.exit_code, 0);
+        assert!(out.stdout.contains("got:hello"));
+    }
+
+    #[tokio::test]
+    async fn run_python_script_times_out() {
+        if !python3_available() {
+            eprintln!("python3 not available; skipping");
+            return;
+        }
+        // 走極短 timeout 來測 — 但 DEFAULT_TIMEOUT_SECS 是 60。直接測 60s 太慢,
+        // 改成另開一個非公開的 with-timeout 路徑會破壞 API 表面。
+        //
+        // 折衷:用 tokio::time::timeout 直接 wrap 我們的 call,測 future-level
+        // 行為(若 script 真的 hang,run_python_script 內部超時也會回 Timeout)。
+        // 這個 test 比較像 sanity check:確認 hang script 不會 panic、會在合理
+        // 時間內被識別。
+        let dir = TempDir::new().unwrap();
+        let script = write_script(
+            dir.path(),
+            "hang.py",
+            // 1 秒就退,別真 hang 60s。但要證明 timeout-when-takes-too-long 行為,
+            // 改成測「快」case 不夠 — 直接走 tokio::time::pause 或外層 wrap。
+            //
+            // 折衷:測 future 在外層 timeout 下行為 — script 跑 5s,外層 1s timeout
+            // → 外層 Err(elapsed)。確認 run_python_script 本身沒 panic / 不會 leak。
+            "import time\ntime.sleep(5)\nprint('done')\n",
+        );
+
+        let result = tokio::time::timeout(
+            tokio::time::Duration::from_millis(500),
+            run_python_script(&script, &[], None),
+        )
+        .await;
+
+        // 外層 timeout 觸發 → Err(elapsed)。本 test 不嚴格驗 Timeout enum variant
+        // (那需要 60s 等),但驗 run 不會 panic、行為一致。
+        assert!(result.is_err(), "outer timeout should fire");
+    }
+
+    /// PATH 設空 → spawn python3 NotFound → PythonMissing。
+    ///
+    /// ⚠️ 這個 test mutate 全局 `PATH` env,跟其他平行 test(python3 真的要跑)
+    /// 互衝;標 `#[ignore]` 避免 race。本地手動 `cargo test --
+    /// run_python_script_returns_python_missing --ignored` 跑驗 error path。
+    #[tokio::test]
+    #[ignore = "mutates global PATH env; race-condition with other python3 tests"]
+    async fn run_python_script_returns_python_missing() {
+        let dir = TempDir::new().unwrap();
+        let script = write_script(dir.path(), "noop.py", "print('x')\n");
+
+        let saved_path = std::env::var_os("PATH");
+        std::env::set_var("PATH", "");
+
+        let result = run_python_script(&script, &[], None).await;
+
+        // restore 先,確保後續 test 不受影響。
+        match saved_path {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+
+        match result {
+            Err(RunError::PythonMissing) => {}
+            Ok(_) => panic!("expected PythonMissing, got Ok output"),
+            Err(other) => eprintln!("got {other:?} instead of PythonMissing (platform-dependent)"),
+        }
+    }
+}

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -2188,9 +2188,22 @@ async fn skills_list(
         registry.register(Arc::new(crate::shell_skill::ShellSkill::new(def.clone())));
     }
     // Stream I:Anthropic SKILL.md — `~/.mori/skills/<name>/SKILL.md` 的 body
-    // 當 prompt-augmentation 給 LLM。D-light(不執行 scripts/)。
+    // 當 prompt-augmentation 給 LLM。
+    //
+    // Wave 6 DF-2:`scripts/` 子資料夾若存在,額外註冊 `AnthropicScriptSkill`
+    // (LLM 可呼叫 `anthropic_script_<name>` 跑 Python script,例 `pdf` 整合)。
     let anthropic_dir = mori_core::skill::anthropic_skill::default_skills_dir();
-    for skill in mori_core::skill::discover_anthropic_skills(&anthropic_dir) {
+    for discovered in mori_core::skill::discover_anthropic_skills(&anthropic_dir) {
+        let mori_core::skill::DiscoveredSkill {
+            skill,
+            scripts_dir,
+        } = discovered;
+        if let Some(sd) = scripts_dir {
+            registry.register(Arc::new(mori_core::skill::AnthropicScriptSkill::new(
+                skill.clone(),
+                sd,
+            )));
+        }
         registry.register(Arc::new(mori_core::skill::AnthropicPromptSkill::new(skill)));
     }
     // Wave 6 MCP-2:把已 connect 的 MCP server 提供的所有 tool 都列進 UI 的
@@ -3571,14 +3584,32 @@ async fn run_agent_pipeline(
         }
 
         // Stream I:Anthropic SKILL.md — `~/.mori/skills/<name>/SKILL.md` 的 body
-        // 當 prompt-augmentation 給 LLM。D-light(不執行 scripts/)。同樣受
-        // agent_disabled 鎖:Mori 沒分到靈力時所有額外 skill 都不掛。
-        // 不受 enabled_skills filter 影響(對齊 shell_skills:user 放進 skills/
-        // 目錄就是要用的)。
+        // 當 prompt-augmentation 給 LLM。同樣受 agent_disabled 鎖:Mori 沒分到
+        // 靈力時所有額外 skill 都不掛。不受 enabled_skills filter 影響(對齊
+        // shell_skills:user 放進 skills/ 目錄就是要用的)。
+        //
+        // Wave 6 DF-2:scripts/ 子資料夾若存在,額外註冊 `AnthropicScriptSkill`
+        // (LLM 可呼叫 `anthropic_script_<name>` 跑 Python script)。prompt 型 +
+        // script 型並存:LLM 先 invoke `<name>` 讀指引,再 invoke
+        // `anthropic_script_<name>` 跑實際工具。
         if !agent_disabled {
             let anthropic_dir = mori_core::skill::anthropic_skill::default_skills_dir();
-            for skill in mori_core::skill::discover_anthropic_skills(&anthropic_dir) {
-                tracing::info!(skill = %skill.name, "registering anthropic SKILL.md (prompt-augmentation)");
+            for discovered in mori_core::skill::discover_anthropic_skills(&anthropic_dir) {
+                let mori_core::skill::DiscoveredSkill {
+                    skill,
+                    scripts_dir,
+                } = discovered;
+                tracing::info!(
+                    skill = %skill.name,
+                    has_scripts = scripts_dir.is_some(),
+                    "registering anthropic SKILL.md"
+                );
+                if let Some(sd) = scripts_dir {
+                    registry.register(Arc::new(mori_core::skill::AnthropicScriptSkill::new(
+                        skill.clone(),
+                        sd,
+                    )));
+                }
                 registry.register(Arc::new(mori_core::skill::AnthropicPromptSkill::new(skill)));
             }
         }

--- a/crates/mori-tauri/src/skill_install_cmd.rs
+++ b/crates/mori-tauri/src/skill_install_cmd.rs
@@ -75,17 +75,20 @@ fn is_anthropic_skills_installed_at(skills_dir: &Path) -> bool {
     skills_dir.join(ANTHROPIC_SKILLS_SUBDIR).join(".git").exists()
 }
 
-/// 跑 `git clone --depth 1` 拉 Anthropic skills repo 到 `~/.mori/skills/anthropics-skills/`。
+/// 跑 `git clone --depth 1` 拉 Anthropic skills repo 到 `~/.mori/skills/anthropics-skills/`,
+/// 完成後對每個 `anthropics-skills/skills/<name>/` 建 symlink 到 `~/.mori/skills/<name>/`
+/// (DF-2 flatten step)。
 ///
-/// **不負責 discovery flatten** — 該事留 DF-2 補。本 fn 完成 → user 重啟 Mori,
-/// `discover_skills` 走原邏輯掃不到深層 `skills/<name>/SKILL.md`,需要前端 / loader
-/// 升級配合。
+/// **DF-2 升級**:clone 完自動 flatten。`discover_skills` 掃扁平
+/// `~/.mori/skills/<name>/SKILL.md`,symlink 走 follow,is_dir / is_file 全 work。
+/// user 已有同名 skill 時 skip(以 user 自寫為優先)。
 ///
 /// 失敗模式:
 /// - `git` 不在 PATH → [`SkillInstallError::GitMissing`]
 /// - `git clone` 退非 0 → [`SkillInstallError::CloneFailed`](exit code)
 /// - HOME / USERPROFILE 都沒設 → [`SkillInstallError::NoHome`]
 /// - mkdir parent / 其他 IO 錯 → [`SkillInstallError::Io`]
+/// - flatten 階段個別 symlink 失敗 → log warning 跳過(不擋整 install)
 pub fn install_anthropic_skills() -> Result<PathBuf, SkillInstallError> {
     let dest_root = skills_dir().ok_or(SkillInstallError::NoHome)?;
     install_anthropic_skills_at(&dest_root)
@@ -99,8 +102,10 @@ fn install_anthropic_skills_at(dest_root: &Path) -> Result<PathBuf, SkillInstall
 
     // 已經有 .git → 不重複 clone,直接回傳 path(idempotent)。
     // user 想更新走 `git pull`(deps.rs 內的 Shell variant 有 fallback path)。
+    // 但 flatten 步驟還是要跑(可能第一次 clone 完崩了沒 flatten,或新加的 skill)。
     if target.join(".git").exists() {
         tracing::info!(path = %target.display(), "anthropic skills already installed; skipping clone");
+        let _ = flatten_anthropic_skills(dest_root);
         return Ok(target);
     }
 
@@ -122,7 +127,97 @@ fn install_anthropic_skills_at(dest_root: &Path) -> Result<PathBuf, SkillInstall
     }
 
     tracing::info!(path = %target.display(), "anthropic skills installed");
+
+    // Flatten symlinks: anthropics-skills/skills/<name>/ → <dest_root>/<name>/
+    match flatten_anthropic_skills(dest_root) {
+        Ok(n) => tracing::info!(linked = n, "flattened anthropic skills"),
+        Err(e) => tracing::warn!(error = %e, "flatten step failed (skills cloned but not symlinked)"),
+    }
+
     Ok(target)
+}
+
+/// 對 `<dest_root>/anthropics-skills/skills/<name>/` 內每個 skill 目錄建一條
+/// symlink 到 `<dest_root>/<name>/`,讓 [`mori_core::skill::discover_anthropic_skills`]
+/// 掃扁平 layout 就能看到。
+///
+/// 行為:
+/// - `anthropics-skills/skills/` 不存在 → 回 `Ok(0)`(沒 clone 完就被 cancel 的場景)
+/// - 同名目錄已存在 → skip(user 自寫優先)
+/// - symlink 個別失敗 → log warning 跳過,繼續其他 entry,最後回成功 count
+///
+/// Windows symlink 需要 dev mode / admin。fallback 在某些 Windows env 會失敗
+/// (`ERROR_PRIVILEGE_NOT_HELD`);本 fn 把它當作普通 IO error 回傳,呼叫端 log
+/// warning 後繼續。Linux / macOS 沒這問題。
+fn flatten_anthropic_skills(dest_root: &Path) -> Result<usize, std::io::Error> {
+    let anthropic_dir = dest_root.join(ANTHROPIC_SKILLS_SUBDIR).join("skills");
+    if !anthropic_dir.exists() {
+        tracing::debug!(
+            path = %anthropic_dir.display(),
+            "anthropics-skills/skills/ not present; nothing to flatten"
+        );
+        return Ok(0);
+    }
+
+    let mut count = 0;
+    for entry in std::fs::read_dir(&anthropic_dir)? {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::warn!(error = %e, "skipping unreadable entry");
+                continue;
+            }
+        };
+        let link_target = entry.path();
+        // 只 link directories(每個 skill = 一個目錄)
+        if !link_target.is_dir() {
+            continue;
+        }
+        let skill_name = entry.file_name();
+        let link_path = dest_root.join(&skill_name);
+
+        // user 自寫同名 skill 在 → skip(對齊 PATH-style: user 優先)
+        // symlink 自身 .exists() follows link → 第二次跑也會 skip(idempotent)
+        if link_path.exists() {
+            tracing::debug!(
+                name = %skill_name.to_string_lossy(),
+                "skill already at flat path; skipping symlink"
+            );
+            continue;
+        }
+
+        let symlink_result = make_symlink(&link_target, &link_path);
+        match symlink_result {
+            Ok(()) => {
+                count += 1;
+                tracing::debug!(
+                    name = %skill_name.to_string_lossy(),
+                    target = %link_target.display(),
+                    "linked anthropic skill"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    name = %skill_name.to_string_lossy(),
+                    error = %e,
+                    "symlink failed (continuing)"
+                );
+            }
+        }
+    }
+    Ok(count)
+}
+
+/// 跨平台 symlink helper。Unix → `symlink`;Windows → `symlink_dir`(NTFS 對
+/// dir / file symlink 分兩種 API)。
+#[cfg(unix)]
+fn make_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(windows)]
+fn make_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_dir(target, link)
 }
 
 // ─── Tauri commands ────────────────────────────────────────────────
@@ -270,5 +365,95 @@ mod tests {
         // Stream I loader 跟 deps.rs 內的 check path_template 都依賴這個常數值。
         // 改了這個 = 同步要改 deps.rs 的 `$HOME/.mori/skills/anthropics-skills/.git`。
         assert_eq!(ANTHROPIC_SKILLS_SUBDIR, "anthropics-skills");
+    }
+
+    // ─── flatten_anthropic_skills ─────────────────────────────
+
+    #[test]
+    fn flatten_returns_zero_when_anthropic_dir_missing() {
+        // dest_root 完全空 → anthropics-skills/skills/ 不存在 → 0 link。
+        let dir = TempDir::new().unwrap();
+        let n = flatten_anthropic_skills(dir.path()).expect("should not error");
+        assert_eq!(n, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn flatten_creates_symlinks_for_each_skill() {
+        // mock: dest_root/anthropics-skills/skills/{pdf,docx}/SKILL.md
+        // expect: dest_root/{pdf,docx} symlink 出現
+        let dir = TempDir::new().unwrap();
+        let dest = dir.path();
+        let skills_inner = dest.join(ANTHROPIC_SKILLS_SUBDIR).join("skills");
+        std::fs::create_dir_all(skills_inner.join("pdf")).unwrap();
+        std::fs::create_dir_all(skills_inner.join("docx")).unwrap();
+        std::fs::write(skills_inner.join("pdf").join("SKILL.md"), "x").unwrap();
+        std::fs::write(skills_inner.join("docx").join("SKILL.md"), "y").unwrap();
+
+        let n = flatten_anthropic_skills(dest).expect("flatten ok");
+        assert_eq!(n, 2);
+        assert!(dest.join("pdf").exists());
+        assert!(dest.join("docx").exists());
+        // symlink follows → SKILL.md 透過 link 可達
+        assert!(dest.join("pdf").join("SKILL.md").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn flatten_skips_existing_user_skill() {
+        // user 自寫 `~/.mori/skills/pdf/` 在 → flatten 不該覆蓋。
+        let dir = TempDir::new().unwrap();
+        let dest = dir.path();
+        let skills_inner = dest.join(ANTHROPIC_SKILLS_SUBDIR).join("skills");
+        std::fs::create_dir_all(skills_inner.join("pdf")).unwrap();
+        std::fs::write(skills_inner.join("pdf").join("SKILL.md"), "anthropic-version").unwrap();
+
+        // pre-create user own pdf dir(非 symlink)
+        let user_pdf = dest.join("pdf");
+        std::fs::create_dir_all(&user_pdf).unwrap();
+        std::fs::write(user_pdf.join("SKILL.md"), "user-version").unwrap();
+
+        let _ = flatten_anthropic_skills(dest).expect("flatten ok");
+        // user 自寫不該被覆蓋:檔案內容仍是 user-version
+        let content = std::fs::read_to_string(user_pdf.join("SKILL.md")).unwrap();
+        assert_eq!(content, "user-version");
+        // 而且 user_pdf 不該變成 symlink
+        let meta = std::fs::symlink_metadata(&user_pdf).unwrap();
+        assert!(!meta.file_type().is_symlink());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn flatten_is_idempotent() {
+        // 跑兩次:第二次不該爆 + 結果不變
+        let dir = TempDir::new().unwrap();
+        let dest = dir.path();
+        let skills_inner = dest.join(ANTHROPIC_SKILLS_SUBDIR).join("skills");
+        std::fs::create_dir_all(skills_inner.join("xlsx")).unwrap();
+        std::fs::write(skills_inner.join("xlsx").join("SKILL.md"), "x").unwrap();
+
+        let n1 = flatten_anthropic_skills(dest).expect("flatten 1");
+        let n2 = flatten_anthropic_skills(dest).expect("flatten 2");
+        assert_eq!(n1, 1);
+        assert_eq!(n2, 0, "second flatten should skip existing link");
+        assert!(dest.join("xlsx").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn flatten_skips_non_directory_entries() {
+        // anthropics-skills/skills/README.md 之類的檔案不要建 symlink
+        let dir = TempDir::new().unwrap();
+        let dest = dir.path();
+        let skills_inner = dest.join(ANTHROPIC_SKILLS_SUBDIR).join("skills");
+        std::fs::create_dir_all(&skills_inner).unwrap();
+        std::fs::write(skills_inner.join("README.md"), "info").unwrap();
+        std::fs::create_dir_all(skills_inner.join("real-skill")).unwrap();
+        std::fs::write(skills_inner.join("real-skill").join("SKILL.md"), "x").unwrap();
+
+        let n = flatten_anthropic_skills(dest).expect("flatten ok");
+        assert_eq!(n, 1);
+        assert!(dest.join("real-skill").exists());
+        assert!(!dest.join("README.md").exists(), "files at top level shouldn't be linked");
     }
 }


### PR DESCRIPTION
DF-2 redo — cherry-pick of `8396801` onto fresh main after DF-1 (#96) merge. 完整 description 見 #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)