### PR TITLE
feat(wiki): L-mori Mori 內在 wiki read side (Lm)

### DIFF
--- a/crates/mori-core/src/skill/mod.rs
+++ b/crates/mori-core/src/skill/mod.rs
@@ -188,6 +188,12 @@ mod read_file;
 // §9 P1 「時之鳥」K5:remind_me LLM tool dispatch path — 接 mori_time::ReminderService
 mod remind_me;
 
+// Wave 7 L-mori 記憶之森(Karpathy LLM Wiki pattern):read_wiki_page LLM tool
+// dispatch path。LLM 看 system prompt 開頭的 wiki/index.md 知道 page 清單,
+// 需要時呼叫此 skill 把 specific page 內容拉進 context。**純 READ** — 寫 wiki
+// 是 future work(annuli reflection / curator,需 yazelin per-dir auth)。
+mod read_wiki_page;
+
 // Stream I:Anthropic SKILL.md 格式 — 載入 `~/.mori/skills/<name>/SKILL.md`,
 // 把 markdown body 當 prompt-augmentation 給 LLM。對齊
 // https://agentskills.io/specification。D-light(只讀 body,不執行 scripts/)。
@@ -222,6 +228,7 @@ pub use paste_selection::PasteSelectionBackSkill;
 
 pub use fetch_url::FetchUrlSkill;
 pub use read_file::ReadFileSkill;
