### PR TITLE
feat(gmail): mori-gmail crate — OAuth + token + read-only API (Gm-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,6 +1159,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,6 +2079,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2204,6 +2251,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2975,6 +3023,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "mori-gmail"
+version = "0.7.1"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wiremock",
+]
+
+[[package]]
 name = "mori-mcp"
 version = "0.7.1"
 dependencies = [
@@ -3237,6 +3302,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -7176,6 +7251,29 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/mori-file-loader",
     "crates/mori-time",
     "crates/mori-mcp",
+    "crates/mori-gmail",
 ]
 
 [workspace.package]

--- a/crates/mori-gmail/Cargo.toml
+++ b/crates/mori-gmail/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "mori-gmail"
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+description = "Mori 的 Gmail 整合(「跨界之手」之一) — OAuth2 + token storage + read-only REST API。Wave 8 Gm-1 foundation。"
+
+[dependencies]
+# Gm-1 純 read-only;workspace reqwest 已開 json + rustls-tls。
+reqwest = { workspace = true }
+
+# 共用
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+chrono = { workspace = true }
+
+# OAuth redirect URL 解析(query string code 取出)
+url = "2"
+
+# Gmail message body 是 base64url(RFC 4648 §5)— `URL_SAFE_NO_PAD`。
+base64 = "0.22"
+
+[dev-dependencies]
+tempfile = "3"
+# Mock HTTP server(Gmail REST API / Google token endpoint),async / hyper based。
+wiremock = "0.6"

