### PR TITLE
feat(scripts): install-knowledge-wiki.sh + dev wiki docs (Ld)

### DIFF
--- a/docs/dev-knowledge-wiki.md
+++ b/docs/dev-knowledge-wiki.md
@@ -1,0 +1,77 @@
+# 開發工具 wiki(L-dev)
+
+> Mori 有她自己的內在 wiki(`spirits/<name>/wiki/`,phase 9+ 的記憶之森 L-mori 側)。
+> 本文講**你**(user)的開發工具 wiki — Claude Code / Codex CLI / Gemini CLI
+> 共用一份 markdown 知識庫,跟 Mori 完全 decouple。
+
+## 為什麼分兩個 wiki
+
+- **Mori 的 wiki**(`spirits/<name>/wiki/`)= 她的內在記憶 / 對你的觀察 / 跟你的關係(private,在她 vault 內)
+- **Dev wiki**(`~/wiki/`)= 你的工程知識 / API refs / 工具用法 / 認識的人(可能 share 給未來 user 看)
+
+兩種 mode、兩種 audience,自然不該同份。Mori 不讀 `~/wiki/`;Claude/Codex/Gemini
+也不讀 Mori 的 vault。
+
+## 安裝
+
+```bash
+bash scripts/install-knowledge-wiki.sh
+```
+
+完成後:
+
+- `~/wiki/` 結構建好(`raw/` + `wiki/{people,projects,concepts,meetings,resources}` + `index.md` + `agents.md` + `log.md`)
+- `~/.claude/CLAUDE.md` / `~/.codex/AGENTS.md` / `~/.gemini/GEMINI.md` 各 symlink 到 `~/wiki/agents.md`
+- 已存在且非 symlink 的 instruction 檔會被**跳過**(腳本不會覆寫 user 自己寫的 CLAUDE.md)
+
+Script idempotent — 可重跑,既有檔不會被覆寫。
+
+## 結構
+
+```
+~/wiki/
+├── index.md                 ← LLM 進來第一個讀的全景目錄
+├── agents.md                ← polyglot agent 規則(Claude/Codex/Gemini symlink 到這)
+├── log.md                   ← agent 動過什麼的 append-only audit trail
+├── raw/                     ← 不可變原料 dump
+│   ├── articles/
+│   ├── papers/
+│   ├── readmes/
+│   └── transcripts/
+└── wiki/                    ← agent 編譯的「百科」(扁平階層 + cross-link)
+    ├── people/              ← 認識的人 + 關係
+    ├── projects/            ← 進行中的專案
+    ├── concepts/            ← 抽象概念 / 框架 / 技術
+    ├── meetings/            ← 會議紀錄
+    └── resources/           ← 工具 / 服務 / 帳號
+```
+
+## Karpathy LLM Wiki pattern
+
+設計靈感:LLM **主動維護** markdown 知識庫,取代 RAG。
+
+- `raw/` 永遠 immutable(原料 append-only,不要改)
+- `wiki/` 由 agent 主動 maintain + cross-link(Obsidian-style `[[<page-name>]]`)
+- 改檔前 agent 必須 append 一行進 `log.md`
+- LLM 進來時先讀 `index.md` 拿全景,再 selective grep / Read 相關 page 進 context
+
+## Mori 跟這份 wiki 的關係
+
+**無**。
+
+Mori 的記憶 / 識身寫在 `~/mori-universe/spirits/<name>/`(SOUL.md / MEMORY.md /
+她自己的 wiki/),完全獨立。本 wiki 是給 yazelin 的開發工具 agent(Claude Code /
+Codex / Gemini)共用的;Mori 不會也不該讀。
+
+agent 規則明文寫死:**不抄 mori-journal / spirits/mori/ 內容過來**(那是
+Mori 的私人領域,不可公開化)。
+
+## 維護
+
+- agent 主動寫 `wiki/`(per `agents.md` 規則)
+- 你自己手動 edit 也 OK(plain markdown,git 可 manage)
+- `raw/` append-only 原料 dump
+- `log.md` append-only audit trail
+
+想把整個 `~/wiki/` 放進 private git repo 也很自然 — 結構就是 markdown,跟
+Obsidian / VSCode 都相容。