+pub use read_wiki_page::ReadWikiPageSkill;
 pub use remind_me::RemindMeSkill;
 
 pub use anthropic_skill::{

--- a/crates/mori-core/src/skill/read_wiki_page.rs
+++ b/crates/mori-core/src/skill/read_wiki_page.rs
@@ -1,0 +1,337 @@
+//! ReadWikiPageSkill — LLM 可呼叫的「讀 wiki page」工具(L-mori 記憶之森)。
+//!
+//! # 為什麼存在
+//!
+//! Wave 7 「L 記憶之森」(Karpathy LLM Wiki pattern):Mori 在
+//! `~/mori-universe/spirits/<name>/wiki/` 維護一份累積的內在百科。System prompt
+//! 注入 `wiki/index.md` 讓 LLM 知道**有哪些 page 可拉**;LLM 透過這個 skill 把
+//! specific page(`people/yazelin.md`、`projects/mori.md` ...)主動拉進 context。
+//!
+//! # 設計決策 — 為什麼 inline 讀檔
+//!
+//! `mori-tauri::wiki_reader` 已經有完整 read logic(graceful skip / path
+//! traversal 防護),但 **mori-core 不能 depend mori-tauri**(layer 反過來)。
+//! 兩個選擇:
+//!
+//! 1. 抽 `wiki_reader` 成新 leaf crate(對齊 `mori-file-loader` pattern)
+//! 2. **在 skill 內 inline 重寫 ~30 行**(對齊 既有 `slugify` / `remind_me` 內
+//!    self-contained helper pattern)
+//!
+//! 選 (2) — wiki reader logic 不到複雜需新 crate,且兩處邏輯 **必須一致**
+//! (path traversal 防護同 rule),重寫成本低 + 程式碼簡單。若 future 加更多
+//! wiki 操作(write / list),再抽 crate。
+//!
+//! # 行為
+//!
+//! - 吃 `{"page": "people/yazelin.md"}` 參數
+//! - resolve 路徑 + 防 path traversal(`..` segment / 絕對路徑 / canonicalize
+//!   後跳出 wiki_root → reject)
+//! - 讀 .md 內容回傳給 LLM
+//! - 失敗(不存在 / traversal / IO):`anyhow!` 往上拋
+//!
+//! # 平台 / 隱私
+//!
+//! 讀本機 vault → `ExecutionTarget::Local`。Wiki 內容可能含 user 個資(eg
+//! `people/yazelin.md`),但既然要餵回 LLM 做 multi-turn,`Privacy::Cloud`
+//! (user 自選 LocalOnly provider 即可)。
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use serde_json::Value;
+
+use super::{ExecutionTarget, Privacy, Skill, SkillOutput};
+use crate::context::Context;
+
+/// LLM 可呼叫的 wiki page reader skill。
+pub struct ReadWikiPageSkill {
+    vault_root: PathBuf,
+    spirit_name: String,
+}
+
+impl ReadWikiPageSkill {
+    pub fn new(vault_root: PathBuf, spirit_name: String) -> Self {
+        Self {
+            vault_root,
+            spirit_name,
+        }
+    }
+}
+
+#[async_trait]
+impl Skill for ReadWikiPageSkill {
+    fn name(&self) -> &'static str {
+        "read_wiki_page"
+    }
+
+    fn description(&self) -> &'static str {
+        "讀我的 wiki 內某一 page 進 context。page 是 wiki/ 內的相對路徑(eg \
+         'people/yazelin.md'、'concepts/transformer.md')。先看 system prompt \
+         開頭的 wiki index 找到 page name 再呼叫,不要亂猜路徑。"
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "string",
+                    "description": "wiki/ 內的相對路徑(.md 結尾)。範例:'people/yazelin.md'、'projects/mori.md'、'concepts/karpathy-llm-wiki.md'。"
+                }
+            },
+            "required": ["page"]
+        })
+    }
+
+    fn target_capability(&self) -> ExecutionTarget {
+        ExecutionTarget::Local
+    }
+
+    fn privacy(&self) -> Privacy {
+        Privacy::Cloud
+    }
+
+    async fn execute(&self, args: Value, _ctx: &Context) -> Result<SkillOutput> {
+        let page = args
+            .get("page")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("missing page"))?
+            .trim()
+            .to_string();
+        if page.is_empty() {
+            return Err(anyhow!("page is empty"));
+        }
+
+        tracing::info!(
+            spirit = %self.spirit_name,
+            page = %page,
+            "read_wiki_page skill"
+        );
+
+        let content = read_wiki_page_inline(&self.vault_root, &self.spirit_name, &page)
+            .map_err(|e| anyhow!("read_wiki_page failed: {e}"))?;
+
+        let chars = content.chars().count();
+        let bytes = content.len();
+
+        Ok(SkillOutput {
+            user_message: content.clone(),
+            data: Some(serde_json::json!({
+                "page": page,
+                "chars": chars,
+                "bytes": bytes,
+                "content": content,
+            })),
+        })
+    }
+}
+
+// ─── inline reader(對齊 mori-tauri::wiki_reader 的 path traversal 防護) ──
+
+#[derive(Debug, thiserror::Error)]
+enum InlineWikiError {
+    #[error("path traversal not allowed: {0}")]
+    PathTraversal(String),
+    #[error("page not found: {0}")]
+    NotFound(String),
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// 讀 `<vault_root>/<spirit_name>/wiki/<page_relative>` 全文。
+///
+/// 安全規則(同 `mori-tauri::wiki_reader::read_wiki_page`):
+/// - 空 page / 絕對路徑 / 含 `..` segment / Windows drive prefix → PathTraversal
+/// - canonicalize 後檔案必須仍 under wiki_root → 否則 PathTraversal(防 symlink)
+/// - 檔案不存在 → NotFound
+fn read_wiki_page_inline(
+    vault_root: &Path,
+    spirit_name: &str,
+    page_relative: &str,
+) -> Result<String, InlineWikiError> {
+    let wiki = vault_root.join(spirit_name).join("wiki");
+
+    if page_relative.is_empty() {
+        return Err(InlineWikiError::PathTraversal(page_relative.to_string()));
+    }
+    let pr_path = PathBuf::from(page_relative);
+    if pr_path.is_absolute() {
+        return Err(InlineWikiError::PathTraversal(page_relative.to_string()));
+    }
+    for component in pr_path.components() {
+        use std::path::Component;
+        match component {
+            Component::Normal(_) => {}
+            _ => return Err(InlineWikiError::PathTraversal(page_relative.to_string())),
+        }
+    }
+
+    let target = wiki.join(&pr_path);
+    if !target.exists() {
+        return Err(InlineWikiError::NotFound(page_relative.to_string()));
+    }
+
+    let wiki_canon = wiki.canonicalize().map_err(InlineWikiError::Io)?;
+    let target_canon = target.canonicalize().map_err(InlineWikiError::Io)?;
+    if !target_canon.starts_with(&wiki_canon) {
+        return Err(InlineWikiError::PathTraversal(page_relative.to_string()));
+    }
+
+    std::fs::read_to_string(&target_canon).map_err(InlineWikiError::Io)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Skill-level + inline reader unit tests。Wiki reader 主要 path traversal /
+    //! NotFound / 成功路徑在 mori-tauri::wiki_reader 也有對應 test,這邊複測
+    //! 一次因為 logic 是 duplicated(intentional, see module doc)。
+
+    use super::*;
+    use crate::context::Context;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn empty_context() -> Context {
+        Context::default()
+    }
+
+    /// 建一個 fake vault `<tmp>/<spirit>/wiki/`,return (tmpdir, vault_root, wiki_dir)。
+    fn make_vault(spirit: &str) -> (TempDir, PathBuf, PathBuf) {
+        let dir = TempDir::new().unwrap();
+        let vault_root = dir.path().to_path_buf();
+        let wiki = vault_root.join(spirit).join("wiki");
+        fs::create_dir_all(&wiki).unwrap();
+        (dir, vault_root, wiki)
+    }
+
+    #[tokio::test]
+    async fn read_wiki_page_skill_name_and_description() {
+        let skill = ReadWikiPageSkill::new(PathBuf::from("/tmp"), "mori".to_string());
+        assert_eq!(skill.name(), "read_wiki_page");
+        let desc = skill.description();
+        assert!(!desc.is_empty());
+        // description 必須提及 wiki / page 才能讓 LLM 知道何時叫
+        assert!(desc.contains("wiki"));
+        assert!(desc.contains("page"));
+    }
+
+    #[tokio::test]
+    async fn read_wiki_page_skill_parameters_schema_requires_page() {
+        let skill = ReadWikiPageSkill::new(PathBuf::from("/tmp"), "mori".to_string());
+        let schema = skill.parameters_schema();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["page"].is_object());
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v == "page"));
+    }
+
+    #[tokio::test]
+    async fn read_wiki_page_skill_returns_content() {
+        let (_tmp, vault_root, wiki) = make_vault("mori");
+        fs::create_dir_all(wiki.join("people")).unwrap();
+        fs::write(
+            wiki.join("people").join("yazelin.md"),
+            "# Yazelin\n\nMori 的 主要 user,住台北。\n",
+        )
+        .unwrap();
+
+        let skill = ReadWikiPageSkill::new(vault_root, "mori".to_string());
+        let args = serde_json::json!({ "page": "people/yazelin.md" });
+        let out = skill
+            .execute(args, &empty_context())
+            .await
+            .expect("read should succeed");
+
+        assert!(out.user_message.contains("Yazelin"));
+        assert!(out.user_message.contains("主要 user"));
+        let data = out.data.expect("data present");
+        assert_eq!(data["page"], "people/yazelin.md");
+        // chars > bytes for CJK content(UTF-8 3 bytes per CJK char)
+        assert!(data["chars"].as_u64().unwrap() > 0);
+        assert!(data["content"].as_str().unwrap().contains("Yazelin"));
+    }
+
+    #[tokio::test]
+    async fn read_wiki_page_skill_returns_error_for_missing_page_arg() {
+        let skill = ReadWikiPageSkill::new(PathBuf::from("/tmp"), "mori".to_string());
+        let args = serde_json::json!({});
+        let err = skill
+            .execute(args, &empty_context())
+            .await
+            .expect_err("missing page arg should err");
+        assert!(err.to_string().contains("missing page"));
+    }
+
+    #[tokio::test]
+    async fn read_wiki_page_skill_errors_on_empty_page() {
+        let skill = ReadWikiPageSkill::new(PathBuf::from("/tmp"), "mori".to_string());
+        let args = serde_json::json!({ "page": "   " });
+        let err = skill
+            .execute(args, &empty_context())
+            .await
+            .expect_err("empty page should err");
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[tokio::test]
+    async fn read_wiki_page_skill_rejects_path_traversal() {
+        let (_tmp, vault_root, wiki) = make_vault("mori");
+        // 造 secret file 在 vault_root 外
+        fs::write(vault_root.parent().unwrap().join("secret.txt"), "TOP SECRET\n")
+            .unwrap();
+        fs::write(wiki.join("decoy.md"), "decoy\n").unwrap();
+
+        let skill = ReadWikiPageSkill::new(vault_root.clone(), "mori".to_string());
+
+        // `..` traversal
+        let args = serde_json::json!({ "page": "../../secret.txt" });
+        let err = skill
+            .execute(args, &empty_context())
+            .await
+            .expect_err("traversal should err");
+        assert!(
+            err.to_string().contains("traversal"),
+            "expected traversal err, got: {err}"
+        );
+
+        // 絕對路徑
+        let args = serde_json::json!({ "page": "/etc/passwd" });
+        let err = skill
+            .execute(args, &empty_context())
+            .await
+            .expect_err("absolute path should err");
+        assert!(err.to_string().contains("traversal"));
+    }
+
+    #[tokio::test]
+    async fn read_wiki_page_skill_returns_not_found_for_missing_page() {
+        let (_tmp, vault_root, _wiki) = make_vault("mori");
+        let skill = ReadWikiPageSkill::new(vault_root, "mori".to_string());
+        let args = serde_json::json!({ "page": "people/nonexistent.md" });
+        let err = skill
+            .execute(args, &empty_context())
+            .await
+            .expect_err("missing page should err");
+        assert!(
+            err.to_string().contains("not found") || err.to_string().contains("NotFound"),
+            "expected NotFound, got: {err}"
+        );
+    }
+
+    #[test]
+    fn inline_reader_handles_nested_pages() {
+        let (_tmp, vault_root, wiki) = make_vault("mori");
+        fs::create_dir_all(wiki.join("concepts").join("ml")).unwrap();
+        fs::write(
+            wiki.join("concepts").join("ml").join("transformer.md"),
+            "Attention is all you need.\n",
+        )
+        .unwrap();
+
+        let got =
+            read_wiki_page_inline(&vault_root, "mori", "concepts/ml/transformer.md")
+                .expect("should read nested page");
+        assert!(got.contains("Attention"));
+    }
+}

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -39,6 +39,11 @@ mod transcribe_cmds;
 mod tts;
 mod wake_sound;
 mod wake_word;