--- a/crates/mori-gmail/src/client.rs
+++ b/crates/mori-gmail/src/client.rs
@@ -1,0 +1,669 @@
+//! Gmail REST API client(read-only)。
+//!
+//! 對應的 Google API doc:
+//! - List threads:`GET /gmail/v1/users/{userId}/threads`
+//! - Get thread:`GET /gmail/v1/users/{userId}/threads/{id}`
+//! - List labels:`GET /gmail/v1/users/{userId}/labels`
+//!
+//! `userId` 一律用 `"me"`(token 對應的 user)。
+//!
+//! ## Token 新鮮度
+//!
+//! 每個 mut method 進場先 [`ensure_fresh_token`] — 若 token 過期就用 refresh_token
+//! 換新並 save 回 disk。LLM 在 Gm-2 透過 Skill 呼叫時不需要關心 refresh 細節。
+//!
+//! ## Body 解碼
+//!
+//! Gmail message body 是 **base64url(no padding)**。我們對每個 message 找:
+//! 1. 若 mime type = `text/plain`,直接 decode 該 part
+//! 2. 否則找 `multipart/alternative` → 內含 `text/plain` part
+//! 3. 都拿不到 → `body_text = ""`(寧可空字串也不讓 caller 收到 partial parse 噪音)
+//!
+//! HTML-only / attachment 等狀況 Gm-1 暫不處理(text/plain 對 LLM context 足夠)。
+//!
+//! ## Endpoint base
+//!
+//! Production base 為 `https://gmail.googleapis.com`。測試時透過
+//! [`GmailClient::with_base`] 注入 mock server URL。
+
+use std::path::PathBuf;
+
+use base64::Engine;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::oauth::{refresh_token_at, OAuthConfig, OAuthError, GOOGLE_TOKEN_URL};
+use crate::token::{GmailToken, TokenError};
+
+/// Production Gmail API base。測試走 [`GmailClient::with_base`] 改寫。
+pub const GMAIL_API_BASE: &str = "https://gmail.googleapis.com";
+
+/// Client 層錯誤類型。
+#[derive(Debug, thiserror::Error)]
+pub enum GmailError {
+    #[error("token: {0}")]
+    Token(#[from] TokenError),
+
+    #[error("oauth: {0}")]
+    OAuth(#[from] OAuthError),
+
+    #[error("http: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// Gmail API 回 4xx / 5xx。`message` 是 Google JSON error body 或 raw text。
+    #[error("api: status={status} message={message}")]
+    Api { status: u16, message: String },
+
+    /// Body base64url 解碼失敗(罕見;Google 自己出問題)。
+    #[error("base64 decode: {0}")]
+    Base64(#[from] base64::DecodeError),
+
+    /// 解析回應 JSON 結構時出問題(欄位缺失 / 型別不對)。
+    #[error("response shape: {0}")]
+    Shape(String),
+}
+
+/// `threads.list` 回的 thread summary(沒展開 messages)。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ThreadSummary {
+    pub id: String,
+    #[serde(default)]
+    pub snippet: String,
+    #[serde(default, rename = "historyId")]
+    pub history_id: String,
+}
+
+/// `threads.get` 回的完整 thread(含 messages + bodies)。
+#[derive(Debug, Clone, Serialize)]
+pub struct Thread {
+    pub id: String,
+    pub messages: Vec<Message>,
+}
+
+/// 單封 Gmail message — 解析過的 header + base64url-decoded text body。
+#[derive(Debug, Clone, Serialize)]
+pub struct Message {
+    pub id: String,
+    pub from: String,
+    pub to: Vec<String>,
+    pub subject: String,
+    pub date: DateTime<Utc>,
+    pub body_text: String,
+    pub snippet: String,
+}
+
+/// Gmail label(`labels.list` 結果)。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Label {
+    pub id: String,
+    pub name: String,
+    #[serde(default, rename = "type")]
+    pub label_type: String,
+}
+
+/// 主 client。對外 read-only(send 留 Gm-2)。
+pub struct GmailClient {
+    token: GmailToken,
+    oauth_config: OAuthConfig,
+    token_path: PathBuf,
+    http: reqwest::Client,
+    /// Gmail REST endpoint base — 預設 [`GMAIL_API_BASE`],測試改寫。
+    api_base: String,
+    /// Token refresh endpoint — 預設 [`GOOGLE_TOKEN_URL`],測試改寫。
+    token_endpoint: String,
+}
+
+impl GmailClient {
+    /// 從 disk 載 token + config,組 client。Token 過期會在第一次 API call 自動 refresh。
+    pub async fn new(
+        token_path: PathBuf,
+        oauth_config: OAuthConfig,
+    ) -> Result<Self, GmailError> {
+        let token = GmailToken::load(&token_path)?;
+        Ok(Self {
+            token,
+            oauth_config,
+            token_path,
+            http: reqwest::Client::new(),
+            api_base: GMAIL_API_BASE.to_string(),
+            token_endpoint: GOOGLE_TOKEN_URL.to_string(),
+        })
+    }
+
+    /// Test-only:用記憶體裡的 token + custom endpoints。
+    #[doc(hidden)]
+    pub fn with_base(
+        token: GmailToken,
+        oauth_config: OAuthConfig,
+        token_path: PathBuf,
+        api_base: impl Into<String>,
+        token_endpoint: impl Into<String>,
+    ) -> Self {
+        Self {
+            token,
+            oauth_config,
+            token_path,
+            http: reqwest::Client::new(),
+            api_base: api_base.into(),
+            token_endpoint: token_endpoint.into(),
+        }
+    }
+
+    /// 取目前 token(僅供測試 / debugging)。
+    #[doc(hidden)]
+    pub fn token_snapshot(&self) -> &GmailToken {
+        &self.token
+    }
+
+    /// 每次 API call 前呼叫:過期 → refresh → save → swap 進 `self.token`。
+    async fn ensure_fresh_token(&mut self) -> Result<(), GmailError> {
+        if !self.token.is_expired() {
+            return Ok(());
+        }
+        tracing::debug!("gmail token expired, refreshing");
+        let new_token =
+            refresh_token_at(&self.token, &self.oauth_config, &self.token_endpoint).await?;
+        new_token.save(&self.token_path)?;
+        self.token = new_token;
+        Ok(())
+    }
+
+    /// `GET /gmail/v1/users/me/threads`(可選 query)。
+    pub async fn list_threads(
+        &mut self,
+        query: Option<&str>,
+        max_results: u32,
+    ) -> Result<Vec<ThreadSummary>, GmailError> {
+        self.ensure_fresh_token().await?;
+        let url = format!("{}/gmail/v1/users/me/threads", self.api_base);
+
+        let mut req = self
+            .http
+            .get(&url)
+            .bearer_auth(&self.token.access_token)
+            .query(&[("maxResults", max_results.to_string())]);
+        if let Some(q) = query {
+            req = req.query(&[("q", q)]);
+        }
+
+        let resp = req.send().await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(GmailError::Api {
+                status: status.as_u16(),
+                message: body,
+            });
+        }
+
+        // Gmail 回 `{ "threads": [...], "resultSizeEstimate": N, "nextPageToken": "..." }`
+        // 沒有 thread 時 `threads` 鍵可能不存在,給 default empty vec。
+        #[derive(Deserialize)]
+        struct ListResp {
+            #[serde(default)]
+            threads: Vec<ThreadSummary>,
+        }
+        let parsed: ListResp = resp.json().await?;
+        Ok(parsed.threads)
+    }
+
+    /// `GET /gmail/v1/users/me/threads/{id}` — 完整 thread,含 messages + decoded text。
+    pub async fn get_thread(&mut self, thread_id: &str) -> Result<Thread, GmailError> {
+        self.ensure_fresh_token().await?;
+        let url = format!("{}/gmail/v1/users/me/threads/{}", self.api_base, thread_id);
+
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(&self.token.access_token)
+            // `format=full` 拿到 payload + bodies。raw / metadata / minimal 都拿不到 body。
+            .query(&[("format", "full")])
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(GmailError::Api {
+                status: status.as_u16(),
+                message: body,
+            });
+        }
+        let raw: RawThread = resp.json().await?;
+        parse_thread(raw)
+    }
+
+    /// `GET /gmail/v1/users/me/labels`。
+    pub async fn list_labels(&mut self) -> Result<Vec<Label>, GmailError> {
+        self.ensure_fresh_token().await?;
+        let url = format!("{}/gmail/v1/users/me/labels", self.api_base);
+
+        let resp = self.http.get(&url).bearer_auth(&self.token.access_token).send().await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(GmailError::Api {
+                status: status.as_u16(),
+                message: body,
+            });
+        }
+        #[derive(Deserialize)]
+        struct ListResp {
+            #[serde(default)]
+            labels: Vec<Label>,
+        }
+        let parsed: ListResp = resp.json().await?;
+        Ok(parsed.labels)
+    }
+}
+
+// =================== 解析 Gmail JSON ===================
+//
+// Gmail message payload 是個樹:
+//   payload: { mimeType, headers, body, parts? }
+// `parts` 是遞迴(`multipart/*` 才有);每個 part 又有 mimeType / body。
+// `body.data` 是 base64url(no padding)的內容字串。
+
+#[derive(Debug, Deserialize)]
+struct RawThread {
+    id: String,
+    #[serde(default)]
+    messages: Vec<RawMessage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawMessage {
+    id: String,
+    #[serde(default)]
+    snippet: String,
+    /// `internalDate` 是 epoch milliseconds 字串(Google API quirk)。
+    #[serde(default, rename = "internalDate")]
+    internal_date: String,
+    payload: Option<RawPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawPayload {
+    #[serde(default, rename = "mimeType")]
+    mime_type: String,
+    #[serde(default)]
+    headers: Vec<RawHeader>,
+    #[serde(default)]
+    body: RawBody,
+    #[serde(default)]
+    parts: Vec<RawPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawHeader {
+    name: String,
+    value: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawBody {
+    #[serde(default)]
+    data: String,
+}
+
+fn parse_thread(raw: RawThread) -> Result<Thread, GmailError> {
+    let messages = raw
+        .messages
+        .into_iter()
+        .map(parse_message)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Thread { id: raw.id, messages })
+}
+
+fn parse_message(raw: RawMessage) -> Result<Message, GmailError> {
+    let snippet = raw.snippet;
+    let id = raw.id;
+
+    // internalDate(ms epoch string) → DateTime<Utc>。Gmail 一定會給,但壞訊息
+    // 我們不 hard fail,回 epoch 0 — caller 通常會排序、看不到也沒事。
+    let date = raw
+        .internal_date
+        .parse::<i64>()
+        .ok()
+        .and_then(|ms| chrono::DateTime::<Utc>::from_timestamp_millis(ms))
+        .unwrap_or(DateTime::<Utc>::from_timestamp(0, 0).unwrap());
+
+    let mut from = String::new();
+    let mut to_list: Vec<String> = Vec::new();
+    let mut subject = String::new();
+    let mut body_text = String::new();
+
+    if let Some(payload) = raw.payload {
+        for h in &payload.headers {
+            match h.name.to_ascii_lowercase().as_str() {
+                "from" => from = h.value.clone(),
+                "to" => {
+                    to_list = h
+                        .value
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                }
+                "subject" => subject = h.value.clone(),
+                _ => {}
+            }
+        }
+        body_text = extract_plain_text(&payload)?;
+    }
+
+    Ok(Message {
+        id,
+        from,
+        to: to_list,
+        subject,
+        date,
+        body_text,
+        snippet,
+    })
+}
+
+/// DFS 找第一個 `text/plain` part,base64url decode 它的 `body.data`。
+fn extract_plain_text(payload: &RawPayload) -> Result<String, GmailError> {
+    // 1. 自己就是 text/plain
+    if payload.mime_type.eq_ignore_ascii_case("text/plain") && !payload.body.data.is_empty() {
+        return decode_base64url(&payload.body.data);
+    }
+    // 2. 遞迴 parts
+    for part in &payload.parts {
+        let inner = extract_plain_text(part)?;
+        if !inner.is_empty() {
+            return Ok(inner);
+        }
+    }
+    // 3. 都沒有 → 空字串(不 fail caller)
+    Ok(String::new())
+}
+
+fn decode_base64url(s: &str) -> Result<String, GmailError> {
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(s.trim())?;
+    // body 內容若不是 UTF-8(Google 偶爾會在 text/plain 摻 latin-1 / quoted-printable
+    // 殘渣),不 hard fail,用 lossy decode — LLM 拿到「字」比拿到 error 重要。
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn dummy_config() -> OAuthConfig {
+        OAuthConfig {
+            client_id: "cid".into(),
+            client_secret: "csecret".into(),
+            redirect_uri: "http://localhost:8765/oauth/callback".into(),
+        }
+    }
+
+    fn fresh_token() -> GmailToken {
+        GmailToken {
+            access_token: "ya29.fresh".into(),
+            refresh_token: "1//refresh".into(),
+            expires_at: Utc::now() + chrono::Duration::hours(1),
+            scope: crate::oauth::GMAIL_READONLY_SCOPE.into(),
+            token_type: "Bearer".into(),
+        }
+    }
+
+    fn expired_token() -> GmailToken {
+        GmailToken {
+            access_token: "ya29.stale".into(),
+            refresh_token: "1//refresh".into(),
+            expires_at: Utc::now() - chrono::Duration::seconds(60),
+            scope: crate::oauth::GMAIL_READONLY_SCOPE.into(),
+            token_type: "Bearer".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_threads_returns_summaries() {
+        let mock = MockServer::start().await;
+
+        let body = serde_json::json!({
+            "threads": [
+                {"id": "t1", "snippet": "hi from alice", "historyId": "100"},
+                {"id": "t2", "snippet": "ping", "historyId": "101"}
+            ],
+            "resultSizeEstimate": 2
+        });
+        Mock::given(method("GET"))
+            .and(path("/gmail/v1/users/me/threads"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(&mock)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let token_path = dir.path().join("gmail-token.json");
+        let mut client = GmailClient::with_base(
+            fresh_token(),
+            dummy_config(),
+            token_path,
+            mock.uri(),
+            // token endpoint 本測試不會打到,給空字串也行;塞 mock 比較不會誤觸網。
+            format!("{}/token", mock.uri()),
+        );
+
+        let threads = client.list_threads(None, 10).await.expect("list ok");
+        assert_eq!(threads.len(), 2);
+        assert_eq!(threads[0].id, "t1");
+        assert_eq!(threads[0].snippet, "hi from alice");
+        assert_eq!(threads[0].history_id, "100");
+        assert_eq!(threads[1].id, "t2");
+    }
+
+    #[tokio::test]
+    async fn list_threads_returns_api_error_for_4xx() {
+        let mock = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/gmail/v1/users/me/threads"))
+            .respond_with(
+                ResponseTemplate::new(401).set_body_string(
+                    r#"{"error":{"code":401,"message":"Invalid Credentials"}}"#,
+                ),
+            )
+            .mount(&mock)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let token_path = dir.path().join("gmail-token.json");
+        let mut client = GmailClient::with_base(
+            fresh_token(),
+            dummy_config(),
+            token_path,
+            mock.uri(),
+            format!("{}/token", mock.uri()),
+        );
+
+        let err = client.list_threads(None, 10).await.expect_err("must 401");
+        match err {
+            GmailError::Api { status, message } => {
+                assert_eq!(status, 401);
+                assert!(message.contains("Invalid Credentials"), "msg={message}");
+            }
+            other => panic!("expected Api 401, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_thread_decodes_base64_body() {
+        let mock = MockServer::start().await;
+
+        // base64url(no padding)of "Hello from Mori\nThis is a test body."
+        // 用 URL_SAFE_NO_PAD encode 出來。
+        let plain = "Hello from Mori\nThis is a test body.";
+        let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(plain.as_bytes());
+
+        let body = serde_json::json!({
+            "id": "thread-123",
+            "messages": [
+                {
+                    "id": "msg-1",
+                    "snippet": "Hello from Mori",
+                    "internalDate": "1716000000000",
+                    "payload": {
+                        "mimeType": "text/plain",
+                        "headers": [
+                            {"name": "From", "value": "Alice <alice@example.com>"},
+                            {"name": "To", "value": "bob@example.com, carol@example.com"},
+                            {"name": "Subject", "value": "Test"}
+                        ],
+                        "body": {"data": encoded}
+                    }
+                }
+            ]
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/gmail/v1/users/me/threads/thread-123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(&mock)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let token_path = dir.path().join("gmail-token.json");
+        let mut client = GmailClient::with_base(
+            fresh_token(),
+            dummy_config(),
+            token_path,
+            mock.uri(),
+            format!("{}/token", mock.uri()),
+        );
+
+        let thread = client.get_thread("thread-123").await.expect("ok");
+        assert_eq!(thread.id, "thread-123");
+        assert_eq!(thread.messages.len(), 1);
+        let msg = &thread.messages[0];
+        assert_eq!(msg.id, "msg-1");
+        assert_eq!(msg.from, "Alice <alice@example.com>");
+        assert_eq!(msg.to, vec!["bob@example.com", "carol@example.com"]);
+        assert_eq!(msg.subject, "Test");
+        assert_eq!(msg.body_text, plain);
+        assert_eq!(msg.snippet, "Hello from Mori");
+    }
+
+    #[tokio::test]
+    async fn get_thread_extracts_plain_from_multipart_alternative() {
+        let mock = MockServer::start().await;
+        let plain = "plain text inside multipart";
+        let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(plain.as_bytes());
+
+        // multipart/alternative → text/plain + text/html;只取 text/plain。
+        let body = serde_json::json!({
+            "id": "tx",
+            "messages": [
+                {
+                    "id": "m1",
+                    "snippet": "snip",
+                    "internalDate": "1716000000000",
+                    "payload": {
+                        "mimeType": "multipart/alternative",
+                        "headers": [{"name": "Subject", "value": "S"}],
+                        "parts": [
+                            {
+                                "mimeType": "text/plain",
+                                "body": {"data": encoded}
+                            },
+                            {
+                                "mimeType": "text/html",
+                                "body": {"data": "PHA+aHRtbDwvcD4"}  // <p>html</p>
+                            }
+                        ]
+                    }
+                }
+            ]
+        });
+        Mock::given(method("GET"))
+            .and(path("/gmail/v1/users/me/threads/tx"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(&mock)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = GmailClient::with_base(
+            fresh_token(),
+            dummy_config(),
+            dir.path().join("gmail-token.json"),
+            mock.uri(),
+            format!("{}/token", mock.uri()),
+        );
+        let thread = client.get_thread("tx").await.expect("ok");
+        assert_eq!(thread.messages[0].body_text, plain);
+    }
+
+    #[tokio::test]
+    async fn ensure_fresh_token_refreshes_when_expired() {
+        let mock = MockServer::start().await;
+
+        // 1. Token endpoint 回新 access_token
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "ya29.refreshed",
+                "expires_in": 3599,
+                "scope": crate::oauth::GMAIL_READONLY_SCOPE,
+                "token_type": "Bearer"
+            })))
+            .mount(&mock)
+            .await;
+
+        // 2. labels.list 回空 list
+        Mock::given(method("GET"))
+            .and(path("/gmail/v1/users/me/labels"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"labels": []})),
+            )
+            .mount(&mock)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let token_path = dir.path().join("gmail-token.json");
+        let mut client = GmailClient::with_base(
+            expired_token(),  // 故意過期
+            dummy_config(),
+            token_path.clone(),
+            mock.uri(),
+            format!("{}/token", mock.uri()),
+        );
+
+        // call API → 應該觸發 refresh
+        let labels = client.list_labels().await.expect("ok");
+        assert!(labels.is_empty());
+
+        // token 已更新進 client
+        assert_eq!(client.token_snapshot().access_token, "ya29.refreshed");
+        assert!(!client.token_snapshot().is_expired());
+
+        // 也已 save 到 disk
+        let saved = GmailToken::load(&token_path).expect("token saved to disk");
+        assert_eq!(saved.access_token, "ya29.refreshed");
+        // refresh response 沒給新 refresh_token → 沿用舊的
+        assert_eq!(saved.refresh_token, "1//refresh");
+    }
+
+    #[test]
+    fn extract_plain_text_returns_empty_when_no_plain_part() {
+        // Only text/html → 沒有 text/plain → 空字串(不 fail)
+        let payload = RawPayload {
+            mime_type: "text/html".into(),
+            headers: vec![],
+            body: RawBody { data: "PGgxPmhpPC9oMT4".into() },  // <h1>hi</h1>
+            parts: vec![],
+        };
+        let got = extract_plain_text(&payload).expect("ok");
+        assert!(got.is_empty(), "html-only should yield empty plain text, got: {got}");
+    }
+
+    #[test]
+    fn decode_base64url_handles_unpadded() {
+        // base64url 沒 padding 也要能 decode。
+        // "Hi" -> "SGk"(沒 = padding)
+        let got = decode_base64url("SGk").expect("ok");
+        assert_eq!(got, "Hi");
+    }
+}

--- a/crates/mori-gmail/src/lib.rs
+++ b/crates/mori-gmail/src/lib.rs
@@ -1,0 +1,66 @@
+//! `mori-gmail` — Gmail 整合(「跨界之手」之一)。
+//!
+//! Mori 透過 Google OAuth2 + Gmail REST API 讀使用者信箱。User-owned data 原則:
+//! 沒有中央 OAuth relay,token 直接放在使用者本機 `~/.mori/gmail-token.json`,
+//! Mori binary 跟 Google 之間是直連。
+//!
+//! ## Wave 8 sub-streams
+//!
+//! - **Gm-1**(本 crate ship 範圍):OAuth2 flow + token storage + read-only API
+//!   (`gmail.readonly` scope,`threads.list / threads.get / labels.list`)。
+//! - **Gm-2**(下一個 stream):LLM Skill wrapper(`ListGmailSkill` /
+//!   `ReadGmailSkill` / `SendGmailSkill`)+ mori-tauri Tauri commands + `gmail.send`
+//!   scope 升級 + Deps 頁 OAuth setup 引導。
+//!
+//! ## Config 慣例
+//!
+//! User 自己在 Google Cloud Console 建 OAuth client(type = Desktop),拿到
+//! `client_id` / `client_secret`,寫進 `~/.mori/gmail-config.json`:
+//!
+//! ```json
+//! {
+//!   "client_id": "...",
+//!   "client_secret": "...",
+//!   "redirect_uri": "http://localhost:8765/oauth/callback"
+//! }
+//! ```
+//!
+//! ## 典型用法(Gm-2 會包成 Tauri command)
+//!
+//! ```ignore
+//! use mori_gmail::{OAuthConfig, GmailClient, default_token_path, run_oauth_flow,
+//!                  GMAIL_READONLY_SCOPE};
+//!
+//! // 第一次 consent
+//! let config = OAuthConfig::load(&OAuthConfig::default_path().unwrap())?;
+//! let token = run_oauth_flow(&config, "csrf-state-token", GMAIL_READONLY_SCOPE).await?;
+//! token.save(&default_token_path().unwrap())?;
+//!
+//! // 之後 API 用
+//! let mut client = GmailClient::new(default_token_path().unwrap(), config).await?;
+//! let threads = client.list_threads(Some("is:unread"), 10).await?;
+//! for t in threads {
+//!     let full = client.get_thread(&t.id).await?;
+//!     // …
+//! }
+//! ```
+//!
+//! ## 未實作 / 暫不做(Gm-2)
+//!
+//! - `messages.send`(需 `gmail.send` scope)
+//! - LLM Skill trait wrapper
+//! - mori-tauri Tauri command 註冊
+//! - 多帳號 / 帳號切換
+//! - HTML body 解析(現階段只取 `text/plain` part)
+//! - 附件下載
+
+pub mod client;
+pub mod oauth;
+pub mod token;
+
+pub use client::{GmailClient, GmailError, Label, Message, Thread, ThreadSummary, GMAIL_API_BASE};
+pub use oauth::{
+    build_auth_url, refresh_token, run_oauth_flow, OAuthConfig, OAuthError,
+    GMAIL_READONLY_SCOPE, GOOGLE_AUTH_URL, GOOGLE_TOKEN_URL,
+};
+pub use token::{default_token_path, GmailToken, TokenError};

--- a/crates/mori-gmail/src/oauth.rs
+++ b/crates/mori-gmail/src/oauth.rs
@@ -1,0 +1,532 @@
+//! OAuth2 flow — desktop-style installed-app flow,本機 redirect server。
+//!
+//! 流程:
+//! 1. spawn 本機 HTTP listener(`localhost:8765`,等待 GET `/oauth/callback?code=…`)
+//! 2. caller 開瀏覽器到 Google consent screen([`build_auth_url`])
+//! 3. 使用者同意 → Google redirect 回 `localhost:8765/oauth/callback?code=…`
+//! 4. listener 取 `code`,POST 給 Google token endpoint 換 access_token + refresh_token
+//! 5. listener 回 user 一頁 "consent done, you can close this window" 後關 socket
+//! 6. token 經 [`crate::token::GmailToken::save`] 寫進 `~/.mori/gmail-token.json`
+//!
+//! ## 為何不用大型 OAuth library
+//!
+//! `oauth2` crate 雖然 robust,但本流程實際只需要 ~3 個 HTTP 動作(redirect → 解
+//! query → exchange / refresh POST),加 listener 整體仍在 ~300 行內。多帶一個大
+//! dep 對 Mori 用戶而言只是 build time + binary size。User-owned data 原則也要求
+//! 沒有第三方 OAuth relay,直接打 Google 即可。
+//!
+//! ## 安全注意
+//!
+//! - Listener 只 bind `127.0.0.1`,不對外開放
+//! - `state` 參數應在初次 redirect 時設,callback 比對 — 本實作 [`parse_callback_query`]
+//!   會把 state 一併拉出來給 caller 比對
+//! - `client_secret` 對 desktop OAuth client 而言不是真 secret(Google 文件明說),
+//!   但仍應放使用者本機 `~/.mori/gmail-config.json`,不入 repo
+//!
+//! ## 未實作 / 暫不做
+//!
+//! - PKCE(Google desktop 流程支援但非必要;Gm-2 可以加)
+//! - 多帳號(token 檔目前單例)
+//! - Listener TLS(不必要;`http://localhost` 是 Google 對 desktop client 認可的
+//!   redirect URI scheme)
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::token::{home_dir, GmailToken, TokenError};
+
+/// Gm-1 唯一 scope。Gm-2 接 send 時會擴成 `"gmail.readonly gmail.send"`。
+pub const GMAIL_READONLY_SCOPE: &str = "https://www.googleapis.com/auth/gmail.readonly";
+
+/// Google OAuth2 endpoints。獨立常數方便測試時改寫(client 層走 mock server)。
+pub const GOOGLE_AUTH_URL: &str = "https://accounts.google.com/o/oauth2/v2/auth";
+pub const GOOGLE_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
+
+/// OAuth 客戶端 config — 由 user 從 Google Cloud Console 拿,寫進
+/// `~/.mori/gmail-config.json`。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OAuthConfig {
+    pub client_id: String,
+    pub client_secret: String,
+    pub redirect_uri: String,
+}
+
+impl OAuthConfig {
+    /// 從 disk 讀 config(`~/.mori/gmail-config.json` 或 caller 給的路徑)。
+    pub fn load(path: &Path) -> Result<Self, OAuthError> {
+        let raw = std::fs::read_to_string(path).map_err(OAuthError::Io)?;
+        let cfg: Self = serde_json::from_str(&raw).map_err(OAuthError::Json)?;
+        Ok(cfg)
+    }
+
+    /// 預設 config 路徑 — `~/.mori/gmail-config.json`(同 token 路徑同目錄)。
+    pub fn default_path() -> Option<PathBuf> {
+        home_dir().map(|h| h.join(".mori").join("gmail-config.json"))
+    }
+}
+
+/// OAuth 層錯誤類型。
+#[derive(Debug, thiserror::Error)]
+pub enum OAuthError {
+    /// 本機 listener / TCP IO 失敗。
+    #[error("io: {0}")]
+    Io(std::io::Error),
+
+    /// Config / response JSON 解析失敗。
+    #[error("json: {0}")]
+    Json(serde_json::Error),
+
+    /// HTTP request 失敗(token exchange / refresh)。
+    #[error("http: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// Google token endpoint 回 4xx / 5xx。
+    #[error("token endpoint error: status={status} body={body}")]
+    TokenEndpoint { status: u16, body: String },
+
+    /// Listener 收到 callback 但沒有 `code` 參數(user 拒絕 / Google 出錯)。
+    #[error("missing 'code' in callback: {0}")]
+    MissingCode(String),
+
+    /// `state` 不匹配 — 可能被 CSRF / 中間人攻擊;直接拒。
+    #[error("oauth state mismatch (expected={expected}, got={got})")]
+    StateMismatch { expected: String, got: String },
+
+    /// 寫 token 檔失敗。
+    #[error("token save: {0}")]
+    Token(#[from] TokenError),
+
+    /// Redirect URI 不合法 / 無法解析。
+    #[error("invalid redirect uri: {0}")]
+    InvalidRedirectUri(String),
+}
+
+impl From<std::io::Error> for OAuthError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+impl From<serde_json::Error> for OAuthError {
+    fn from(e: serde_json::Error) -> Self {
+        Self::Json(e)
+    }
+}
+
+/// Google token endpoint 的 raw response。
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    /// refresh_token 只在初次 consent 時有;refresh 流程通常拿不到新的。
+    refresh_token: Option<String>,
+    expires_in: i64,
+    scope: String,
+    token_type: String,
+}
+
+/// 組 Google consent URL。
+///
+/// `state` 是 caller 提供的 CSRF token,callback 必須回相同 state。Caller 自己生
+/// 隨機字串(不在這層引 rand crate)。
+///
+/// Scope 由 caller 控制(Gm-1 固定 [`GMAIL_READONLY_SCOPE`])— 留參數以便 Gm-2
+/// 升 scope 時不用改 API。
+pub fn build_auth_url(config: &OAuthConfig, scope: &str, state: &str) -> String {
+    // 標準 OAuth2 query。`access_type=offline` 才會回 refresh_token;
+    // `prompt=consent` 強制每次都跑 consent UI(避免 user 已給過 readonly 但要升 scope 時
+    // Google 跳過 consent)。Gm-1 兩者都加,Gm-2 升 scope 也照樣 work。
+    let mut url = Url::parse(GOOGLE_AUTH_URL).expect("hard-coded URL must parse");
+    url.query_pairs_mut()
+        .append_pair("client_id", &config.client_id)
+        .append_pair("redirect_uri", &config.redirect_uri)
+        .append_pair("response_type", "code")
+        .append_pair("scope", scope)
+        .append_pair("access_type", "offline")
+        .append_pair("prompt", "consent")
+        .append_pair("state", state);
+    url.into()
+}
+
+/// 從 callback request line 抽 query params。
+///
+/// 純 parse helper,跟 server / network IO 解耦,可獨立測。
+///
+/// Input 是 Google redirect 過來的 path+query,例如
+/// `/oauth/callback?code=4/0AX...&state=abc&scope=...`。
+pub fn parse_callback_query(request_line: &str) -> HashMap<String, String> {
+    // request line:`GET /oauth/callback?code=…&state=… HTTP/1.1`
+    let path_and_query = request_line
+        .split_whitespace()
+        .nth(1)
+        .unwrap_or("");
+    let query = path_and_query.split('?').nth(1).unwrap_or("");
+
+    let mut out = HashMap::new();
+    for kv in query.split('&').filter(|s| !s.is_empty()) {
+        let mut parts = kv.splitn(2, '=');
+        if let (Some(k), Some(v)) = (parts.next(), parts.next()) {
+            let key = url::form_urlencoded::parse(k.as_bytes())
+                .map(|(a, _)| a.into_owned())
+                .next()
+                .unwrap_or_else(|| k.to_string());
+            let val = url::form_urlencoded::parse(v.as_bytes())
+                .map(|(a, _)| a.into_owned())
+                .next()
+                .unwrap_or_else(|| v.to_string());
+            out.insert(key, val);
+        }
+    }
+    out
+}
+
+/// Listener bind port,從 `redirect_uri` 拉出來。預設 8765。
+fn redirect_port(redirect_uri: &str) -> Result<u16, OAuthError> {
+    let url = Url::parse(redirect_uri)
+        .map_err(|e| OAuthError::InvalidRedirectUri(format!("{redirect_uri}: {e}")))?;
+    url.port_or_known_default()
+        .ok_or_else(|| OAuthError::InvalidRedirectUri(format!("{redirect_uri}: no port")))
+}
+
+/// 跑完整 OAuth flow:spawn listener,等 user 在瀏覽器同意,exchange token,save token。
+///
+/// **不會自動開瀏覽器** — caller(Gm-2 Tauri command)用 `webbrowser::open` /
+/// shell 開,本層只負責 listener + token exchange,避免拉 `webbrowser` dep 進來。
+///
+/// Caller 流程示意:
+/// ```ignore
+/// let state = "random-csrf-token";  // caller 自己生
+/// let auth_url = build_auth_url(&config, GMAIL_READONLY_SCOPE, state);
+/// // 並行:開瀏覽器 + 等 listener
+/// std::thread::spawn(|| open_browser(&auth_url));
+/// let token = run_oauth_flow(&config, state, GMAIL_READONLY_SCOPE).await?;
+/// token.save(&token_path)?;
+/// ```
+///
+/// Listener 是 **blocking**(`std::net::TcpListener`)— 在 tokio async 環境用
+/// `tokio::task::spawn_blocking` 包,不阻塞 runtime。本函式內部已用
+/// `spawn_blocking`,caller 直接 `.await` 即可。
+pub async fn run_oauth_flow(
+    config: &OAuthConfig,
+    expected_state: &str,
+    scope: &str,
+) -> Result<GmailToken, OAuthError> {
+    let port = redirect_port(&config.redirect_uri)?;
+    let expected_state_owned = expected_state.to_string();
+
+    // 1. 等 listener 收 callback。spawn_blocking 跑 std::net listener。
+    let code = tokio::task::spawn_blocking(move || -> Result<String, OAuthError> {
+        wait_for_callback(port, &expected_state_owned)
+    })
+    .await
+    .map_err(|e| {
+        OAuthError::Io(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("listener join: {e}"),
+        ))
+    })??;
+
+    // 2. exchange code → token
+    exchange_code(config, &code, scope).await
+}
+
+/// 阻塞等 listener 接到第一筆 callback,parse code,回應 user 一頁簡單 HTML 後關 socket。
+fn wait_for_callback(port: u16, expected_state: &str) -> Result<String, OAuthError> {
+    let listener = TcpListener::bind(("127.0.0.1", port))?;
+    // 超時(5 分鐘)避免無限掛著 — user 沒同意 / 關 tab 時 listener 不會永遠等。
+    listener
+        .set_nonblocking(false)
+        .map_err(OAuthError::Io)?;
+
+    // 只接一筆 connection 就結束。若 user 在 5 分鐘內沒同意,呼叫者 future 也會被
+    // 上層 task timeout drop 掉(本層不自帶 timeout 邏輯,留給 caller 視 UX 而定)。
+    let (mut stream, _peer) = listener.accept()?;
+
+    // 不期待 long-running connection — 設個短 read timeout 防壞 client 卡住。
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .map_err(OAuthError::Io)?;
+
+    let mut buf = [0u8; 4096];
+    let n = stream.read(&mut buf)?;
+    let request_text = String::from_utf8_lossy(&buf[..n]);
+
+    // request_text 是整段 HTTP request;第一行就是 request line。
+    let request_line = request_text.lines().next().unwrap_or("");
+    let params = parse_callback_query(request_line);
+
+    // 比對 state(CSRF 防護)— 即使 user 已同意,state 不對也 reject。
+    match params.get("state") {
+        Some(got) if got == expected_state => {}
+        Some(got) => {
+            let _ = stream.write_all(callback_response_body(
+                "state mismatch — possible CSRF, refusing.",
+            ).as_bytes());
+            return Err(OAuthError::StateMismatch {
+                expected: expected_state.to_string(),
+                got: got.clone(),
+            });
+        }
+        None => {
+            let _ = stream.write_all(
+                callback_response_body("missing state — refusing.").as_bytes(),
+            );
+            return Err(OAuthError::MissingCode("no state".into()));
+        }
+    }
+
+    if let Some(err) = params.get("error") {
+        let _ = stream.write_all(
+            callback_response_body(&format!("Google returned error: {err}"))
+                .as_bytes(),
+        );
+        return Err(OAuthError::MissingCode(format!("google error: {err}")));
+    }
+
+    let code = match params.get("code") {
+        Some(c) => c.clone(),
+        None => {
+            let _ = stream.write_all(
+                callback_response_body("no 'code' in callback — refusing.")
+                    .as_bytes(),
+            );
+            return Err(OAuthError::MissingCode(request_line.to_string()));
+        }
+    };
+
+    // 回 user 一頁簡單成功訊息。即使後面 exchange 失敗,user 端瀏覽器已關心不到。
+    let _ = stream.write_all(
+        callback_response_body("Mori received your consent. You can close this tab.")
+            .as_bytes(),
+    );
+
+    Ok(code)
+}
+
+fn callback_response_body(message: &str) -> String {
+    // 極簡 HTTP/1.1 response;沒裝 hyper / axum,自己寫 headers。
+    let body = format!(
+        "<!doctype html><html><body style='font-family:sans-serif;padding:2em'>\
+         <h2>Mori — Gmail</h2><p>{message}</p></body></html>"
+    );
+    format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n\
+         Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    )
+}
+
+/// 用 authorization code 跟 Google 換 token。
+async fn exchange_code(
+    config: &OAuthConfig,
+    code: &str,
+    _scope: &str,
+) -> Result<GmailToken, OAuthError> {
+    exchange_code_at(config, code, GOOGLE_TOKEN_URL).await
+}
+
+/// `exchange_code` 但 endpoint 可改寫 — test only。
+async fn exchange_code_at(
+    config: &OAuthConfig,
+    code: &str,
+    endpoint: &str,
+) -> Result<GmailToken, OAuthError> {
+    let client = reqwest::Client::new();
+    let form = [
+        ("code", code),
+        ("client_id", config.client_id.as_str()),
+        ("client_secret", config.client_secret.as_str()),
+        ("redirect_uri", config.redirect_uri.as_str()),
+        ("grant_type", "authorization_code"),
+    ];
+    let resp = client.post(endpoint).form(&form).send().await?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(OAuthError::TokenEndpoint {
+            status: status.as_u16(),
+            body,
+        });
+    }
+    let raw: TokenResponse = resp.json().await?;
+    let refresh = raw.refresh_token.ok_or_else(|| OAuthError::TokenEndpoint {
+        status: 200,
+        body: "no refresh_token in response — re-consent with prompt=consent".into(),
+    })?;
+    Ok(GmailToken {
+        access_token: raw.access_token,
+        refresh_token: refresh,
+        expires_at: Utc::now() + chrono::Duration::seconds(raw.expires_in),
+        scope: raw.scope,
+        token_type: raw.token_type,
+    })
+}
+
+/// 用 refresh_token 拿新 access_token。Google 通常不會回新的 refresh_token,
+/// 我們把舊的 refresh_token 保留下來覆蓋進新 [`GmailToken`]。
+pub async fn refresh_token(
+    token: &GmailToken,
+    config: &OAuthConfig,
+) -> Result<GmailToken, OAuthError> {
+    refresh_token_at(token, config, GOOGLE_TOKEN_URL).await
+}
+
+/// `refresh_token` 但 endpoint 可改寫 — test only。
+pub(crate) async fn refresh_token_at(
+    token: &GmailToken,
+    config: &OAuthConfig,
+    endpoint: &str,
+) -> Result<GmailToken, OAuthError> {
+    let client = reqwest::Client::new();
+    let form = [
+        ("refresh_token", token.refresh_token.as_str()),
+        ("client_id", config.client_id.as_str()),
+        ("client_secret", config.client_secret.as_str()),
+        ("grant_type", "refresh_token"),
+    ];
+    let resp = client.post(endpoint).form(&form).send().await?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(OAuthError::TokenEndpoint {
+            status: status.as_u16(),
+            body,
+        });
+    }
+    let raw: TokenResponse = resp.json().await?;
+    Ok(GmailToken {
+        access_token: raw.access_token,
+        // refresh 流程通常不會給新的 refresh_token,沿用舊的。
+        refresh_token: raw.refresh_token.unwrap_or_else(|| token.refresh_token.clone()),
+        expires_at: Utc::now() + chrono::Duration::seconds(raw.expires_in),
+        scope: raw.scope,
+        token_type: raw.token_type,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn oauth_config_parses_from_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gmail-config.json");
+        let raw = r#"{
+            "client_id": "abc.apps.googleusercontent.com",
+            "client_secret": "GOCSPX-xyz",
+            "redirect_uri": "http://localhost:8765/oauth/callback"
+        }"#;
+        std::fs::write(&path, raw).unwrap();
+
+        let cfg = OAuthConfig::load(&path).expect("config load");
+        assert_eq!(cfg.client_id, "abc.apps.googleusercontent.com");
+        assert_eq!(cfg.client_secret, "GOCSPX-xyz");
+        assert_eq!(cfg.redirect_uri, "http://localhost:8765/oauth/callback");
+    }
+
+    #[test]
+    fn oauth_redirect_uri_parses_code() {
+        // 真實 Google redirect 過來的 request line(含 url-encoded code)。
+        let line = "GET /oauth/callback?state=xyz&code=4%2F0AX4XfWj-secret&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.readonly HTTP/1.1";
+        let params = parse_callback_query(line);
+
+        assert_eq!(params.get("state").map(String::as_str), Some("xyz"));
+        // url-encoded `4/0AX4XfWj-secret`
+        assert_eq!(
+            params.get("code").map(String::as_str),
+            Some("4/0AX4XfWj-secret")
+        );
+        assert_eq!(
+            params.get("scope").map(String::as_str),
+            Some("https://www.googleapis.com/auth/gmail.readonly")
+        );
+    }
+
+    #[test]
+    fn build_auth_url_includes_required_params() {
+        let cfg = OAuthConfig {
+            client_id: "cid".into(),
+            client_secret: "secret".into(),
+            redirect_uri: "http://localhost:8765/oauth/callback".into(),
+        };
+        let url = build_auth_url(&cfg, GMAIL_READONLY_SCOPE, "state-abc");
+
+        // 不假設 query order,只 assert 必要參數都在。
+        assert!(url.starts_with(GOOGLE_AUTH_URL), "url: {url}");
+        for needle in [
+            "client_id=cid",
+            "response_type=code",
+            "access_type=offline",
+            "prompt=consent",
+            "state=state-abc",
+        ] {
+            assert!(url.contains(needle), "url should contain {needle}: {url}");
+        }
+        // scope 是 url-encoded 的;assert encoded form。
+        assert!(
+            url.contains("scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.readonly"),
+            "url should contain encoded scope: {url}"
+        );
+    }
+
+    #[test]
+    fn redirect_port_extracts_from_uri() {
+        assert_eq!(
+            redirect_port("http://localhost:8765/oauth/callback").unwrap(),
+            8765
+        );
+        assert_eq!(
+            redirect_port("http://127.0.0.1:9090/cb").unwrap(),
+            9090
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_token_hits_endpoint_and_returns_new_token() {
+        use wiremock::matchers::{body_string_contains, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        let response_body = serde_json::json!({
+            "access_token": "ya29.new_access",
+            "expires_in": 3599,
+            "scope": "https://www.googleapis.com/auth/gmail.readonly",
+            "token_type": "Bearer"
+            // 注意:refresh 流程沒回新 refresh_token,沿用舊的。
+        });
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_string_contains("grant_type=refresh_token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
+            .mount(&mock)
+            .await;
+
+        let cfg = OAuthConfig {
+            client_id: "cid".into(),
+            client_secret: "csecret".into(),
+            redirect_uri: "http://localhost:8765/oauth/callback".into(),
+        };
+        let old = GmailToken {
+            access_token: "ya29.expired".into(),
+            refresh_token: "old_refresh".into(),
+            expires_at: Utc::now() - chrono::Duration::seconds(60),
+            scope: GMAIL_READONLY_SCOPE.into(),
+            token_type: "Bearer".into(),
+        };
+        let endpoint = format!("{}/", mock.uri());
+        let new_token = refresh_token_at(&old, &cfg, &endpoint).await.expect("refresh ok");
+
+        assert_eq!(new_token.access_token, "ya29.new_access");
+        // 沿用舊 refresh_token
+        assert_eq!(new_token.refresh_token, "old_refresh");
+        assert!(!new_token.is_expired(), "newly refreshed token should be fresh");
+    }
+}

--- a/crates/mori-gmail/src/token.rs
+++ b/crates/mori-gmail/src/token.rs
@@ -1,0 +1,197 @@
+//! Token storage — `~/.mori/gmail-token.json` 的 load / save / 過期判斷。
+//!
+//! Token 由 [`crate::oauth`] 模組產生(初次 consent 或 refresh 後),由
+//! [`crate::client::GmailClient`] 在每次 API call 前判斷新鮮度並按需 refresh。
+//!
+//! ## 路徑慣例
+//!
+//! 預設 token 路徑由 [`default_token_path`] 決定:
+//! - Unix:`$HOME/.mori/gmail-token.json`
+//! - Windows:`$USERPROFILE\.mori\gmail-token.json`
+//!
+//! 若兩個環境變數都拿不到,回 `None`,caller 自己拿一個合理路徑(例如測試用
+//! tempdir)。CLAUDE.md 註明 Windows 的 `HOME` 可能沒設要 fallback `USERPROFILE`,
+//! 對齊既有 [`mori_cli`] 等 crate 的處理。
+//!
+//! ## 過期判斷
+//!
+//! [`GmailToken::is_expired`] 預留 **30 秒 buffer** — 若 `expires_at` 已經在「30
+//! 秒內」到期,視為過期。避免 client 剛判斷 fresh、發 request 時 token 正好過期
+//! 拿到 401 的競態。Google OAuth access_token 預設壽命 1 小時,30 秒 buffer 不影響
+//! 整體有效時間。
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+/// `token.rs` 層錯誤類型。
+#[derive(Debug, thiserror::Error)]
+pub enum TokenError {
+    /// 讀寫 token 檔的 IO 錯誤。
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// JSON 解析失敗(檔案壞了 / 不是預期格式)。
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+/// Gmail OAuth token + metadata。
+///
+/// 對應 Google OAuth2 token endpoint 回傳的 JSON,額外加 `expires_at`(absolute
+/// time,在 [`crate::oauth`] 由 `expires_in` 秒數 + `Utc::now()` 算出),方便
+/// load 後直接判斷 fresh。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GmailToken {
+    /// 短期 access token(預設 ~1 小時)。
+    pub access_token: String,
+
+    /// 長期 refresh token(只在初次 consent 時拿到,Google 不一定每次 refresh 都回傳)。
+    pub refresh_token: String,
+
+    /// `access_token` 過期的絕對時間。
+    pub expires_at: DateTime<Utc>,
+
+    /// Google 回的 granted scope(space-separated)。Gm-1 應該只有 `gmail.readonly`。
+    pub scope: String,
+
+    /// 一律 `"Bearer"`,Google 不會給其他類型。保留欄位讓 caller 顯式寫 Authorization
+    /// header 時可讀。
+    pub token_type: String,
+}
+
+/// 過期判斷的安全 buffer(秒)。
+const EXPIRY_BUFFER_SECS: i64 = 30;
+
+impl GmailToken {
+    /// 若 `expires_at` 已經過,或距現在不到 [`EXPIRY_BUFFER_SECS`] 秒,回 `true`。
+    pub fn is_expired(&self) -> bool {
+        let threshold = Utc::now() + Duration::seconds(EXPIRY_BUFFER_SECS);
+        self.expires_at <= threshold
+    }
+
+    /// 從 disk load。檔案不存在 → [`TokenError::Io`](kind = NotFound);
+    /// 內容不合 JSON → [`TokenError::Json`]。
+    pub fn load(path: &Path) -> Result<Self, TokenError> {
+        let raw = std::fs::read_to_string(path)?;
+        let token: Self = serde_json::from_str(&raw)?;
+        Ok(token)
+    }
+
+    /// 寫入 disk(原子性:先寫到 `.tmp`,再 rename)。
+    ///
+    /// 若 parent 目錄不存在會自動建立(`create_dir_all`),token 檔放 `~/.mori/`,
+    /// 不一定先存在。
+    pub fn save(&self, path: &Path) -> Result<(), TokenError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let raw = serde_json::to_string_pretty(self)?;
+
+        // 原子寫入:.tmp -> rename。避免半寫狀態被下次 load 拿到。
+        let tmp = path.with_extension("json.tmp");
+        std::fs::write(&tmp, raw)?;
+        std::fs::rename(&tmp, path)?;
+        Ok(())
+    }
+}
+
+/// 預設 token 路徑 — `~/.mori/gmail-token.json`。
+///
+/// Linux / macOS 走 `$HOME`,Windows fallback `$USERPROFILE`。兩個都拿不到回
+/// `None`(罕見:CI / 沙箱環境),caller 自己決定要 panic 還是用其他路徑。
+pub fn default_token_path() -> Option<PathBuf> {
+    home_dir().map(|h| h.join(".mori").join("gmail-token.json"))
+}
+
+/// home 目錄解析。內部 helper,留給 [`crate::oauth`] 跟 [`crate::client`] 共用
+/// (gmail-config.json 也走同一個目錄)。
+pub(crate) fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_token(expires_at: DateTime<Utc>) -> GmailToken {
+        GmailToken {
+            access_token: "ya29.fake_access".into(),
+            refresh_token: "1//fake_refresh".into(),
+            expires_at,
+            scope: "https://www.googleapis.com/auth/gmail.readonly".into(),
+            token_type: "Bearer".into(),
+        }
+    }
+
+    #[test]
+    fn token_save_load_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        // 故意指到不存在的 nested dir,確認 save 會 mkdir。
+        let path = dir.path().join("nested").join("gmail-token.json");
+
+        let original = sample_token(Utc::now() + Duration::hours(1));
+        original.save(&path).expect("save");
+
+        let loaded = GmailToken::load(&path).expect("load");
+        assert_eq!(loaded.access_token, original.access_token);
+        assert_eq!(loaded.refresh_token, original.refresh_token);
+        assert_eq!(loaded.scope, original.scope);
+        assert_eq!(loaded.token_type, original.token_type);
+        // chrono round-trip 精度到秒以下,但 to/from JSON 走 RFC 3339 應 byte-equal。
+        assert_eq!(loaded.expires_at, original.expires_at);
+    }
+
+    #[test]
+    fn token_is_expired_returns_true_for_past_time() {
+        let token = sample_token(Utc::now() - Duration::seconds(1));
+        assert!(token.is_expired(), "past expiry must be reported expired");
+    }
+
+    #[test]
+    fn token_is_expired_returns_false_for_future() {
+        // 1 小時後,遠超 30s buffer。
+        let token = sample_token(Utc::now() + Duration::hours(1));
+        assert!(!token.is_expired(), "1h-future expiry must be fresh");
+    }
+
+    #[test]
+    fn token_is_expired_respects_30s_buffer() {
+        // 10 秒後到期 — 在 30s buffer 內,視為過期。
+        let token = sample_token(Utc::now() + Duration::seconds(10));
+        assert!(
+            token.is_expired(),
+            "within-30s expiry should be flagged as expired (buffer)"
+        );
+    }
+
+    #[test]
+    fn default_token_path_uses_home() {
+        // 暫時設 HOME 到 tempdir 並清掉 USERPROFILE,確認 default_token_path()
+        // 回 `<HOME>/.mori/gmail-token.json`。
+        //
+        // ⚠️ env::set_var 在 Rust 1.74+ 是 unsafe 在多 thread 場景,這裡 test
+        // single-thread 內 OK;Rust 早期版本只是普通 fn,呼叫 site 無需 unsafe。
+        let dir = tempfile::tempdir().unwrap();
+        let prev_home = std::env::var_os("HOME");
+        let prev_userprofile = std::env::var_os("USERPROFILE");
+
+        std::env::set_var("HOME", dir.path());
+        std::env::remove_var("USERPROFILE");
+
+        let got = default_token_path().expect("HOME set, should resolve");
+        assert_eq!(got, dir.path().join(".mori").join("gmail-token.json"));
+
+        // 還原 — 避免污染同進程其他 test。
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        if let Some(v) = prev_userprofile {
+            std::env::set_var("USERPROFILE", v);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**Wave 8 Gm-1**(跨界之手 — Gmail 第一條) — `mori-gmail` 新 crate foundation。OAuth2 + token storage + refresh + Gmail API read-only。Gm-2 接 LLM Skills + send scope。

§9 P1「跨界之手」之 Gmail。

## Changes

- `crates/mori-gmail/`(新 crate):
  - `token.rs`:`GmailToken` + atomic save/load + expiry buffer
  - `oauth.rs`:OAuth2 config + local callback server(`std::net` minimal,不拉 hyper/axum)+ refresh
  - `client.rs`:`GmailClient` list_threads / get_thread / list_labels + auto-fresh-token
- workspace `Cargo.toml`:+ member
- Cargo.lock:url 2.5 / base64 0.22 / wiremock 0.6(dev)

## Design

- **Local OAuth callback server 用 `std::net`**:OAuth callback 只需 single GET,`TcpListener::accept` + 4KB buffer + 手寫 minimal HTTP response ~60 行,避免新 dep tree
- **Token refresh 30s buffer**:避免「剛 check fresh 就發 request 拿 401」競態
- **Atomic token write**:`.tmp` → rename,防半寫狀態
- **State (CSRF) 強制比對**:state 不符 reject 不換 token
- **Body 解析**:DFS payload.parts 找第一個 `text/plain`;multipart/alternative 自動拿 plain version;HTML-only body = `""`(不 fail caller)
- **base64url 用 URL_SAFE_NO_PAD**(RFC 4648 §5,Gmail 規格)
- **Endpoint 注入** test-only constructor + `pub(crate)` `refresh_token_at`,讓 wiremock 完全攔截,production 用常數預設

## Test plan

- [x] **17 tests passing**:
  - token 5(round-trip / expiry / 30s buffer / default path)
  - oauth 5(config / callback query / build_auth_url / port / refresh via wiremock)
  - client 7(list_threads 200 / 4xx / get_thread base64 / multipart-alt / ensure_fresh refresh + save / html-only empty / base64url no padding)
- [x] verify.sh 全綠

## Setup(user 需做)

1. Google Cloud Console → 建 OAuth client(type = Desktop)
2. 拿 client_id + client_secret,存 `~/.mori/gmail-config.json`:
   ```json
   {"client_id": "...", "client_secret": "...", "redirect_uri": "http://localhost:8765/oauth/callback"}
   ```
3. Gm-2 將提供 Tauri command 觸發 `run_oauth_flow` → browser → consent → token 自動存

## Known follow-up(Gm-2)

- `ListGmailSkill` / `ReadGmailSkill` / `SendGmailSkill` LLM 對外
- Tauri commands(`gmail_oauth_start_cmd` / `gmail_list_threads_cmd` / `gmail_get_thread_cmd`)
- send scope(`gmail.send`,單獨 consent)
- system prompt 工具描述
- Deps 頁 OAuth setup 引導入口
- 多帳號(`~/.mori/gmail-tokens/<account>.json`)目前單例
- HTML-only 信件 body fallback(html2text 之類)

🤖 Generated with [Claude Code](https://claude.com/claude-code)