--- a/scripts/install-knowledge-wiki.sh
+++ b/scripts/install-knowledge-wiki.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# L-dev — install user knowledge wiki at ~/wiki/ + symlink agents.md
+# 到 各 AI CLI 的 global instruction 檔(Claude / Codex / Gemini)。
+#
+# Karpathy LLM Wiki pattern:LLM 主動維護的 markdown 知識庫,取代 RAG。
+# Mori 不讀這 wiki(她有自己的 spirits/mori/wiki/)。
+#
+# ─── Usage ───────────────────────────────────────────────────────────
+#
+#   bash scripts/install-knowledge-wiki.sh
+#
+# Idempotent:可重跑;既有檔不會被覆寫,既有非 symlink instruction 檔會被跳過。
+
+set -euo pipefail
+
+WIKI_ROOT="${HOME}/wiki"
+
+echo ">>> 建 ~/wiki/ 結構..."
+mkdir -p "${WIKI_ROOT}/raw"/{articles,papers,readmes,transcripts}
+mkdir -p "${WIKI_ROOT}/wiki"/{people,projects,concepts,meetings,resources}
+
+# 範例 index.md(只在不存在時寫,避免覆蓋 user 自己改的版本)
+if [ ! -e "${WIKI_ROOT}/index.md" ]; then
+  cat > "${WIKI_ROOT}/index.md" <<'EOF'
+# 開發工具 wiki — index
+
+> 這是 user(yazelin)的開發工具共用知識庫,Claude Code / Codex / Gemini 都讀這份。
+> Mori 有她自己的 wiki(spirits/mori/wiki/),不讀這份。
+
+## 結構
+
+- `raw/` — 不可變原料(papers / articles / repo READMEs / transcripts)
+- `wiki/` — agent 編譯的「百科」(扁平階層,主動 cross-link)
+  - `people/` — 認識的人 + 關係
+  - `projects/` — 進行中的專案
+  - `concepts/` — 抽象概念 / 框架 / 技術
+  - `meetings/` — 會議紀錄
+  - `resources/` — 工具 / 服務 / 帳號
+- `agents.md` — agent 用 wiki 的行為規則
+- `log.md` — agent 動過什麼的 audit trail
+
+## 規則
+
+- raw/ 永遠 immutable
+- wiki/ 由 agent 主動 maintain + cross-link
+- 改檔前 agent 必須 append log.md 行
+- 不抄 mori-journal / spirits/mori 內容過來(那是 Mori 的私人領域)
+
+EOF
+  echo "  ✓ 寫 ${WIKI_ROOT}/index.md"
+else
+  echo "  · ${WIKI_ROOT}/index.md 已存在,跳過"
+fi
+
+# 範例 agents.md (polyglot:Claude/Codex/Gemini 全讀這份)
+if [ ! -e "${WIKI_ROOT}/agents.md" ]; then
+  cat > "${WIKI_ROOT}/agents.md" <<'EOF'
+# Agent 用 wiki 的規則(polyglot)
+
+本檔被 Claude Code (CLAUDE.md) / Codex CLI (AGENTS.md) / Gemini CLI (GEMINI.md) symlink。
+任何 agent 進到 yazelin 的開發環境讀本檔。
+
+## 進來時
+
+1. **先讀 `~/wiki/index.md`** 拿全景目錄(單 context window 大小)
+2. 看 user 問題 → 從 index 找相關 wiki page → grep / Read 那幾 page → 拉進 context
+3. **不要一次全讀 wiki/**(會撐爆 context)
+
+## 累積知識
+
+當 user 跟你聊到值得記的事(新 project / 新人 / 新概念 / 新會議),你**可以主動** append 進 wiki:
+
+- 確定要寫 → 在對應 wiki/<category>/ 內建新 .md 或 append 既有
+- 在 log.md 末尾 append 「YYYY-MM-DD HH:MM agent=X action=Y target=Z」一行
+- 完成後跟 user 講你寫了什麼(透明)
+
+## 不要
+
+- ❌ 動 `raw/`(原料永久 immutable)
+- ❌ 抄 mori-journal / spirits/mori/ 內容過來(那是 Mori 的私人領域,不可公開化)
+- ❌ 刪 wiki page(append-only;真要砍找 user)
+- ❌ 用 agent 動過的事不寫 log.md
+
+## 風格
+
+- 詩意中文 + 工程具體性並存
+- 文件結尾 cross-link 相關 page `[[<page-name>]]`(Obsidian-style)
+- 每 page 第一行寫一句話 summary 給 LLM scan index 用
+
+EOF
+  echo "  ✓ 寫 ${WIKI_ROOT}/agents.md"
+else
+  echo "  · ${WIKI_ROOT}/agents.md 已存在,跳過"
+fi
+
+# 空 log.md
+if [ ! -e "${WIKI_ROOT}/log.md" ]; then
+  {
+    echo "# Wiki audit trail"
+    echo ""
+  } > "${WIKI_ROOT}/log.md"
+  echo "  ✓ 寫 ${WIKI_ROOT}/log.md"
+else
+  echo "  · ${WIKI_ROOT}/log.md 已存在,跳過"
+fi
+
+# Symlinks to 各 CLI
+echo ""
+echo ">>> Symlink agents.md 到各 AI CLI global instruction..."
+
+link_if_writable() {
+  local link_path="$1"
+  local target="$2"
+
+  mkdir -p "$(dirname "$link_path")"
+
+  if [ -e "$link_path" ] && [ ! -L "$link_path" ]; then
+    echo "  ⚠ $link_path exists 且非 symlink,跳過(請 user 自決)"
+    return
+  fi
+
+  ln -sfn "$target" "$link_path"
+  echo "  ✓ $link_path → $target"
+}
+
+link_if_writable "${HOME}/.claude/CLAUDE.md" "${WIKI_ROOT}/agents.md"
+link_if_writable "${HOME}/.codex/AGENTS.md" "${WIKI_ROOT}/agents.md"
+link_if_writable "${HOME}/.gemini/GEMINI.md" "${WIKI_ROOT}/agents.md"
+
+echo ""
+echo ">>> 完成!"
+echo ""
+echo "下一步:"
+echo "  1. 進 ~/wiki/ 開始寫(cd ~/wiki && \$EDITOR index.md)"
+echo "  2. 任何 AI CLI(Claude/Codex/Gemini)進你開發環境會自動讀 agents.md"
+echo "  3. 想加新 page:agent 會主動寫,or 你自己 mkdir wiki/<category>/<name>.md"
+echo ""


### PR DESCRIPTION
## Summary

**Wave 7 Ld** — User 開發工具共用 wiki(`~/wiki/`)的 setup script。跟 Mori 自己的內在 wiki(`spirits/mori/wiki/`)完全 decouple。

Claude Code / Codex CLI / Gemini CLI 透過 symlink 共用一份 `agents.md` polyglot 規則檔。

## Changes

- `scripts/install-knowledge-wiki.sh`(新,4.6KB,executable):
  - 建 `~/wiki/{raw/{articles,papers,readmes,transcripts}, wiki/{people,projects,concepts,meetings,resources}, index.md, agents.md, log.md}`
  - Symlink `~/.claude/CLAUDE.md` / `~/.codex/AGENTS.md` / `~/.gemini/GEMINI.md` 到 `~/wiki/agents.md`
  - Idempotent(重跑「已存在跳過」),既有非 symlink 檔警告 + 保留
- `docs/dev-knowledge-wiki.md`(新,~2.7KB):結構說明 + 跟 Mori wiki 的差異

## Design

- **跟 L-mori 完全 decouple** — agents.md 明文寫「不抄 spirits/mori 內容」
- **三家 AI CLI 共用** — symlink 同份 `agents.md`,polyglot 規則(中英文都讀得懂)
- **Karpathy LLM Wiki pattern** — raw/ + wiki/ + index.md + agents.md + log.md

## Test plan

- [x] `bash -n` syntax check pass
- [x] 兩輪 idempotent dry-run on TMPHOME
- [x] 既有非 symlink 檔 → 警告 + 保留(test 過)
- [x] 結構建對(raw + wiki 子目錄齊)
- [x] Symlink 三家對

## Manual

User 跑:`bash scripts/install-knowledge-wiki.sh` → `~/wiki/` 結構建好 + symlink 進各 CLI global instruction 檔。

🤖 Generated with [Claude Code](https://claude.com/claude-code)