+// Wave 7 L-mori 記憶之森 — read `~/mori-universe/spirits/<name>/wiki/` 結構,
+// 把 wiki/index.md 注入 system prompt + 暴露 read_wiki_page LLM skill。
+// 純 READ;寫 wiki 是 future work(annuli reflection / curator,需 yazelin
+// per-dir auth)。
+mod wiki_reader;
 
 use std::sync::Arc;
 
@@ -55,8 +60,8 @@ use mori_core::paste::PasteController;
 use mori_core::skill::PasteSelectionBackSkill;
 use mori_core::skill::{
     ComposeSkill, EditMemorySkill, FetchUrlSkill, ForgetMemorySkill, PolishSkill,
-    ReadFileSkill, RecallMemorySkill, RememberSkill, RemindMeSkill, SetModeSkill, SkillRegistry,
-    SummarizeSkill, TranslateSkill,
+    ReadFileSkill, ReadWikiPageSkill, RecallMemorySkill, RememberSkill, RemindMeSkill,
+    SetModeSkill, SkillRegistry, SummarizeSkill, TranslateSkill,
 };
 use mori_time::{Notifier, ReminderService};
 use mori_core::{PHASE, VERSION};
@@ -2165,6 +2170,18 @@ async fn skills_list(
     if let Some(svc) = app.try_state::<Arc<ReminderService>>() {
         registry.register(Arc::new(RemindMeSkill::new(svc.inner().clone())));
     }
+    // Wave 7 L-mori 記憶之森:read_wiki_page LLM skill — UI Skills tab 也要列出。
+    // vault_root 跟 spirit_name 從 annuli config 拿(spirit_name 預設 "mori"),
+    // vault_root 失敗(沒 HOME)→ 跳過註冊(LLM 拿不到 skill,但 UI 不爆)。
+    if let Some(vault_root) = default_vault_root() {
+        let cfg = annuli_config::AnnuliConfig::load(&mori_dir().join("config.json"));
+        let spirit = if cfg.spirit_name.is_empty() {
+            "mori".to_string()
+        } else {
+            cfg.spirit_name
+        };
+        registry.register(Arc::new(ReadWikiPageSkill::new(vault_root, spirit)));
+    }
     registry.register(Arc::new(RememberSkill::new(mem_arc.clone())));
     registry.register(Arc::new(RecallMemorySkill::new(mem_arc.clone())));
     registry.register(Arc::new(ForgetMemorySkill::new(mem_arc.clone())));
@@ -3369,20 +3386,58 @@ async fn run_agent_pipeline(
         // spirit_name 從 annuli config 拿(default "mori"),空字串退到 "mori"。
         // 注意:這條走 vault 直接讀檔(不經 annuli HTTP)— vault 是 source of truth,
         // annuli 是 consumer 之一(跟 mori-desktop 同層讀同一份 vault,不互相依賴)。
-        let soul_text = {
+        let (vault_root_opt, spirit_name_for_wiki) = {
             let cfg = annuli_config::AnnuliConfig::load(&mori_dir().join("config.json"));
             let spirit = if cfg.spirit_name.is_empty() {
                 "mori".to_string()
             } else {
                 cfg.spirit_name
             };
-            default_vault_root().and_then(|root| load_soul_content(&root, &spirit))
+            (default_vault_root(), spirit)
         };
+        let soul_text = vault_root_opt
+            .as_deref()
+            .and_then(|root| load_soul_content(root, &spirit_name_for_wiki));
         let mut system_prompt = if body_expanded.trim().is_empty() {
             build_system_prompt(soul_text.as_deref(), &memory_index, &ctx)
         } else {
             format!("{}\n\n---\n\n{}", body_expanded, context_section)
         };
+
+        // Wave 7 L-mori 記憶之森(Karpathy LLM Wiki pattern)— 把 wiki/index.md
+        // 注入 system prompt,讓 LLM 知道 Mori 有哪些累積的 wiki page。需要拉
+        // specific page 時走 `read_wiki_page` skill。Wiki 還沒建(index.md 不存在
+        // / 空)→ 整段 skip,行為不破(graceful)。
+        //
+        // 注入點放這(build_system_prompt 之後、MCP append 之前):
+        // - 兩條 prompt branch(SOUL + build_system_prompt vs profile body_expanded)
+        //   都要吃到 → 在 caller append 而非進 build_system_prompt 參數
+        // - 在 MCP tools 之前 → wiki 是「內在知識」layer,MCP 是「外部工具」layer
+        if let Some(vault_root) = vault_root_opt.as_deref() {
+            if let Some(index) = wiki_reader::read_index(vault_root, &spirit_name_for_wiki) {
+                system_prompt.push_str(
+                    "\n\n# 我的 wiki(主動拉感興趣的 page)\n\n",
+                );
+                system_prompt.push_str(
+                    "下面是我累積的內在知識索引(`~/mori-universe/spirits/<name>/wiki/index.md`)。\
+                     看到 user 問題跟某個 page 相關時,呼叫 `read_wiki_page(page)` 把該 page \
+                     內容拉進 context 再答。page 是 wiki/ 內的相對路徑(eg \
+                     `people/yazelin.md`、`projects/mori.md`)。\n\n",
+                );
+                system_prompt.push_str(index.trim_end());
+                system_prompt.push_str("\n");
+
+                // AGENTS.md 是 user 寫的「Mori 怎麼用 wiki」規則,有就附在 index 後面。
+                if let Some(agents_md) =
+                    wiki_reader::read_agents_md(vault_root, &spirit_name_for_wiki)
+                {
+                    system_prompt.push_str("\n## Wiki 使用規則(AGENTS.md)\n\n");
+                    system_prompt.push_str(agents_md.trim_end());
+                    system_prompt.push_str("\n");
+                }
+                system_prompt.push_str("\n");
+            }
+        }
 
         // Wave 6 MCP-2:把目前連上的 MCP server / tool 描述附加到 system prompt 末尾。
         // - 不動 `build_system_prompt` 簽名,改在 caller append(讓 mori-core 不知道
@@ -3523,6 +3578,24 @@ async fn run_agent_pipeline(
         // LLM 知道工具存在但 reach 不到實作(SkillRegistry::dispatch 找不到 name)。
         if allows("read_file_text") {
             registry.register(Arc::new(mori_core::skill::ReadFileSkill));
+        }
+        // Wave 7 L-mori 記憶之森:`read_wiki_page` LLM tool dispatch 路徑。
+        // System prompt 上方已注入 wiki/index.md 內容讓 LLM 知道有哪些 page,
+        // 但沒這個 register LLM 叫 read_wiki_page 會吃 "unknown skill" error。
+        // vault_root 從 default_vault_root() 拿,spirit_name 從 annuli config
+        // 拿(同 SOUL 注入路徑)— 都失敗(沒 HOME)→ 跳過註冊。
+        if allows("read_wiki_page") {
+            if let Some(vault_root) = default_vault_root() {
+                let cfg = annuli_config::AnnuliConfig::load(&mori_dir().join("config.json"));
+                let spirit = if cfg.spirit_name.is_empty() {
+                    "mori".to_string()
+                } else {
+                    cfg.spirit_name
+                };
+                registry.register(Arc::new(mori_core::skill::ReadWikiPageSkill::new(
+                    vault_root, spirit,
+                )));
+            }
         }
         // §9 P1 「時之鳥」K5 — `remind_me` LLM tool dispatch 路徑。同上,system prompt
         // 已注入工具描述,沒 register LLM 叫 remind_me 會吃 "unknown skill" error。
@@ -4619,6 +4692,26 @@ fn build_system_prompt(soul: Option<&str>, memory_index: &str, ctx: &MoriContext
     );
     prompt.push_str(
         "  • 讀失敗會回 error message,**不要重試**或編造內容 — 直接告訴 user 失敗了\n\n",
+    );
+
+    // Wave 7 L-mori 記憶之森 — read_wiki_page。LLM 看 system prompt 上方的
+    // 「我的 wiki」section(index.md 內容)找到相關 page name 再呼叫。
+    prompt.push_str("**read_wiki_page(page)**:讀我的 wiki 內的某一 page 進 context。\n");
+    prompt.push_str(
+        "  • 觸發:user 問題跟「我的 wiki」section 列的某個 page 相關時,先拉該 page \
+         內容再答(對齊 Karpathy LLM Wiki pattern)\n",
+    );
+    prompt.push_str(
+        "  • page 是 wiki/ 內的相對路徑(eg `people/yazelin.md`、`projects/mori.md`、\
+         `concepts/transformer.md`)\n",
+    );
+    prompt.push_str(
+        "  • **wiki section 不存在時**(我剛被召喚出來、wiki 還沒建)— 此工具不會出現在 \
+         system prompt;當 prompt 沒「我的 wiki」段時別硬叫\n",
+    );
+    prompt.push_str(
+        "  • 一輪可叫多次(若多個 page 相關,各拉一次)。但只在必要時叫 — \
+         index 看不出相關的 page 別硬挖\n\n",
     );
 
     // §9 P1 「時之鳥」K5 — remind_me 工具描述。LLM 看 user 講「X 點提醒我 Y」「等等

--- a/crates/mori-tauri/src/wiki_reader.rs
+++ b/crates/mori-tauri/src/wiki_reader.rs
@@ -1,0 +1,299 @@
+//! L-mori — read `~/mori-universe/spirits/<name>/wiki/` Karpathy LLM Wiki 結構。
+//!
+//! # 為什麼存在
+//!
+//! Wave 7 「L 記憶之森」(Karpathy LLM Wiki pattern)在 mori-desktop 側的整合。
+//! Mori 在 `~/mori-universe/spirits/<name>/wiki/` 維護一份累積的內在百科 — 每個
+//! page 是 .md 檔(`people/yazelin.md`、`projects/mori.md`、`concepts/...`)。
+//! 啟動時讀 `wiki/index.md` 進 system prompt 讓 LLM 知道**有哪些 page 可拉**;
+//! LLM 需要時主動呼叫 `read_wiki_page(page)` skill 把 specific page 內容拉進
+//! context window。
+//!
+//! # 範圍 — 純 READ
+//!
+//! 本 module **read-only**。**不寫 vault**。對應 mori-journal CLAUDE.md 硬規矩 3
+//! 「identity/ / memories/ 禁止 ghost-write」— wiki/ 雖然不是 identity / memories
+//! 但同層次,屬 Mori 的「內在生命」,要寫先 explicit re-authorize。後續 Wave 8
+//! annuli reflection / curator 自動編譯 wiki page 是 future work(needs yazelin
+//! per-dir auth)— **本 stream 不碰**。
+//!
+//! # 預期 wiki 結構(per `mori-jarvis-direction.md §6`)
+//!
+//! ```text
+//! ~/mori-universe/spirits/<spirit>/wiki/
+//! ├── raw/                  # 不可變來源(conversations / articles / meetings)
+//! ├── wiki/                 # LLM 編譯的「百科」(flat 階層 people/projects/...)
+//! ├── index.md              # 入口:列全部 page + 短描述(單 context window 大小)
+//! ├── AGENTS.md             # Mori 怎麼用 wiki 的規則(user 可改)
+//! └── log.md                # Mori 動過什麼的 audit trail
+//! ```
+//!
+//! # graceful skip
+//!
+//! - 第一次跑 mori-desktop:wiki/ 還沒建 → [`read_index`] 回 `None`,system prompt
+//!   整段不 emit,行為不破。
+//! - User 後續 mkdir + 寫 index.md → 下次啟動自動讀到。
+//! - 空 index.md → 同 `None`(沒內容塞 prompt 沒意義)。
+//!
+//! # path traversal 防護
+//!
+//! [`read_wiki_page`] resolve 完路徑 **必須留在 wiki/ 內**;
+//! `../../../../etc/passwd`、絕對路徑、symlink 跳出 wiki/ → `WikiError::PathTraversal`。
+
+use std::path::{Path, PathBuf};
+
+/// `<vault_root>/<spirit_name>/wiki/` 的絕對路徑。
+///
+/// 不檢查存在性 — caller 用 [`read_index`] / [`read_wiki_page`] 個別 dispatch。
+pub fn wiki_root(vault_root: &Path, spirit_name: &str) -> PathBuf {
+    vault_root.join(spirit_name).join("wiki")
+}
+
+/// 讀 `wiki/index.md` 全文。
+///
+/// 行為:
+/// - 不存在 / read 失敗 → `None`
+/// - 空檔(trim 後 empty)→ `None`(沒內容塞 system prompt 沒意義)
+/// - 有內容 → `Some(content)`
+///
+/// 取 graceful skip 設計:wiki 沒建好不該擋 startup,LLM 多/少這段都能跑。
+pub fn read_index(vault_root: &Path, spirit_name: &str) -> Option<String> {
+    let path = wiki_root(vault_root, spirit_name).join("index.md");
+    read_md_file(&path)
+}
+
+/// 讀 `wiki/AGENTS.md` 全文 — Mori 怎麼用 wiki 的規則(user 可改)。
+///
+/// 同 [`read_index`] graceful 行為:不存在 / 空 → `None`。
+pub fn read_agents_md(vault_root: &Path, spirit_name: &str) -> Option<String> {
+    let path = wiki_root(vault_root, spirit_name).join("AGENTS.md");
+    read_md_file(&path)
+}
+
+/// 讀 `wiki/<page_relative>` 內容。
+///
+/// `page_relative` 是 wiki/ 內的相對路徑(eg `"people/yazelin.md"`、
+/// `"concepts/transformer.md"`)。
+///
+/// # 安全性(path traversal 防護)
+///
+/// 1. resolve 後路徑 **必須留在 wiki_root() 之下**。`../../etc/passwd` /
+///    絕對路徑 / symlink 跳出 → [`WikiError::PathTraversal`]。
+/// 2. canonicalize 前先做 string-level reject(`..` segments 直接拒);
+///    canonicalize 需要檔案存在,缺檔的 path traversal 也擋得住。
+///
+/// # 錯誤
+///
+/// - [`WikiError::PathTraversal`]:path 含 `..` 或 resolved 跳出 wiki_root
+/// - [`WikiError::NotFound`]:檔案不存在
+/// - [`WikiError::Io`]:read 失敗(權限 / IO error)
+///
+/// 註:目前 mori-core 的 `ReadWikiPageSkill` 走 self-contained inline copy
+/// (避免 mori-core depend mori-tauri 的反向依賴)。這個 public function 是
+/// 留給未來 Tauri command(eg `read_wiki_page_cmd` 給前端 JS)/ admin 工具用,
+/// 所以掛 `#[allow(dead_code)]` 對齊 `fetch_canonical_soul` 同 pattern。
+#[allow(dead_code)]
+pub fn read_wiki_page(
+    vault_root: &Path,
+    spirit_name: &str,
+    page_relative: &str,
+) -> Result<String, WikiError> {
+    let wiki = wiki_root(vault_root, spirit_name);
+
+    // String-level reject:含 `..` segment、絕對路徑、Windows drive letter 一律拒。
+    // 在 canonicalize 前做 — 缺檔的 traversal attempt 也擋得住。
+    if page_relative.is_empty() {
+        return Err(WikiError::PathTraversal(page_relative.to_string()));
+    }
+    let pr_path = PathBuf::from(page_relative);
+    if pr_path.is_absolute() {
+        return Err(WikiError::PathTraversal(page_relative.to_string()));
+    }
+    for component in pr_path.components() {
+        use std::path::Component;
+        match component {
+            Component::Normal(_) => {}
+            // ParentDir = `..`、RootDir = `/`、Prefix = `C:` 等都拒
+            _ => return Err(WikiError::PathTraversal(page_relative.to_string())),
+        }
+    }
+
+    let target = wiki.join(&pr_path);
+
+    if !target.exists() {
+        return Err(WikiError::NotFound(page_relative.to_string()));
+    }
+
+    // canonicalize 雙保險 — 防 symlink 跳出 wiki_root。wiki_root 不存在會 fail,
+    // 但走到這 target 存在 + target 一定 under wiki_root.join(...),所以 wiki_root
+    // 也存在。
+    let wiki_canon = wiki
+        .canonicalize()
+        .map_err(WikiError::Io)?;
+    let target_canon = target.canonicalize().map_err(WikiError::Io)?;
+    if !target_canon.starts_with(&wiki_canon) {
+        return Err(WikiError::PathTraversal(page_relative.to_string()));
+    }
+
+    std::fs::read_to_string(&target_canon).map_err(WikiError::Io)
+}
+
+/// 讀 .md 檔的共用 helper:不存在 / 失敗 / 空 → `None`。
+fn read_md_file(path: &Path) -> Option<String> {
+    match std::fs::read_to_string(path) {
+        Ok(s) if !s.trim().is_empty() => Some(s),
+        Ok(_) => {
+            tracing::debug!(
+                path = %path.display(),
+                "wiki .md file exists but is empty, treating as missing"
+            );
+            None
+        }
+        Err(e) => {
+            tracing::debug!(
+                path = %path.display(),
+                error = %e,
+                "wiki .md not readable"
+            );
+            None
+        }
+    }
+}
+
+/// `read_wiki_page` 的錯誤型別。同上,留 public 給未來 Tauri command。
+#[allow(dead_code)]
+#[derive(Debug, thiserror::Error)]
+pub enum WikiError {
+    #[error("path traversal not allowed: {0}")]
+    PathTraversal(String),
+    #[error("page not found: {0}")]
+    NotFound(String),
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// 建一個 fake vault `vault_root/<spirit>/wiki/` + 內部結構,給 tests 用。
+    fn make_vault(spirit: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let wiki = dir.path().join(spirit).join("wiki");
+        fs::create_dir_all(&wiki).expect("mkdir wiki");
+        (dir, wiki)
+    }
+
+    #[test]
+    fn wiki_root_returns_expected_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let got = wiki_root(dir.path(), "mori");
+        assert_eq!(got, dir.path().join("mori").join("wiki"));
+    }
+
+    #[test]
+    fn read_index_returns_none_when_missing() {
+        let (dir, _) = make_vault("mori");
+        // 沒寫 index.md → None
+        let got = read_index(dir.path(), "mori");
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn read_index_returns_content_when_exists() {
+        let (dir, wiki) = make_vault("mori");
+        fs::write(
+            wiki.join("index.md"),
+            "# Mori 的 wiki index\n\n- people/yazelin.md — 主要 user\n",
+        )
+        .unwrap();
+
+        let got = read_index(dir.path(), "mori").expect("should read index");
+        assert!(got.contains("Mori 的 wiki index"));
+        assert!(got.contains("people/yazelin.md"));
+    }
+
+    #[test]
+    fn read_index_returns_none_for_empty_file() {
+        let (dir, wiki) = make_vault("mori");
+        fs::write(wiki.join("index.md"), "   \n\n  \n").unwrap();
+        // trim 後 empty → None(沒內容塞 system prompt 沒意義)
+        assert!(read_index(dir.path(), "mori").is_none());
+    }
+
+    #[test]
+    fn read_agents_md_returns_content_when_exists() {
+        let (dir, wiki) = make_vault("mori");
+        fs::write(
+            wiki.join("AGENTS.md"),
+            "# Wiki 使用規則\n\n當 user 問到 X 時,先讀 wiki/X.md\n",
+        )
+        .unwrap();
+
+        let got = read_agents_md(dir.path(), "mori").expect("should read AGENTS");
+        assert!(got.contains("Wiki 使用規則"));
+    }
+
+    #[test]
+    fn read_agents_md_returns_none_when_missing() {
+        let (dir, _) = make_vault("mori");
+        assert!(read_agents_md(dir.path(), "mori").is_none());
+    }
+
+    #[test]
+    fn read_wiki_page_returns_content() {
+        let (dir, wiki) = make_vault("mori");
+        fs::create_dir_all(wiki.join("people")).unwrap();
+        fs::write(
+            wiki.join("people").join("yazelin.md"),
+            "# Yazelin\n\nMori 的 主要 user。\n",
+        )
+        .unwrap();
+
+        let got = read_wiki_page(dir.path(), "mori", "people/yazelin.md")
+            .expect("should read page");
+        assert!(got.contains("Yazelin"));
+        assert!(got.contains("主要 user"));
+    }
+
+    #[test]
+    fn read_wiki_page_rejects_path_traversal() {
+        let (dir, wiki) = make_vault("mori");
+        // 在 vault_root 外造一個 secret 檔案。
+        fs::write(dir.path().join("secret.txt"), "TOP SECRET\n").unwrap();
+        // 假裝 wiki/ 下也有 dummy 讓 wiki 存在(canonicalize 可走)
+        fs::write(wiki.join("decoy.md"), "decoy\n").unwrap();
+
+        // `../../secret.txt` — 應該拒(`..` segment 直接拒)
+        let err = read_wiki_page(dir.path(), "mori", "../../secret.txt")
+            .expect_err("should reject path traversal");
+        assert!(matches!(err, WikiError::PathTraversal(_)));
+
+        // `../../../etc/passwd` — 同
+        let err = read_wiki_page(dir.path(), "mori", "../../../etc/passwd")
+            .expect_err("should reject path traversal");
+        assert!(matches!(err, WikiError::PathTraversal(_)));
+
+        // 絕對路徑 — 拒
+        let err = read_wiki_page(dir.path(), "mori", "/etc/passwd")
+            .expect_err("should reject absolute path");
+        assert!(matches!(err, WikiError::PathTraversal(_)));
+    }
+
+    #[test]
+    fn read_wiki_page_returns_not_found_for_missing() {
+        let (dir, _) = make_vault("mori");
+        let err = read_wiki_page(dir.path(), "mori", "people/nonexistent.md")
+            .expect_err("missing page should err");
+        assert!(matches!(err, WikiError::NotFound(_)));
+    }
+
+    #[test]
+    fn read_wiki_page_rejects_empty_relative() {
+        let (dir, _) = make_vault("mori");
+        let err = read_wiki_page(dir.path(), "mori", "")
+            .expect_err("empty page_relative should err");
+        assert!(matches!(err, WikiError::PathTraversal(_)));
+    }
+}

--- a/docs/wiki-structure.md
+++ b/docs/wiki-structure.md
@@ -1,0 +1,81 @@
+# Mori 的內在 wiki(L-mori 記憶之森)
+
+Mori 在 `~/mori-universe/spirits/<name>/wiki/` 維護一份內在知識庫 — Karpathy LLM Wiki 風格的累積百科。對齊 §6 章「記憶之森」設計:Mori 不是無記憶 chatbot,而是有連續、可成長的內在世界。
+
+## 概念
+
+每個 page 是一份 `.md` 檔(`people/yazelin.md`、`projects/mori.md`、`concepts/transformer.md`)。`wiki/index.md` 列出所有 page + 短描述 — **單 context window 大小**,啟動時整段塞進 system prompt。
+
+LLM 看到 index 後,需要時主動呼叫 `read_wiki_page(page)` skill 把 specific page 拉進 context window 再答 — 不是「把整本 wiki 塞 prompt」,而是「LLM 主動翻字典」的 pattern(Karpathy LLM Wiki 原始設計)。
+
+## 結構
+
+```text
+~/mori-universe/spirits/<spirit>/wiki/
+├── raw/                          # 不可變來源(yazelin 跟 Mori 累積)
+│   ├── conversations/            # annuli events 摘要
+│   ├── articles/                 # 網頁 clip
+│   └── meetings/                 # 會議筆記
+├── wiki/                         # LLM 編譯的「百科」(flat 階層)
+│   ├── people/                   # 人物 — yazelin.md / mori.md / ...
+│   ├── projects/                 # 專案 — mori-desktop.md / annuli.md / ...
+│   ├── concepts/                 # 概念 — transformer.md / karpathy-llm-wiki.md / ...
+│   ├── meetings/                 # 會議
+│   └── resources/                # 資源 / 引用
+├── index.md                      # 入口:列全部 page + 短描述
+├── AGENTS.md                     # Mori 怎麼用 wiki 的規則(user 可改)
+└── log.md                        # Mori 動過 wiki 的 audit trail
+```
+
+`raw/` 是「原始材料」(不可變);`wiki/` 是「LLM 編譯後的百科」。兩層分開讓未來 annuli 可以 re-compile 而不掉資料。
+
+## 怎麼建?
+
+第一次跑 mori-desktop 不會自動建 wiki — 尊重 user 對 vault 的所有權,Mori 不 ghost-write。User 自己 mkdir + 寫:
+
+```bash
+mkdir -p ~/mori-universe/spirits/mori/wiki/{raw,wiki/{people,projects,concepts,meetings,resources}}
+
+cat > ~/mori-universe/spirits/mori/wiki/index.md <<'EOF'
+# Mori 的 wiki index
+
+主要 page:
+
+- `people/yazelin.md` — 我的主要 user
+- `projects/mori-desktop.md` — Mori 自己的身體 / 桌面 GUI repo
+- `projects/annuli.md` — 反思引擎 / 年輪系統
+- `concepts/karpathy-llm-wiki.md` — LLM Wiki 設計來源
+EOF
+
+cat > ~/mori-universe/spirits/mori/wiki/AGENTS.md <<'EOF'
+# Wiki 使用規則
+
+- 看到 user 問題涉及 wiki 列出的 page,先拉該 page 再答,別憑空回
+- 沒對應 page 時誠實說「我的 wiki 還沒有這個 page」,不要硬編
+- 不要在每輪都拉一堆 page — 只拉真的相關的
+EOF
+```
+
+之後 Mori 啟動時自動讀 `index.md` 進 system prompt。LLM 看到後可呼叫 `read_wiki_page(page)` 拉特定 page 進 context window。
+
+## 安全 / 邊界
+
+- **純 READ**:mori-desktop 端只**讀** wiki,不寫。User 完全掌控 wiki 內容(對齊 CLAUDE.md 硬規矩 2「User-owned data」+ 硬規矩 3「identity / memories 禁止 ghost-write」)
+- **Path traversal 防護**:`read_wiki_page` 的 `page` 參數含 `..` segment / 絕對路徑 / canonicalize 後跳出 wiki/ 一律拒(`WikiError::PathTraversal`)
+- **graceful skip**:wiki 沒建(index.md 不存在 / 空)→ system prompt 整段不 emit,LLM 不會看到 `read_wiki_page` 工具描述,行為跟 wiki 系統不存在時一樣
+
+## Mori 怎麼 maintain wiki?
+
+**目前 read-only**。Wave 8 + 規劃:
+
+- **annuli reflection**(自動編譯):annuli 從 events / rings / digests 編譯成 wiki page(eg user 講話夠多次「我喜歡 X」就建 / 更新 `people/<user>.md`「偏好」段)— 需 yazelin **per-dir explicit auth**(對齊 mori-journal CLAUDE.md 硬規矩 3 的寫入邊界)
+- **curator**(LLM 主動 review):annuli curator layer 定期讀 raw/ + 既有 wiki/,提出 update / refactor 建議(同樣 needs yazelin 確認 + 走 audit trail `log.md`)
+
+兩件事都是 future work;**本 stream(Wave 7)只 wire 讀路徑**,讓 LLM 能用 wiki 但不能改 wiki。
+
+## 相關檔案
+
+- `crates/mori-tauri/src/wiki_reader.rs` — 讀 wiki 結構(`read_index` / `read_agents_md` / `read_wiki_page` + `WikiError`)
+- `crates/mori-core/src/skill/read_wiki_page.rs` — LLM-callable `read_wiki_page` skill
+- `crates/mori-tauri/src/main.rs::run_agent_pipeline` — system prompt 注入點 + skill 註冊
+- `crates/mori-tauri/src/soul_distribution.rs` — 對比:SOUL.md 走 ensure-write,wiki/ 走 read-only


### PR DESCRIPTION
## Summary

**Wave 7 Lm** — Mori 的內在 wiki(`spirits/<name>/wiki/`)mori-desktop 端 read integration。Karpathy LLM Wiki pattern。**Read-only**(不寫 vault,per mori-journal CLAUDE.md 硬規矩)。

Mori 啟動時讀 `wiki/index.md` 進 system prompt,LLM 看到後可叫 `read_wiki_page(page)` 拉特定 page 進 context。

## Changes

- `crates/mori-tauri/src/wiki_reader.rs`(新):`read_index` / `read_agents_md` / `read_wiki_page` + `WikiError` thiserror,graceful skip + path traversal 防護
- `crates/mori-core/src/skill/read_wiki_page.rs`(新):`ReadWikiPageSkill` impl Skill,inline reader 避免 mori-core depend mori-tauri 反向依賴
- `crates/mori-core/src/skill/mod.rs`:+ mod + exports
- `crates/mori-tauri/src/main.rs`:
  - mod wiki_reader
  - 兩處 SkillRegistry 註冊 ReadWikiPageSkill(agent loop `allows("read_wiki_page")` gate + skills_list 無條件)
  - system prompt 注入 wiki index(`build_system_prompt` 後 / MCP 前 append)
  - 加 read_wiki_page tool 描述到 build_system_prompt
- `docs/wiki-structure.md`(新):wiki 結構 / 怎麼建 / 安全邊界 / future 設計

## Design

- **Read-only 邊界**:對齊 mori-journal CLAUDE.md 硬規矩 3(identity / memories 禁止 ghost-write)— mori-desktop 不寫 vault。寫 wiki 是 future work(annuli reflection / curator,需 yazelin per-dir auth)
- **Graceful skip**:wiki/ 未建(index.md 不存在 / 空)→ system prompt 整段不 emit;vault_root 失敗(沒 HOME)→ 跳過 skill 註冊。startup 不破
- **Path traversal 防護**:string-level reject(`..` segment / 絕對路徑 / Windows drive prefix)+ canonicalize 後 starts_with(wiki_root) 雙保險(防 symlink)
- **Inline reader**:read_wiki_page.rs 內 reader logic 對齊既有 slugify self-contained pattern,避免反向 dep
- 跟 Ld (#99) **完全 decouple** — Ld 在 `~/wiki/` 是 user 開發工具 wiki,Lm 在 `spirits/mori/wiki/` 是 Mori 內在 wiki

## Test plan

- [x] **18 new tests**:
  - mori-tauri wiki_reader:10
  - mori-core ReadWikiPageSkill:8
- [x] mori-core:**267 passed**(含 8 新增)
- [x] mori-tauri:**129 passed**(含 10 新增)
- [x] cargo check workspace clean
- [x] verify.sh 全綠

## Manual

User 建 wiki:
```bash
mkdir -p ~/mori-universe/spirits/mori/wiki/{raw,wiki/{people,projects,concepts,meetings,resources}}
echo '# Mori 的 wiki' > ~/mori-universe/spirits/mori/wiki/index.md
```
重啟 Mori → LLM 看到 wiki index + 可叫 `read_wiki_page("people/yazelin.md")` 之類。

## Known follow-up

- **寫 wiki 由 annuli reflection / curator 做**(需 yazelin per-dir auth on `spirits/mori/wiki/`)— 本 PR 範圍外
- mori-tauri `pub fn read_wiki_page` 目前無 caller(skill 走 inline copy),`#[allow(dead_code)]` 留給未來 Tauri command / admin tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)