### PR TITLE
feat(gmail): Wire mori-gmail into Mori — send + LLM Skills + Tauri (Gm-2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2991,10 +2991,12 @@ version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "chrono",
  "futures-util",
  "hound",
  "mori-file-loader",
+ "mori-gmail",
  "mori-mcp",
  "mori-time",
  "regex",
@@ -3007,6 +3009,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]
@@ -3069,6 +3072,7 @@ dependencies = [
  "image",
  "mori-core",
  "mori-file-loader",
+ "mori-gmail",
  "mori-mcp",
  "mori-time",
  "parking_lot",
@@ -3091,6 +3095,7 @@ dependencies = [
  "tracing-subscriber",
  "which",
  "windows 0.58.0",
+ "wiremock",
  "x11rb",
  "zip 2.4.2",
 ]

--- a/crates/mori-core/Cargo.toml
+++ b/crates/mori-core/Cargo.toml
@@ -53,5 +53,16 @@ mori-time = { path = "../mori-time" }
 # 不 depend mori-core,無 cycle 風險。
 mori-mcp = { path = "../mori-mcp" }
 
+# Wave 8 Gm-2 「跨界之手」:`ListGmailSkill` / `ReadGmailSkill` / `SendGmailSkill`
+# 接 mori-gmail::GmailClient(OAuth2 + Gmail REST API,Gm-1 提供)。純 path dep —
+# mori-gmail 是 leaf crate(reqwest + serde + chrono + url + base64),不 depend
+# mori-core,無 cycle 風險。Skill 用 Arc<Mutex<GmailClient>> 共享 client(send
+# 需要 mut self for ensure_fresh_token,Mutex 提供 interior mutability)。
+mori-gmail = { path = "../mori-gmail" }
+
 [dev-dependencies]
 tempfile = "3"
+# Wave 8 Gm-2:`skill/gmail.rs` tests 走 wiremock 模擬 Gmail REST endpoint,
+# 對齊 mori-gmail crate 內部 client tests 風格(不打真 Google,不要 OAuth)。
+wiremock = "0.6"
+base64 = "0.22"

--- a/crates/mori-core/src/skill/gmail.rs
+++ b/crates/mori-core/src/skill/gmail.rs
@@ -1,0 +1,701 @@
+//! Gmail 系列 LLM-callable skill(Wave 8 Gm-2「跨界之手」)。
+//!
+//! 三個 skill 共用一份 [`mori_gmail::GmailClient`](Arc<Mutex<>>)。Client 內含 token
+//! state(過期會自動 refresh + save 回 disk),`ensure_fresh_token` 需要 `&mut self`,
+//! 所以 client 用 `Arc<Mutex<GmailClient>>` 包,所有 skill share 同一份。
+//!
+//! ## Skill 列表
+//!
+//! - [`ListGmailSkill`] — `list_gmail(query?, max?)`:列 thread summary。
+//! - [`ReadGmailSkill`] — `read_gmail(thread_id)`:展開 thread 全文(messages + bodies)。
+//! - [`SendGmailSkill`] — `send_gmail(to, subject, body, reply_to_thread_id?)`:寄信
+//!   或回某條 thread。Send 需要 `gmail.send` scope — `execute` 進場前先 check
+//!   token 是否含此 scope,沒有就回 error 提示 user 跑 OAuth re-consent。
+//!
+//! ## 用 Arc<Mutex<>> 而非 Arc 的原因
+//!
+//! `GmailClient::list_threads / get_thread / send_message` 都吃 `&mut self`
+//! (`ensure_fresh_token` 內可能更新 token state)。多個 skill 同進程要 share
+//! 一份 client → interior mutability 用 `tokio::sync::Mutex`(async 環境 — 不能用
+//! `std::sync::Mutex`,await 跨 lock 會 deadlock)。
+//!
+//! ## 為什麼分 3 個 skill 而不是 1 個 method-dispatch
+//!
+//! 對齊既有 `RemindMeSkill` 一個動作一個 skill 的 pattern,讓 LLM tool definition
+//! 描述精準(各 skill 自己 schema + description),減少 LLM 看「method 字串」誤
+//! invoke 的機率。
+
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use tokio::sync::Mutex;
+
+use mori_gmail::{GmailClient, GMAIL_SEND_SCOPE};
+
+use super::{ExecutionTarget, Privacy, Skill, SkillOutput};
+use crate::context::Context;
+
+/// 共用 client wrapper — 也是 mori-tauri 端 `.manage(SharedGmailClient(...))` 的型別。
+/// 讓 Tauri command + 各 Skill 都從同一個 `Arc<Mutex<GmailClient>>` 拿 clone。
+#[derive(Clone)]
+pub struct SharedGmailClient(pub Arc<Mutex<GmailClient>>);
+
+// ─────────────────────────────────────────────────────────────────────
+// List
+// ─────────────────────────────────────────────────────────────────────
+
+pub struct ListGmailSkill {
+    pub client: Arc<Mutex<GmailClient>>,
+}
+
+impl ListGmailSkill {
+    pub fn new(client: Arc<Mutex<GmailClient>>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl Skill for ListGmailSkill {
+    fn name(&self) -> &'static str {
+        "list_gmail"
+    }
+
+    fn description(&self) -> &'static str {
+        "列我最近的 Gmail thread(summary;snippet + history id,沒展開 body)。\
+         可選 query 用 Gmail search 語法(`from:alice`、`is:unread`、`subject:meeting`、\
+         `after:2026/01/01` 等)。預設 max=10。要看 thread 全文呼叫 `read_gmail(thread_id)`。"
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Gmail 搜尋語法,例如 `is:unread`、`from:bob@x.com`、`subject:report`。空字串 / 省略 = 全部最近。"
+                },
+                "max": {
+                    "type": "integer",
+                    "description": "回傳上限(預設 10)。LLM 用,別超過 50。",
+                    "minimum": 1,
+                    "maximum": 100
+                }
+            }
+        })
+    }
+
+    fn target_capability(&self) -> ExecutionTarget {
+        ExecutionTarget::Local
+    }
+
+    fn privacy(&self) -> Privacy {
+        Privacy::Cloud
+    }
+
+    async fn execute(&self, args: Value, _context: &Context) -> Result<SkillOutput> {
+        let query = args
+            .get("query")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        let max = args
+            .get("max")
+            .and_then(|v| v.as_u64())
+            .map(|n| n as u32)
+            .unwrap_or(10);
+
+        tracing::info!(query = ?query, max, "list_gmail skill");
+
+        let summaries = {
+            let mut client = self.client.lock().await;
+            client
+                .list_threads(query.as_deref(), max)
+                .await
+                .map_err(|e| anyhow!("list_gmail failed: {e}"))?
+        };
+
+        // user_message:列每 thread 一行 — id + snippet。LLM 拿到後通常會挑一條
+        // 講給 user 聽 / 進一步 read_gmail。
+        let user_message = if summaries.is_empty() {
+            "(沒有符合的 Gmail thread)".to_string()
+        } else {
+            let mut s = String::new();
+            for t in &summaries {
+                s.push_str(&format!("- {} | {}\n", t.id, t.snippet));
+            }
+            s
+        };
+
+        Ok(SkillOutput {
+            user_message,
+            data: Some(json!({
+                "count": summaries.len(),
+                "threads": summaries,
+            })),
+        })
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Read
+// ─────────────────────────────────────────────────────────────────────
+
+pub struct ReadGmailSkill {
+    pub client: Arc<Mutex<GmailClient>>,
+}
+
+impl ReadGmailSkill {
+    pub fn new(client: Arc<Mutex<GmailClient>>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl Skill for ReadGmailSkill {
+    fn name(&self) -> &'static str {
+        "read_gmail"
+    }
+
+    fn description(&self) -> &'static str {
+        "讀一條 Gmail thread 的完整訊息(每封 message 的 from / to / subject / date / body)。\
+         `thread_id` 通常從 `list_gmail` 結果拿。"
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "thread_id": {
+                    "type": "string",
+                    "description": "Gmail thread id(從 `list_gmail` 結果拿)。"
+                }
+            },
+            "required": ["thread_id"]
+        })
+    }
+
+    fn target_capability(&self) -> ExecutionTarget {
+        ExecutionTarget::Local
+    }
+
+    fn privacy(&self) -> Privacy {
+        Privacy::Cloud
+    }
+
+    async fn execute(&self, args: Value, _context: &Context) -> Result<SkillOutput> {
+        let thread_id = args
+            .get("thread_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("missing thread_id"))?
+            .trim()
+            .to_string();
+        if thread_id.is_empty() {
+            return Err(anyhow!("thread_id is empty"));
+        }
+
+        tracing::info!(thread_id = %thread_id, "read_gmail skill");
+
+        let thread = {
+            let mut client = self.client.lock().await;
+            client
+                .get_thread(&thread_id)
+                .await
+                .map_err(|e| anyhow!("read_gmail failed: {e}"))?
+        };
+
+        // user_message:逐封 dump 給 LLM,LLM 自己決定怎麼摘要 / 答 user。
+        let mut s = String::new();
+        s.push_str(&format!("Thread {}:\n\n", thread.id));
+        for (i, m) in thread.messages.iter().enumerate() {
+            s.push_str(&format!(
+                "--- Message {} ---\nFrom: {}\nTo: {}\nDate: {}\nSubject: {}\n\n{}\n\n",
+                i + 1,
+                m.from,
+                m.to.join(", "),
+                m.date.to_rfc3339(),
+                m.subject,
+                m.body_text,
+            ));
+        }
+
+        Ok(SkillOutput {
+            user_message: s,
+            data: Some(serde_json::to_value(&thread)?),
+        })
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Send
+// ─────────────────────────────────────────────────────────────────────
+
+pub struct SendGmailSkill {
+    pub client: Arc<Mutex<GmailClient>>,
+}
+
+impl SendGmailSkill {
+    pub fn new(client: Arc<Mutex<GmailClient>>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl Skill for SendGmailSkill {
+    fn name(&self) -> &'static str {
+        "send_gmail"
+    }
+
+    fn description(&self) -> &'static str {
+        "代亞澤寄一封 Gmail。to 是 recipient list(可多人),subject / body 必填。\
+         可選 `reply_to_thread_id` 把這封接到既有 thread 上(會自動加 In-Reply-To header)。\
+         需要 `gmail.send` scope — 沒授權會回 error,user 需要重跑 OAuth flow 升 scope。\
+         寫之前**先口頭跟 user 確認內容**(寄出就收不回來)。"
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "to": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "收件人 email list(至少一個)。"
+                },
+                "subject": {
+                    "type": "string",
+                    "description": "信件主旨。reply 的話 caller 自己加 `Re: ` prefix。"
+                },
+                "body": {
+                    "type": "string",
+                    "description": "信件純文字內容(LLM 寫好的)。"
+                },
+                "reply_to_thread_id": {
+                    "type": "string",
+                    "description": "可選 — 若是回覆某條既有 thread,傳那條 thread 的 id(從 `list_gmail` / `read_gmail` 拿)。\
+                                    也應從原 message 拿 `message_id` 一起傳 `in_reply_to`(同欄位)— 本層簡化只接 thread_id,\
+                                    `In-Reply-To` 用 thread_id 當 placeholder(Gmail thread 機制本身用 threadId 串)。"
+                },
+                "in_reply_to": {
+                    "type": "string",
+                    "description": "可選 — 原信的 Message-ID header(讀 thread 後從 message data 拿)。\
+                                    若給,會放進 In-Reply-To / References header,對方 mail client 才會顯示為「reply」格式。"
+                }
+            },
+            "required": ["to", "subject", "body"]
+        })
+    }
+
+    fn target_capability(&self) -> ExecutionTarget {
+        ExecutionTarget::Local
+    }
+
+    fn privacy(&self) -> Privacy {
+        Privacy::Cloud
+    }
+
+    /// 寄信是 destructive(寄出去收不回),要 LLM 在 UI 二次確認。
+    fn confirm_required(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, args: Value, _context: &Context) -> Result<SkillOutput> {
+        // 1. parse args
+        let to: Vec<String> = args
+            .get("to")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| anyhow!("missing to (must be array)"))?
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.trim().to_string()))
+            .filter(|s| !s.is_empty())
+            .collect();
+        if to.is_empty() {
+            return Err(anyhow!("to is empty"));
+        }
+        let subject = args
+            .get("subject")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("missing subject"))?
+            .to_string();
+        let body = args
+            .get("body")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("missing body"))?
+            .to_string();
+        let reply_thread_id = args
+            .get("reply_to_thread_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        let in_reply_to = args
+            .get("in_reply_to")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
+        // 2. check send scope before打 API — 沒授權直接回明確 error,user 看了
+        //    才知道要重跑 OAuth flow。Google 本身會 401 / 403 但 error message
+        //    含 "insufficient_scope" 對 LLM 不夠直觀。
+        {
+            let client = self.client.lock().await;
+            if !client.token_snapshot().has_scope(GMAIL_SEND_SCOPE) {
+                return Err(anyhow!(
+                    "send_gmail requires `{}` scope but current token doesn't have it. \
+                     Please re-run OAuth flow with send scope (Mori 設定頁 → Gmail OAuth → \
+                     Re-authorize with send permission).",
+                    GMAIL_SEND_SCOPE,
+                ));
+            }
+        }
+
+        tracing::info!(
+            to_count = to.len(),
+            has_thread = reply_thread_id.is_some(),
+            subject_chars = subject.chars().count(),
+            body_chars = body.chars().count(),
+            "send_gmail skill",
+        );
+
+        // 3. send or reply
+        let outcome = {
+            let mut client = self.client.lock().await;
+            match (reply_thread_id.as_deref(), in_reply_to.as_deref()) {
+                (Some(tid), Some(irt)) => client
+                    .send_reply(tid, &to, &subject, &body, irt)
+                    .await
+                    .map_err(|e| anyhow!("send_reply failed: {e}"))?,
+                (Some(tid), None) => {
+                    // 有 thread_id 但沒 in_reply_to — 用 thread_id 當 placeholder。
+                    // Gmail thread 串接靠 threadId(server-side),Header 主要給對方
+                    // mail client 認 reply 關係,placeholder 仍比沒 header 好。
+                    let placeholder = format!("<{tid}@thread.placeholder>");
+                    client
+                        .send_reply(tid, &to, &subject, &body, &placeholder)
+                        .await
+                        .map_err(|e| anyhow!("send_reply failed: {e}"))?
+                }
+                _ => client
+                    .send_message(&to, &subject, &body)
+                    .await
+                    .map_err(|e| anyhow!("send_message failed: {e}"))?,
+            }
+        };
+
+        let user_message = if reply_thread_id.is_some() {
+            format!(
+                "寄出回覆了。message id {} / thread {}。",
+                outcome.id, outcome.thread_id,
+            )
+        } else {
+            format!(
+                "寄出了。message id {} / thread {}。",
+                outcome.id, outcome.thread_id,
+            )
+        };
+
+        Ok(SkillOutput {
+            user_message,
+            data: Some(json!({
+                "id": outcome.id,
+                "thread_id": outcome.thread_id,
+                "to": to,
+                "subject": subject,
+            })),
+        })
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    //! Skill-level tests — 直接組 `Arc<Mutex<GmailClient>>` 內部用 `GmailClient::with_base`
+    //! 注入 wiremock,驗 dispatch 路徑活著 + args 驗證 + scope guard。
+
+    use super::*;
+    use crate::context::Context as MoriContext;
+    use base64::Engine as _;
+    use chrono::Utc;
+    use mori_gmail::{GmailToken, OAuthConfig, GMAIL_READONLY_SCOPE};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn empty_context() -> MoriContext {
+        MoriContext::default()
+    }
+
+    fn dummy_oauth() -> OAuthConfig {
+        OAuthConfig {
+            client_id: "cid".into(),
+            client_secret: "csecret".into(),
+            redirect_uri: "http://localhost:8765/oauth/callback".into(),
+        }
+    }
+
+    /// token 帶 readonly + send scope(Gm-2 升級後狀態)。
+    fn token_full_scope() -> GmailToken {
+        GmailToken {
+            access_token: "ya29.full".into(),
+            refresh_token: "1//refresh".into(),
+            expires_at: Utc::now() + chrono::Duration::hours(1),
+            scope: format!("{GMAIL_READONLY_SCOPE} {GMAIL_SEND_SCOPE}"),
+            token_type: "Bearer".into(),
+        }
+    }
+
+    /// token 只有 readonly(Gm-1 token 沒升級)。
+    fn token_readonly_only() -> GmailToken {
+        GmailToken {
+            access_token: "ya29.read".into(),
+            refresh_token: "1//refresh".into(),
+            expires_at: Utc::now() + chrono::Duration::hours(1),
+            scope: GMAIL_READONLY_SCOPE.into(),
+            token_type: "Bearer".into(),
+        }
+    }
+
+    fn make_client(mock_uri: String, token: GmailToken) -> Arc<Mutex<GmailClient>> {
+        let dir = tempfile::tempdir().unwrap();
+        // tempdir 在 fn return 前 drop — 但 GmailClient 只在 refresh 時寫 disk,
+        // 測試的 token 都不會過期,不會 trigger 寫;tempdir drop 也只刪空目錄,
+        // 安全。若日後 refresh 路徑要測,改成把 TempDir 持給 Arc 同生命週期。
+        let token_path = dir.path().join("gmail-token.json");
+        let token_endpoint = format!("{mock_uri}/token");
+        let client = GmailClient::with_base(token, dummy_oauth(), token_path, mock_uri, token_endpoint);
+        Arc::new(Mutex::new(client))
+    }
+
+    // ── ListGmailSkill ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn list_gmail_skill_returns_summaries() {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/gmail/v1/users/me/threads"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "threads": [
+                    {"id": "t1", "snippet": "hi", "historyId": "100"},
+                    {"id": "t2", "snippet": "ping", "historyId": "101"}
+                ]
+            })))
+            .mount(&mock)
+            .await;
+
+        let client = make_client(mock.uri(), token_full_scope());
+        let skill = ListGmailSkill::new(client);
+        let out = skill
+            .execute(serde_json::json!({"max": 5}), &empty_context())
+            .await
+            .expect("list ok");
+        assert!(out.user_message.contains("t1"));
+        assert!(out.user_message.contains("hi"));
+        let data = out.data.expect("data present");
+        assert_eq!(data["count"], 2);
+        assert_eq!(data["threads"][0]["id"], "t1");
+    }
+
+    #[tokio::test]
+    async fn list_gmail_skill_returns_empty_message_when_no_threads() {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/gmail/v1/users/me/threads"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&mock)
+            .await;
+
+        let client = make_client(mock.uri(), token_full_scope());
+        let skill = ListGmailSkill::new(client);
+        let out = skill
+            .execute(serde_json::json!({}), &empty_context())
+            .await
+            .expect("ok");
+        assert!(out.user_message.contains("沒有"), "got: {}", out.user_message);
+    }
+
+    // ── ReadGmailSkill ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn read_gmail_skill_dumps_thread_messages() {
+        let mock = MockServer::start().await;
+        let body_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"hello body");
+        Mock::given(method("GET"))
+            .and(path("/gmail/v1/users/me/threads/t-xyz"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "t-xyz",
+                "messages": [{
+                    "id": "m1",
+                    "snippet": "snip",
+                    "internalDate": "1716000000000",
+                    "payload": {
+                        "mimeType": "text/plain",
+                        "headers": [
+                            {"name": "From", "value": "Alice <alice@x.com>"},
+                            {"name": "To", "value": "bob@x.com"},
+                            {"name": "Subject", "value": "Hi"}
+                        ],
+                        "body": {"data": body_b64}
+                    }
+                }]
+            })))
+            .mount(&mock)
+            .await;
+
+        let client = make_client(mock.uri(), token_full_scope());
+        let skill = ReadGmailSkill::new(client);
+        let out = skill
+            .execute(serde_json::json!({"thread_id": "t-xyz"}), &empty_context())
+            .await
+            .expect("read ok");
+        assert!(out.user_message.contains("Alice"));
+        assert!(out.user_message.contains("hello body"));
+        assert!(out.user_message.contains("Hi"));
+        let data = out.data.expect("data");
+        assert_eq!(data["id"], "t-xyz");
+        assert_eq!(data["messages"][0]["subject"], "Hi");
+    }
+
+    #[tokio::test]
+    async fn read_gmail_skill_errors_on_missing_thread_id() {
+        // 不 hit mock — 應該在 arg validation 階段就 fail
+        let mock = MockServer::start().await;
+        let client = make_client(mock.uri(), token_full_scope());
+        let skill = ReadGmailSkill::new(client);
+        let err = skill
+            .execute(serde_json::json!({}), &empty_context())
+            .await
+            .expect_err("missing thread_id");
+        assert!(err.to_string().contains("thread_id"));
+    }
+
+    // ── SendGmailSkill ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn send_gmail_skill_sends_simple_message() {
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/gmail/v1/users/me/messages/send"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "sent-1",
+                "threadId": "thread-new"
+            })))
+            .mount(&mock)
+            .await;
+
+        let client = make_client(mock.uri(), token_full_scope());
+        let skill = SendGmailSkill::new(client);
+        let out = skill
+            .execute(
+                serde_json::json!({
+                    "to": ["bob@x.com"],
+                    "subject": "hi",
+                    "body": "hello"
+                }),
+                &empty_context(),
+            )
+            .await
+            .expect("send ok");
+        assert!(out.user_message.contains("sent-1"));
+        let data = out.data.expect("data");
+        assert_eq!(data["id"], "sent-1");
+        assert_eq!(data["thread_id"], "thread-new");
+    }
+
+    #[tokio::test]
+    async fn send_gmail_skill_blocks_when_token_missing_send_scope() {
+        // mock 即使有也不該被 hit — scope guard 先 fail
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/gmail/v1/users/me/messages/send"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "should-not-happen",
+                "threadId": "x"
+            })))
+            .mount(&mock)
+            .await;
+
+        let client = make_client(mock.uri(), token_readonly_only());
+        let skill = SendGmailSkill::new(client);
+        let err = skill
+            .execute(
+                serde_json::json!({
+                    "to": ["bob@x.com"],
+                    "subject": "hi",
+                    "body": "hello"
+                }),
+                &empty_context(),
+            )
+            .await
+            .expect_err("scope guard should fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("scope") && msg.contains("send"),
+            "expected scope-related error, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_gmail_skill_errors_on_missing_required_args() {
+        let mock = MockServer::start().await;
+        let client = make_client(mock.uri(), token_full_scope());
+        let skill = SendGmailSkill::new(client);
+
+        // 缺 to
+        let err = skill
+            .execute(
+                serde_json::json!({"subject": "s", "body": "b"}),
+                &empty_context(),
+            )
+            .await
+            .expect_err("missing to");
+        assert!(err.to_string().contains("to"));
+
+        // empty to
+        let err = skill
+            .execute(
+                serde_json::json!({"to": [], "subject": "s", "body": "b"}),
+                &empty_context(),
+            )
+            .await
+            .expect_err("empty to");
+        assert!(err.to_string().contains("to"));
+    }
+
+    // ── name / description / schema 完整性 ─────────────────────────
+
+    #[test]
+    fn skill_metadata_is_set() {
+        // 不需要 client(metadata 不打 IO),但 trait method 仍要 self —
+        // 給空 mock client。
+        let dummy = Arc::new(Mutex::new(GmailClient::with_base(
+            token_full_scope(),
+            dummy_oauth(),
+            std::path::PathBuf::from("/tmp/x"),
+            "http://localhost",
+            "http://localhost/token",
+        )));
+        let list = ListGmailSkill::new(dummy.clone());
+        assert_eq!(list.name(), "list_gmail");
+        assert!(!list.description().is_empty());
+
+        let read = ReadGmailSkill::new(dummy.clone());
+        assert_eq!(read.name(), "read_gmail");
+        let schema = read.parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v == "thread_id"));
+
+        let send = SendGmailSkill::new(dummy);
+        assert_eq!(send.name(), "send_gmail");
+        assert!(send.confirm_required(), "send should be confirm-required");
+        let schema = send.parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        for needle in ["to", "subject", "body"] {
+            assert!(
+                required.iter().any(|v| v.as_str() == Some(needle)),
+                "send_gmail schema must require {needle}"
+            );
+        }
+    }
+}

--- a/crates/mori-core/src/skill/mod.rs
+++ b/crates/mori-core/src/skill/mod.rs
@@ -212,6 +212,12 @@ pub mod python_runner;
 // `name()` 格式 `mcp_<server>_<tool>`,避免跟既有 skill collision。
 mod mcp_tool;
 
+// Wave 8 Gm-2「跨界之手」:Gmail 系列 skill — `list_gmail` / `read_gmail` /
+// `send_gmail`。共用一份 `Arc<Mutex<mori_gmail::GmailClient>>`,Tauri 端啟動時
+// 從 `~/.mori/gmail-config.json` + `~/.mori/gmail-token.json` 建,沒 init 成功
+// 整組 skill 都不註冊(LLM 看不到工具)。
+pub mod gmail;
+
 pub use echo::EchoSkill;
 pub use edit::EditMemorySkill;
 pub use forget::ForgetMemorySkill;
@@ -237,6 +243,8 @@ pub use anthropic_skill::{
 };
 
 pub use mcp_tool::McpToolSkill;
+
+pub use gmail::{ListGmailSkill, ReadGmailSkill, SendGmailSkill, SharedGmailClient};
 
 // ─── 共用 helpers(memory-related skills 用)────────────────────────
 

--- a/crates/mori-gmail/src/client.rs
+++ b/crates/mori-gmail/src/client.rs
@@ -254,6 +254,138 @@ impl GmailClient {
         let parsed: ListResp = resp.json().await?;
         Ok(parsed.labels)
     }
+
+    /// `POST /gmail/v1/users/me/messages/send` — 寄一封新 message。
+    ///
+    /// `to` 是 recipient list,`subject` / `body` 是 plain text 內容。Body 是
+    /// RFC 822 格式 + base64url encode 後塞到 `raw` 欄位。
+    ///
+    /// 需要 `gmail.send` scope。Token 沒這個 scope 會被 Google 401 / 403,
+    /// caller(`SendGmailSkill`)應在進場前先 `token.has_scope(...)` check。
+    ///
+    /// 回傳 `SendOutcome { id, thread_id }` — Google 在 send 成功後告訴你新 message
+    /// 在哪條 thread 上(send 沒指定 threadId 時 Google 自己 assign 一條新 thread)。
+    pub async fn send_message(
+        &mut self,
+        to: &[String],
+        subject: &str,
+        body: &str,
+    ) -> Result<SendOutcome, GmailError> {
+        let raw = build_rfc822_message(to, subject, body, None, None);
+        self.send_raw(&raw, None).await
+    }
+
+    /// `POST /gmail/v1/users/me/messages/send` — 回某條既有 thread。
+    ///
+    /// 相較於 [`send_message`]:
+    /// - body 內加 `In-Reply-To: <in_reply_to>` + `References: <in_reply_to>` headers,
+    ///   讓 Gmail / 對方 mail client 認得這是 thread 內回覆
+    /// - request body 加 `threadId` 欄位讓 Gmail 把 message 接到正確 thread
+    ///
+    /// `subject` 通常 caller 已加 "Re: " prefix(這層不自動加 — 讓 caller 決定
+    /// 「Re:」「回覆:」「Fwd:」等格式)。
+    pub async fn send_reply(
+        &mut self,
+        thread_id: &str,
+        to: &[String],
+        subject: &str,
+        body: &str,
+        in_reply_to: &str,
+    ) -> Result<SendOutcome, GmailError> {
+        let raw = build_rfc822_message(to, subject, body, Some(in_reply_to), Some(in_reply_to));
+        self.send_raw(&raw, Some(thread_id)).await
+    }
+
+    /// 共用底層:`POST /messages/send`,body `{ raw, threadId? }`。
+    async fn send_raw(
+        &mut self,
+        raw_rfc822: &str,
+        thread_id: Option<&str>,
+    ) -> Result<SendOutcome, GmailError> {
+        self.ensure_fresh_token().await?;
+        let url = format!("{}/gmail/v1/users/me/messages/send", self.api_base);
+
+        let encoded =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw_rfc822.as_bytes());
+        let mut body_json = serde_json::json!({ "raw": encoded });
+        if let Some(tid) = thread_id {
+            body_json["threadId"] = serde_json::Value::String(tid.to_string());
+        }
+
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(&self.token.access_token)
+            .json(&body_json)
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(GmailError::Api {
+                status: status.as_u16(),
+                message: body,
+            });
+        }
+
+        // Gmail 對 send 成功回 `{ "id": "...", "threadId": "...", "labelIds": [...] }`。
+        // 只取我們關心的兩個欄位。
+        #[derive(Deserialize)]
+        struct SendResp {
+            id: String,
+            #[serde(default, rename = "threadId")]
+            thread_id: String,
+        }
+        let parsed: SendResp = resp.json().await?;
+        Ok(SendOutcome {
+            id: parsed.id,
+            thread_id: parsed.thread_id,
+        })
+    }
+}
+
+/// `send_message` / `send_reply` 成功回傳。Gmail 對 send 的 response 是
+/// `{ id, threadId, labelIds }`,我們只 surface 前兩個給 caller / LLM。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SendOutcome {
+    pub id: String,
+    pub thread_id: String,
+}
+
+/// 拼一封純文字 RFC 822 message(headers + 空行 + body)。
+///
+/// 公開出來供測試 + Skill caller debug 用。實際上不直接送 — `send_message` /
+/// `send_reply` 內部呼叫並 base64url encode。
+///
+/// 規則:
+/// - `To` 是 comma-separated(多人收件)
+/// - 沒指定 `From` — Gmail 會自動填認證的 user email
+/// - body 一律 `Content-Type: text/plain; charset=UTF-8`(LLM 多半也只會寫純文字)
+/// - reply 時帶 `In-Reply-To` + `References`(同個 Message-ID;簡化處理 — Google
+///   會再幫 thread 串好。RFC 5322 嚴格上 References 應該是整條 chain,但 Gmail
+///   thread 是用 thread_id 串的,header 主要給對方 mail client 認 reply 關係)
+pub fn build_rfc822_message(
+    to: &[String],
+    subject: &str,
+    body: &str,
+    in_reply_to: Option<&str>,
+    references: Option<&str>,
+) -> String {
+    let to_joined = to.join(", ");
+    let mut out = String::new();
+    out.push_str(&format!("To: {to_joined}\r\n"));
+    out.push_str(&format!("Subject: {subject}\r\n"));
+    out.push_str("Content-Type: text/plain; charset=UTF-8\r\n");
+    out.push_str("MIME-Version: 1.0\r\n");
+    if let Some(irt) = in_reply_to {
+        out.push_str(&format!("In-Reply-To: {irt}\r\n"));
+    }
+    if let Some(refs) = references {
+        out.push_str(&format!("References: {refs}\r\n"));
+    }
+    out.push_str("\r\n");
+    out.push_str(body);
+    out
 }
 
 // =================== 解析 Gmail JSON ===================
@@ -665,5 +797,205 @@ mod tests {
         // "Hi" -> "SGk"(沒 = padding)
         let got = decode_base64url("SGk").expect("ok");
         assert_eq!(got, "Hi");
+    }
+
+    // ────────────────────────── Gm-2 send tests ──────────────────────────
+
+    fn send_scoped_token() -> GmailToken {
+        // 模擬完成 Gm-2 升 scope 後拿到的 token(含 readonly + send 兩個 scope)。
+        GmailToken {
+            access_token: "ya29.send-ok".into(),
+            refresh_token: "1//refresh".into(),
+            expires_at: Utc::now() + chrono::Duration::hours(1),
+            scope: format!(
+                "{} {}",
+                crate::oauth::GMAIL_READONLY_SCOPE,
+                crate::oauth::GMAIL_SEND_SCOPE,
+            ),
+            token_type: "Bearer".into(),
+        }
+    }
+
+    #[test]
+    fn build_rfc822_message_renders_headers_and_body() {
+        let to = vec!["bob@example.com".to_string(), "carol@example.com".to_string()];
+        let raw = build_rfc822_message(&to, "Hi Bob", "Hello from Mori", None, None);
+
+        assert!(raw.contains("To: bob@example.com, carol@example.com\r\n"));
+        assert!(raw.contains("Subject: Hi Bob\r\n"));
+        assert!(raw.contains("Content-Type: text/plain; charset=UTF-8\r\n"));
+        assert!(raw.contains("MIME-Version: 1.0\r\n"));
+        // headers / body 之間應該有空行(\r\n\r\n)
+        assert!(raw.contains("\r\n\r\nHello from Mori"));
+        // 沒指定 reply headers 時不應出現
+        assert!(!raw.contains("In-Reply-To"));
+        assert!(!raw.contains("References"));
+    }
+
+    #[test]
+    fn build_rfc822_message_includes_reply_headers() {
+        let to = vec!["alice@example.com".to_string()];
+        let raw = build_rfc822_message(
+            &to,
+            "Re: hi",
+            "Sure thing.",
+            Some("<msg-abc@mail.gmail.com>"),
+            Some("<msg-abc@mail.gmail.com>"),
+        );
+
+        assert!(raw.contains("In-Reply-To: <msg-abc@mail.gmail.com>\r\n"));
+        assert!(raw.contains("References: <msg-abc@mail.gmail.com>\r\n"));
+        assert!(raw.contains("\r\n\r\nSure thing."));
+    }
+
+    #[tokio::test]
+    async fn send_message_builds_rfc822_and_posts_to_send_endpoint() {
+        let mock = MockServer::start().await;
+
+        // 攔 send endpoint 並驗 body 結構
+        let send_body = serde_json::json!({
+            "id": "msg-newly-sent",
+            "threadId": "thread-fresh",
+            "labelIds": ["SENT"]
+        });
+        Mock::given(method("POST"))
+            .and(path("/gmail/v1/users/me/messages/send"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(send_body))
+            .mount(&mock)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = GmailClient::with_base(
+            send_scoped_token(),
+            dummy_config(),
+            dir.path().join("gmail-token.json"),
+            mock.uri(),
+            format!("{}/token", mock.uri()),
+        );
+
+        let to = vec!["bob@example.com".to_string()];
+        let outcome = client
+            .send_message(&to, "Test subj", "Test body")
+            .await
+            .expect("send ok");
+        assert_eq!(outcome.id, "msg-newly-sent");
+        assert_eq!(outcome.thread_id, "thread-fresh");
+
+        // 也檢 mock 確實收到 1 個 POST(wiremock 內建 verify_received)
+        let received = mock.received_requests().await.unwrap_or_default();
+        let send_req = received
+            .iter()
+            .find(|r| r.url.path() == "/gmail/v1/users/me/messages/send")
+            .expect("send request recorded");
+        // body 是 JSON `{ raw: base64url(rfc822) }`,decode 應含我們的 headers + body
+        let json: serde_json::Value =
+            serde_json::from_slice(&send_req.body).expect("body json");
+        let raw_b64 = json["raw"].as_str().expect("raw field");
+        let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(raw_b64)
+            .expect("base64 decode");
+        let decoded_str = String::from_utf8(decoded).expect("utf-8");
+        assert!(decoded_str.contains("To: bob@example.com"));
+        assert!(decoded_str.contains("Subject: Test subj"));
+        assert!(decoded_str.contains("\r\n\r\nTest body"));
+        // send_message 沒 threadId 欄位
+        assert!(json.get("threadId").is_none(), "send_message must not include threadId");
+    }
+
+    #[tokio::test]
+    async fn send_message_returns_api_error_for_4xx() {
+        let mock = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/gmail/v1/users/me/messages/send"))
+            .respond_with(
+                ResponseTemplate::new(403).set_body_string(
+                    r#"{"error":{"code":403,"message":"Request had insufficient authentication scopes."}}"#,
+                ),
+            )
+            .mount(&mock)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = GmailClient::with_base(
+            // 故意只給 readonly scope — 但實際上這層不 check,Google 端會 403
+            fresh_token(),
+            dummy_config(),
+            dir.path().join("gmail-token.json"),
+            mock.uri(),
+            format!("{}/token", mock.uri()),
+        );
+
+        let err = client
+            .send_message(&["x@y.z".into()], "s", "b")
+            .await
+            .expect_err("403 expected");
+        match err {
+            GmailError::Api { status, message } => {
+                assert_eq!(status, 403);
+                assert!(
+                    message.contains("insufficient"),
+                    "expected scope error, got: {message}"
+                );
+            }
+            other => panic!("expected Api 403, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_reply_includes_thread_id_and_reply_headers() {
+        let mock = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/gmail/v1/users/me/messages/send"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "msg-reply-789",
+                "threadId": "thread-original",
+                "labelIds": ["SENT"]
+            })))
+            .mount(&mock)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut client = GmailClient::with_base(
+            send_scoped_token(),
+            dummy_config(),
+            dir.path().join("gmail-token.json"),
+            mock.uri(),
+            format!("{}/token", mock.uri()),
+        );
+
+        let to = vec!["alice@example.com".into()];
+        let outcome = client
+            .send_reply(
+                "thread-original",
+                &to,
+                "Re: hello",
+                "ack.",
+                "<orig-msg-id@mail.gmail.com>",
+            )
+            .await
+            .expect("reply ok");
+
+        assert_eq!(outcome.id, "msg-reply-789");
+        assert_eq!(outcome.thread_id, "thread-original");
+
+        // 驗 send request body:應含 threadId + In-Reply-To header
+        let received = mock.received_requests().await.unwrap_or_default();
+        let send_req = received
+            .iter()
+            .find(|r| r.url.path() == "/gmail/v1/users/me/messages/send")
+            .expect("send request recorded");
+        let json: serde_json::Value =
+            serde_json::from_slice(&send_req.body).expect("body json");
+        assert_eq!(json["threadId"], "thread-original");
+        let raw_b64 = json["raw"].as_str().expect("raw");
+        let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(raw_b64)
+            .expect("decode");
+        let decoded_str = String::from_utf8(decoded).expect("utf-8");
+        assert!(decoded_str.contains("In-Reply-To: <orig-msg-id@mail.gmail.com>"));
+        assert!(decoded_str.contains("References: <orig-msg-id@mail.gmail.com>"));
+        assert!(decoded_str.contains("Subject: Re: hello"));
     }
 }

--- a/crates/mori-gmail/src/lib.rs
+++ b/crates/mori-gmail/src/lib.rs
@@ -33,7 +33,7 @@
 //!
 //! // 第一次 consent
 //! let config = OAuthConfig::load(&OAuthConfig::default_path().unwrap())?;
-//! let token = run_oauth_flow(&config, "csrf-state-token", GMAIL_READONLY_SCOPE).await?;
+//! let token = run_oauth_flow(&config, "csrf-state-token", &[GMAIL_READONLY_SCOPE]).await?;
 //! token.save(&default_token_path().unwrap())?;
 //!
 //! // 之後 API 用
@@ -58,9 +58,13 @@ pub mod client;
 pub mod oauth;
 pub mod token;
 
-pub use client::{GmailClient, GmailError, Label, Message, Thread, ThreadSummary, GMAIL_API_BASE};
+pub use client::{
+    build_rfc822_message, GmailClient, GmailError, Label, Message, SendOutcome, Thread,
+    ThreadSummary, GMAIL_API_BASE,
+};
 pub use oauth::{
     build_auth_url, refresh_token, run_oauth_flow, OAuthConfig, OAuthError,
-    GMAIL_READONLY_SCOPE, GOOGLE_AUTH_URL, GOOGLE_TOKEN_URL,
+    GMAIL_DEFAULT_SCOPES, GMAIL_READONLY_SCOPE, GMAIL_SEND_SCOPE, GOOGLE_AUTH_URL,
+    GOOGLE_TOKEN_URL,
 };
 pub use token::{default_token_path, GmailToken, TokenError};

--- a/crates/mori-gmail/src/oauth.rs
+++ b/crates/mori-gmail/src/oauth.rs
@@ -45,6 +45,12 @@ use crate::token::{home_dir, GmailToken, TokenError};
 /// Gm-1 唯一 scope。Gm-2 接 send 時會擴成 `"gmail.readonly gmail.send"`。
 pub const GMAIL_READONLY_SCOPE: &str = "https://www.googleapis.com/auth/gmail.readonly";
 
+/// Gm-2 升 scope:`gmail.send`(POST /messages/send 需要)。
+pub const GMAIL_SEND_SCOPE: &str = "https://www.googleapis.com/auth/gmail.send";
+
+/// Gm-2 預設組合 scope — readonly + send。Mori 對 Gmail 的標準授權集合。
+pub const GMAIL_DEFAULT_SCOPES: &[&str] = &[GMAIL_READONLY_SCOPE, GMAIL_SEND_SCOPE];
+
 /// Google OAuth2 endpoints。獨立常數方便測試時改寫(client 層走 mock server)。
 pub const GOOGLE_AUTH_URL: &str = "https://accounts.google.com/o/oauth2/v2/auth";
 pub const GOOGLE_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
@@ -136,18 +142,20 @@ struct TokenResponse {
 /// `state` 是 caller 提供的 CSRF token,callback 必須回相同 state。Caller 自己生
 /// 隨機字串(不在這層引 rand crate)。
 ///
-/// Scope 由 caller 控制(Gm-1 固定 [`GMAIL_READONLY_SCOPE`])— 留參數以便 Gm-2
-/// 升 scope 時不用改 API。
-pub fn build_auth_url(config: &OAuthConfig, scope: &str, state: &str) -> String {
+/// Scopes 由 caller 控制 — Gm-1 用 `[GMAIL_READONLY_SCOPE]`,Gm-2 升級成
+/// `[GMAIL_READONLY_SCOPE, GMAIL_SEND_SCOPE]`(也就是 `GMAIL_DEFAULT_SCOPES`)。
+/// Google 對 scope 的格式是 single string、space-separated;這層把 slice join 起來。
+pub fn build_auth_url(config: &OAuthConfig, scopes: &[&str], state: &str) -> String {
     // 標準 OAuth2 query。`access_type=offline` 才會回 refresh_token;
     // `prompt=consent` 強制每次都跑 consent UI(避免 user 已給過 readonly 但要升 scope 時
     // Google 跳過 consent)。Gm-1 兩者都加,Gm-2 升 scope 也照樣 work。
+    let scope_joined = scopes.join(" ");
     let mut url = Url::parse(GOOGLE_AUTH_URL).expect("hard-coded URL must parse");
     url.query_pairs_mut()
         .append_pair("client_id", &config.client_id)
         .append_pair("redirect_uri", &config.redirect_uri)
         .append_pair("response_type", "code")
-        .append_pair("scope", scope)
+        .append_pair("scope", &scope_joined)
         .append_pair("access_type", "offline")
         .append_pair("prompt", "consent")
         .append_pair("state", state);
@@ -215,7 +223,7 @@ fn redirect_port(redirect_uri: &str) -> Result<u16, OAuthError> {
 pub async fn run_oauth_flow(
     config: &OAuthConfig,
     expected_state: &str,
-    scope: &str,
+    scopes: &[&str],
 ) -> Result<GmailToken, OAuthError> {
     let port = redirect_port(&config.redirect_uri)?;
     let expected_state_owned = expected_state.to_string();
@@ -233,7 +241,9 @@ pub async fn run_oauth_flow(
     })??;
 
     // 2. exchange code → token
-    exchange_code(config, &code, scope).await
+    //    scope 在 exchange_code 內目前用不到(Google 從 authorization code 自身解出
+    //    granted scope),參數保留供未來 PKCE / scope-down-grade 場景擴用。
+    exchange_code(config, &code, scopes).await
 }
 
 /// 阻塞等 listener 接到第一筆 callback,parse code,回應 user 一頁簡單 HTML 後關 socket。
@@ -327,7 +337,7 @@ fn callback_response_body(message: &str) -> String {
 async fn exchange_code(
     config: &OAuthConfig,
     code: &str,
-    _scope: &str,
+    _scopes: &[&str],
 ) -> Result<GmailToken, OAuthError> {
     exchange_code_at(config, code, GOOGLE_TOKEN_URL).await
 }
@@ -457,7 +467,7 @@ mod tests {
             client_secret: "secret".into(),
             redirect_uri: "http://localhost:8765/oauth/callback".into(),
         };
-        let url = build_auth_url(&cfg, GMAIL_READONLY_SCOPE, "state-abc");
+        let url = build_auth_url(&cfg, &[GMAIL_READONLY_SCOPE], "state-abc");
 
         // 不假設 query order,只 assert 必要參數都在。
         assert!(url.starts_with(GOOGLE_AUTH_URL), "url: {url}");
@@ -474,6 +484,26 @@ mod tests {
         assert!(
             url.contains("scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.readonly"),
             "url should contain encoded scope: {url}"
+        );
+    }
+
+    #[test]
+    fn build_auth_url_joins_multi_scope_with_space() {
+        let cfg = OAuthConfig {
+            client_id: "cid".into(),
+            client_secret: "secret".into(),
+            redirect_uri: "http://localhost:8765/oauth/callback".into(),
+        };
+        let url = build_auth_url(&cfg, GMAIL_DEFAULT_SCOPES, "s");
+
+        // 兩個 scope 用 `+`(url-encoded space)分隔。
+        // Order = caller-provided slice order → readonly first, send second。
+        assert!(
+            url.contains(
+                "scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.readonly+\
+                 https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.send"
+            ),
+            "url should contain both scopes joined with space: {url}"
         );
     }
 

--- a/crates/mori-gmail/src/token.rs
+++ b/crates/mori-gmail/src/token.rs
@@ -71,6 +71,17 @@ impl GmailToken {
         self.expires_at <= threshold
     }
 
+    /// 此 token 是否包含某個 OAuth scope。Google 在 token endpoint 回的 `scope`
+    /// 欄位是 **space-separated 完整 URL**(eg
+    /// `"https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.send"`),
+    /// 我們直接 split-whitespace + 等值比對。
+    ///
+    /// Gm-2 在 `SendGmailSkill::execute` 進場前先 check `has_scope(GMAIL_SEND_SCOPE)`,
+    /// false 就回 "需要重新 OAuth" 給 LLM,LLM 再轉達給 user。
+    pub fn has_scope(&self, scope: &str) -> bool {
+        self.scope.split_whitespace().any(|s| s == scope)
+    }
+
     /// 從 disk load。檔案不存在 → [`TokenError::Io`](kind = NotFound);
     /// 內容不合 JSON → [`TokenError::Json`]。
     pub fn load(path: &Path) -> Result<Self, TokenError> {
@@ -166,6 +177,23 @@ mod tests {
             token.is_expired(),
             "within-30s expiry should be flagged as expired (buffer)"
         );
+    }
+
+    #[test]
+    fn has_scope_detects_individual_scope_in_space_separated_list() {
+        let mut t = sample_token(Utc::now() + Duration::hours(1));
+        // 單一 scope
+        t.scope = "https://www.googleapis.com/auth/gmail.readonly".into();
+        assert!(t.has_scope("https://www.googleapis.com/auth/gmail.readonly"));
+        assert!(!t.has_scope("https://www.googleapis.com/auth/gmail.send"));
+
+        // 雙 scope(Gm-2 升級後)
+        t.scope = "https://www.googleapis.com/auth/gmail.readonly \
+                   https://www.googleapis.com/auth/gmail.send"
+            .into();
+        assert!(t.has_scope("https://www.googleapis.com/auth/gmail.readonly"));
+        assert!(t.has_scope("https://www.googleapis.com/auth/gmail.send"));
+        assert!(!t.has_scope("https://www.googleapis.com/auth/gmail.compose"));
     }
 
     #[test]

--- a/crates/mori-tauri/Cargo.toml
+++ b/crates/mori-tauri/Cargo.toml
@@ -27,6 +27,12 @@ mori-time = { path = "../mori-time" }
 # dispatch tool call;mcp_cmd.rs 內的 Tauri commands 也 share 同一份。
 # 純 leaf crate(只 depend rmcp / serde / tokio / tracing),無 cycle 風險。
 mori-mcp = { path = "../mori-mcp" }
+# Wave 8 Gm-2 「跨界之手」 — mori-gmail::GmailClient + OAuth flow。Tauri 端啟動時
+# 嘗試從 ~/.mori/gmail-config.json + ~/.mori/gmail-token.json 建一份 client(沒設
+# 就 skip,Gmail skill 不註冊)。`gmail_cmd.rs` 提供 OAuth start / status / list /
+# read / send 等 Tauri commands;`SharedGmailClient`(mori-core)註冊進 Tauri
+# Manager,Gmail 系列 skill 共用同一份 Arc<Mutex<GmailClient>>。
+mori-gmail = { path = "../mori-gmail" }
 tauri = { version = "2", features = ["tray-icon", "image-png", "devtools"] }
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-global-shortcut = "2"
@@ -129,3 +135,6 @@ custom-protocol = ["tauri/custom-protocol"]
 [dev-dependencies]
 # Wave 4 annuli_config tests 用 NamedTempFile 寫測試用 config.json
 tempfile = "3"
+# Wave 8 Gm-2:`gmail_cmd::tests` 走 wiremock mock Gmail REST endpoint,
+# 對齊 mori-gmail / mori-core 內部 client tests 風格。
+wiremock = "0.6"

--- a/crates/mori-tauri/src/deps.rs
+++ b/crates/mori-tauri/src/deps.rs
@@ -987,6 +987,51 @@ pub fn registry() -> Vec<DepSpec> {
                 }),
             ],
         },
+        // Wave 8 Gm-2「跨界之手」:Gmail 整合 OAuth setup。check 看 token 檔是否存在
+        // ;install 是 manual 引導(user 需要在 Google Cloud Console 自建 OAuth client,
+        // 沒辦法 one-click — Mori 不能用 yazelin 的 client_id 代收 token,違反
+        // user-owned data 原則)。Tauri command `gmail_oauth_start_cmd` 跑 listener,
+        // 但 client_id / client_secret 必須先擺進 ~/.mori/gmail-config.json。
+        DepSpec {
+            id: "gmail-oauth",
+            name: "Gmail OAuth(跨界之手)",
+            description: "Gmail 整合 — 代亞澤讀 / 發 email。需 user 自己在 Google Cloud \
+                          Console 建 OAuth client(Desktop type),拿到 client_id / \
+                          client_secret 後寫進 ~/.mori/gmail-config.json,Mori 重啟跑 \
+                          gmail_oauth_start_cmd 觸發 consent flow。**沒有中央 OAuth \
+                          relay** — token 直接放 user 本機,Mori binary 跟 Google 直連。",
+            unlocks: "list_gmail / read_gmail / send_gmail LLM skill + Tauri commands",
+            size_hint: None,
+            needs_sudo: false,
+            platforms: &["linux", "macos", "windows"],
+            install_caveat: Some(
+                "OAuth flow 需要瀏覽器 — Mori 會 spawn localhost:8765 接 callback。\
+                 第一次 consent 需要 user 在 Google Cloud Console「OAuth 同意畫面」加\
+                 自己 email 為 test user(否則 Google 拒絕陌生 client)。",
+            ),
+            check: CheckSpec::File {
+                path_template: "$HOME/.mori/gmail-token.json",
+            },
+            check_overrides: &[
+                ("windows", CheckSpec::File {
+                    path_template: "$USERPROFILE\\.mori\\gmail-token.json",
+                }),
+            ],
+            install: InstallSpec::Manual {
+                commands: &[
+                    "# 1. 開 https://console.cloud.google.com → 建 project → 啟用 Gmail API",
+                    "# 2. 「API 與服務」→ 「OAuth 同意畫面」→ 加你自己 email 為 test user",
+                    "# 3. 「憑證」→ 建 OAuth 用戶端 → Desktop app type → 下載 JSON",
+                    "# 4. 改名 ~/.mori/gmail-config.json,內容改成這格式:",
+                    "#    {\"client_id\":\"...\", \"client_secret\":\"...\", \
+                       \"redirect_uri\":\"http://localhost:8765/oauth/callback\"}",
+                    "# 5. 重啟 Mori,跑 Tauri command gmail_oauth_start_cmd(前端 \
+                       OAuth 按鈕 / 或開 devtools invoke『gmail_oauth_start_cmd』)",
+                    "# 6. 瀏覽器跑完 consent → token 自動存 ~/.mori/gmail-token.json",
+                ],
+            },
+            install_overrides: &[],
+        },
     ]
 }
 

--- a/crates/mori-tauri/src/gmail_cmd.rs
+++ b/crates/mori-tauri/src/gmail_cmd.rs
@@ -1,0 +1,463 @@
+//! Tauri commands bridging mori-gmail 到 IPC / LLM tool(Wave 8 Gm-2)。
+//!
+//! 對齊 `reminders_cmd.rs` 的「do_* helper + #[tauri::command] wrapper」風格 —
+//! command 內帶 `tauri::State` 很難 unit test,把實質邏輯拆出來。
+//!
+//! ## 五條 commands
+//!
+//! - `gmail_oauth_start_cmd(scopes)` — 跑完整 OAuth flow(spawn listener、等 user
+//!   在瀏覽器同意、save token)。**不會自動開瀏覽器**,只回 auth URL 給前端去開
+//!   (前端用 `open_external_url` Tauri command 自己處理)。回 `()`。
+//! - `gmail_oauth_status_cmd()` — 看 ~/.mori/gmail-token.json 是否存在、是否含
+//!   send scope。回 `GmailOAuthStatus { authorized, has_send_scope }`。
+//! - `gmail_list_threads_cmd(query?, max?)` — 對映 `GmailClient::list_threads`。
+//! - `gmail_get_thread_cmd(thread_id)` — 對映 `GmailClient::get_thread`。
+//! - `gmail_send_cmd(to, subject, body, reply_to_thread_id?, in_reply_to?)` —
+//!   寄信(或回覆既有 thread)。
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+use mori_core::skill::SharedGmailClient;
+use mori_gmail::{
+    default_token_path, GmailClient, GmailToken, OAuthConfig, SendOutcome, Thread,
+    ThreadSummary, GMAIL_DEFAULT_SCOPES, GMAIL_SEND_SCOPE,
+};
+
+// ─────────────────────────────────────────────────────────────────────
+// 啟動時:嘗試 init client(沒 config / 沒 token 就回 None)
+// ─────────────────────────────────────────────────────────────────────
+
+/// 嘗試從本機既有 config + token 建一份 GmailClient。
+///
+/// 流程:
+/// 1. `~/.mori/gmail-config.json` 存在 → load OAuthConfig,否則 None
+/// 2. `~/.mori/gmail-token.json` 存在 → GmailClient::new 載 token,否則 None
+///
+/// 失敗一律回 None(`tracing::warn` 記錄原因)— gmail 是 optional feature,
+/// 任何啟動失敗都不該擋住 Mori 主功能。Caller 拿到 None 就不註冊 Gmail skill /
+/// 不 .manage(SharedGmailClient),LLM 看不到 Gmail 工具。
+pub async fn init_gmail_client_optional() -> Option<SharedGmailClient> {
+    let config_path = OAuthConfig::default_path()?;
+    if !config_path.exists() {
+        tracing::info!(
+            path = %config_path.display(),
+            "gmail-config.json not found — Gmail skills disabled",
+        );
+        return None;
+    }
+    let config = match OAuthConfig::load(&config_path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(
+                path = %config_path.display(),
+                error = %e,
+                "gmail-config.json load failed — Gmail skills disabled",
+            );
+            return None;
+        }
+    };
+    let token_path = default_token_path()?;
+    if !token_path.exists() {
+        tracing::info!(
+            path = %token_path.display(),
+            "gmail-token.json not found (need OAuth consent first) — Gmail skills disabled",
+        );
+        return None;
+    }
+    let client = match GmailClient::new(token_path, config).await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(error = %e, "GmailClient::new failed — Gmail skills disabled");
+            return None;
+        }
+    };
+    Some(SharedGmailClient(Arc::new(Mutex::new(client))))
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 內部 helpers(無 Tauri State,可直接 unit test)
+// ─────────────────────────────────────────────────────────────────────
+
+/// `gmail_oauth_status_cmd` 的 helper — 給 token_path 自己控制(unit test 用 tempdir)。
+pub(crate) fn do_oauth_status(token_path: &PathBuf) -> GmailOAuthStatus {
+    match GmailToken::load(token_path) {
+        Ok(t) => GmailOAuthStatus {
+            authorized: true,
+            has_send_scope: t.has_scope(GMAIL_SEND_SCOPE),
+            scope: t.scope.clone(),
+        },
+        Err(_) => GmailOAuthStatus {
+            authorized: false,
+            has_send_scope: false,
+            scope: String::new(),
+        },
+    }
+}
+
+/// `gmail_list_threads_cmd` 的 helper。
+pub(crate) async fn do_list_threads(
+    client: &Mutex<GmailClient>,
+    query: Option<String>,
+    max: Option<u32>,
+) -> Result<Vec<ThreadSummary>, String> {
+    let mut c = client.lock().await;
+    c.list_threads(query.as_deref(), max.unwrap_or(10))
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// `gmail_get_thread_cmd` 的 helper。
+pub(crate) async fn do_get_thread(
+    client: &Mutex<GmailClient>,
+    thread_id: String,
+) -> Result<Thread, String> {
+    let mut c = client.lock().await;
+    c.get_thread(&thread_id).await.map_err(|e| e.to_string())
+}
+
+/// `gmail_send_cmd` 的 helper。
+pub(crate) async fn do_send(
+    client: &Mutex<GmailClient>,
+    to: Vec<String>,
+    subject: String,
+    body: String,
+    reply_to_thread_id: Option<String>,
+    in_reply_to: Option<String>,
+) -> Result<SendOutcome, String> {
+    // scope guard — 對齊 SendGmailSkill 的行為:先 check token scope,讓 error
+    // 訊息對 user / LLM 友善(Google 自己回 403 但 message 不夠直觀)。
+    {
+        let c = client.lock().await;
+        if !c.token_snapshot().has_scope(GMAIL_SEND_SCOPE) {
+            return Err(format!(
+                "send_gmail requires `{}` scope; please re-run OAuth flow",
+                GMAIL_SEND_SCOPE,
+            ));
+        }
+    }
+    let mut c = client.lock().await;
+    match (reply_to_thread_id.as_deref(), in_reply_to.as_deref()) {
+        (Some(tid), Some(irt)) => c
+            .send_reply(tid, &to, &subject, &body, irt)
+            .await
+            .map_err(|e| e.to_string()),
+        (Some(tid), None) => {
+            let placeholder = format!("<{tid}@thread.placeholder>");
+            c.send_reply(tid, &to, &subject, &body, &placeholder)
+                .await
+                .map_err(|e| e.to_string())
+        }
+        _ => c
+            .send_message(&to, &subject, &body)
+            .await
+            .map_err(|e| e.to_string()),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 公開 IPC types
+// ─────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GmailOAuthStatus {
+    /// `~/.mori/gmail-token.json` 載得起來。
+    pub authorized: bool,
+    /// 此 token 含 `gmail.send` scope(`send_gmail` 才能用)。
+    pub has_send_scope: bool,
+    /// Granted scope 全字串(space-separated)— 供 UI 顯示。
+    pub scope: String,
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Tauri commands
+// ─────────────────────────────────────────────────────────────────────
+
+/// 跑完整 OAuth flow(blocking listener + token exchange + save)。
+///
+/// `scopes` 沒帶就用 `GMAIL_DEFAULT_SCOPES`(readonly + send)。流程:
+/// 1. caller(前端)在呼叫此 command **之前** open auth URL — 用 `open_external_url`
+///    或 `webbrowser` 開,Mori 本層只負責 listener
+/// 2. user 在瀏覽器同意 → Google redirect 回 localhost:8765/oauth/callback
+/// 3. listener 收 code → POST 換 token → save 到 `~/.mori/gmail-token.json`
+///
+/// **CAVEAT**:此 command 跑完後 client / SharedGmailClient state 仍是舊的 —
+/// LLM 要看到新 scope **需要重啟 Mori**(simplification:不做 hot-swap)。
+#[tauri::command]
+pub async fn gmail_oauth_start_cmd(scopes: Option<Vec<String>>) -> Result<String, String> {
+    let config_path =
+        OAuthConfig::default_path().ok_or("no HOME / USERPROFILE — can't resolve gmail-config.json path")?;
+    let config = OAuthConfig::load(&config_path).map_err(|e| {
+        format!(
+            "load gmail-config.json failed (path={}): {e}",
+            config_path.display()
+        )
+    })?;
+
+    // state 簡單用 timestamp+pid 當 CSRF token(本機 listener、URL 不出本機,
+    // 真有人 MITM ~/.mori 也 game over);本層只負責跟 wait_for_callback 比對。
+    let state = format!(
+        "mori-{}-{}",
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0),
+        std::process::id()
+    );
+
+    // scopes:caller 沒帶就用 default(readonly + send)。
+    let scope_strings: Vec<String> = scopes.unwrap_or_else(|| {
+        GMAIL_DEFAULT_SCOPES.iter().map(|s| s.to_string()).collect()
+    });
+    let scope_refs: Vec<&str> = scope_strings.iter().map(|s| s.as_str()).collect();
+
+    // 印 auth URL 給前端 / log。前端負責開瀏覽器。
+    let auth_url = mori_gmail::build_auth_url(&config, &scope_refs, &state);
+    tracing::info!(auth_url = %auth_url, "Gmail OAuth started — open this URL in browser");
+
+    let token = mori_gmail::run_oauth_flow(&config, &state, &scope_refs)
+        .await
+        .map_err(|e| format!("OAuth flow failed: {e}"))?;
+
+    let token_path = default_token_path().ok_or("no HOME — can't resolve token path")?;
+    token
+        .save(&token_path)
+        .map_err(|e| format!("save token failed: {e}"))?;
+    tracing::info!(path = %token_path.display(), "Gmail token saved");
+
+    // 回 user-facing 訊息 + auth URL(前端要再開一次 url 給 user)。
+    Ok(format!(
+        "OAuth 完成,token 已存 {}。\n(初次跑前需要先開瀏覽器跑 consent — auth_url:{})",
+        token_path.display(),
+        auth_url,
+    ))
+}
+
+/// 看 token 狀態(authorized? send scope?)。
+#[tauri::command]
+pub fn gmail_oauth_status_cmd() -> Result<GmailOAuthStatus, String> {
+    let path = default_token_path().ok_or("no HOME — can't resolve token path")?;
+    Ok(do_oauth_status(&path))
+}
+
+/// `list_threads(query?, max?)` — 列最近 thread summary。
+#[tauri::command]
+pub async fn gmail_list_threads_cmd(
+    state: tauri::State<'_, SharedGmailClient>,
+    query: Option<String>,
+    max: Option<u32>,
+) -> Result<Vec<ThreadSummary>, String> {
+    do_list_threads(&state.0, query, max).await
+}
+
+/// `get_thread(thread_id)` — 展開 thread 全文(messages + bodies)。
+#[tauri::command]
+pub async fn gmail_get_thread_cmd(
+    state: tauri::State<'_, SharedGmailClient>,
+    thread_id: String,
+) -> Result<Thread, String> {
+    do_get_thread(&state.0, thread_id).await
+}
+
+/// `send(to, subject, body, reply_to_thread_id?, in_reply_to?)` — 寄信(或回覆既有 thread)。
+#[tauri::command]
+pub async fn gmail_send_cmd(
+    state: tauri::State<'_, SharedGmailClient>,
+    to: Vec<String>,
+    subject: String,
+    body: String,
+    reply_to_thread_id: Option<String>,
+    in_reply_to: Option<String>,
+) -> Result<SendOutcome, String> {
+    do_send(&state.0, to, subject, body, reply_to_thread_id, in_reply_to).await
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    //! 對齊 reminders_cmd::tests 風格 — Tauri State / runtime mock 麻煩,
+    //! 直接 unit-test `do_*` helpers。GmailClient 用 `with_base` 注 wiremock。
+
+    use super::*;
+    use base64::Engine as _;
+    use chrono::Utc;
+    use mori_gmail::{GmailToken, GMAIL_READONLY_SCOPE};
+    use wiremock::matchers::{method, path as wmpath};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn dummy_oauth() -> OAuthConfig {
+        OAuthConfig {
+            client_id: "cid".into(),
+            client_secret: "csecret".into(),
+            redirect_uri: "http://localhost:8765/oauth/callback".into(),
+        }
+    }
+
+    fn token_with(scope: &str) -> GmailToken {
+        GmailToken {
+            access_token: "ya29.fake".into(),
+            refresh_token: "1//r".into(),
+            expires_at: Utc::now() + chrono::Duration::hours(1),
+            scope: scope.into(),
+            token_type: "Bearer".into(),
+        }
+    }
+
+    fn client_with(mock_uri: String, token: GmailToken) -> Mutex<GmailClient> {
+        let dir = tempfile::tempdir().unwrap();
+        let token_path = dir.path().join("gmail-token.json");
+        let token_endpoint = format!("{mock_uri}/token");
+        Mutex::new(GmailClient::with_base(
+            token,
+            dummy_oauth(),
+            token_path,
+            mock_uri,
+            token_endpoint,
+        ))
+    }
+
+    #[test]
+    fn do_oauth_status_returns_not_authorized_for_missing_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gmail-token.json"); // 不存在
+        let status = do_oauth_status(&path);
+        assert!(!status.authorized);
+        assert!(!status.has_send_scope);
+        assert!(status.scope.is_empty());
+    }
+
+    #[test]
+    fn do_oauth_status_reports_authorized_and_scope() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gmail-token.json");
+        let token = token_with(&format!("{GMAIL_READONLY_SCOPE} {GMAIL_SEND_SCOPE}"));
+        token.save(&path).unwrap();
+
+        let status = do_oauth_status(&path);
+        assert!(status.authorized);
+        assert!(status.has_send_scope);
+        assert!(status.scope.contains("gmail.readonly"));
+        assert!(status.scope.contains("gmail.send"));
+    }
+
+    #[test]
+    fn do_oauth_status_authorized_but_no_send_scope() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gmail-token.json");
+        let token = token_with(GMAIL_READONLY_SCOPE);
+        token.save(&path).unwrap();
+
+        let status = do_oauth_status(&path);
+        assert!(status.authorized);
+        assert!(!status.has_send_scope);
+        assert_eq!(status.scope, GMAIL_READONLY_SCOPE);
+    }
+
+    #[tokio::test]
+    async fn do_list_threads_returns_summaries() {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wmpath("/gmail/v1/users/me/threads"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "threads": [{"id": "t1", "snippet": "yo", "historyId": "100"}]
+            })))
+            .mount(&mock)
+            .await;
+        let c = client_with(mock.uri(), token_with(GMAIL_READONLY_SCOPE));
+        let out = do_list_threads(&c, None, Some(5)).await.expect("ok");
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, "t1");
+    }
+
+    #[tokio::test]
+    async fn do_get_thread_returns_thread_data() {
+        let mock = MockServer::start().await;
+        let body_b64 =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"plain body");
+        Mock::given(method("GET"))
+            .and(wmpath("/gmail/v1/users/me/threads/t-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "t-1",
+                "messages": [{
+                    "id": "m1",
+                    "snippet": "snip",
+                    "internalDate": "1716000000000",
+                    "payload": {
+                        "mimeType": "text/plain",
+                        "headers": [
+                            {"name": "From", "value": "a@x.com"},
+                            {"name": "To", "value": "b@x.com"},
+                            {"name": "Subject", "value": "S"}
+                        ],
+                        "body": {"data": body_b64}
+                    }
+                }]
+            })))
+            .mount(&mock)
+            .await;
+        let c = client_with(mock.uri(), token_with(GMAIL_READONLY_SCOPE));
+        let thread = do_get_thread(&c, "t-1".into()).await.expect("ok");
+        assert_eq!(thread.id, "t-1");
+        assert_eq!(thread.messages.len(), 1);
+        assert_eq!(thread.messages[0].body_text, "plain body");
+    }
+
+    #[tokio::test]
+    async fn do_send_blocks_without_send_scope() {
+        let mock = MockServer::start().await;
+        // mock 即使 mount 也不該被打到
+        Mock::given(method("POST"))
+            .and(wmpath("/gmail/v1/users/me/messages/send"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "x",
+                "threadId": "x"
+            })))
+            .mount(&mock)
+            .await;
+
+        let c = client_with(mock.uri(), token_with(GMAIL_READONLY_SCOPE));
+        let err = do_send(
+            &c,
+            vec!["a@b.c".into()],
+            "s".into(),
+            "b".into(),
+            None,
+            None,
+        )
+        .await
+        .expect_err("should block");
+        assert!(err.contains("scope"), "expected scope error, got: {err}");
+    }
+
+    #[tokio::test]
+    async fn do_send_sends_when_scope_ok() {
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(wmpath("/gmail/v1/users/me/messages/send"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "sent-1",
+                "threadId": "t-fresh"
+            })))
+            .mount(&mock)
+            .await;
+        let c = client_with(
+            mock.uri(),
+            token_with(&format!("{GMAIL_READONLY_SCOPE} {GMAIL_SEND_SCOPE}")),
+        );
+        let out = do_send(
+            &c,
+            vec!["a@b.c".into()],
+            "s".into(),
+            "b".into(),
+            None,
+            None,
+        )
+        .await
+        .expect("send ok");
+        assert_eq!(out.id, "sent-1");
+        assert_eq!(out.thread_id, "t-fresh");
+    }
+}

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -9,6 +9,10 @@ mod character_pack;
 mod context_provider;
 mod deps;
 mod file_loader_cmd;
+// Wave 8 Gm-2 「跨界之手」 — Gmail Tauri commands(OAuth start / status / list /
+// get / send)+ 啟動時 try-init GmailClient(沒 config / 沒 token 就 skip,Gmail
+// 系列 skill 不註冊)。對齊既有 `reminders_cmd` / `file_loader_cmd` 模組風格。
+mod gmail_cmd;
 mod hotkey_config;
 mod mcp_cmd;
 #[cfg(target_os = "linux")]
@@ -59,9 +63,10 @@ use mori_core::mode::{Mode, ModeController};
 use mori_core::paste::PasteController;
 use mori_core::skill::PasteSelectionBackSkill;
 use mori_core::skill::{
-    ComposeSkill, EditMemorySkill, FetchUrlSkill, ForgetMemorySkill, PolishSkill,
-    ReadFileSkill, ReadWikiPageSkill, RecallMemorySkill, RememberSkill, RemindMeSkill,
-    SetModeSkill, SkillRegistry, SummarizeSkill, TranslateSkill,
+    ComposeSkill, EditMemorySkill, FetchUrlSkill, ForgetMemorySkill,
+    ListGmailSkill, PolishSkill, ReadFileSkill, ReadGmailSkill, ReadWikiPageSkill,
+    RecallMemorySkill, RememberSkill, RemindMeSkill, SendGmailSkill, SetModeSkill,
+    SharedGmailClient, SkillRegistry, SummarizeSkill, TranslateSkill,
 };
 use mori_time::{Notifier, ReminderService};
 use mori_core::{PHASE, VERSION};
@@ -2170,6 +2175,14 @@ async fn skills_list(
     if let Some(svc) = app.try_state::<Arc<ReminderService>>() {
         registry.register(Arc::new(RemindMeSkill::new(svc.inner().clone())));
     }
+    // Wave 8 Gm-2「跨界之手」— Gmail skill。SharedGmailClient 是 optional state
+    // (沒 OAuth / token 沒裝 → 撈不到,Gmail skill 不出現在 Skills tab)。
+    if let Some(shared) = app.try_state::<SharedGmailClient>() {
+        let client = shared.0.clone();
+        registry.register(Arc::new(ListGmailSkill::new(client.clone())));
+        registry.register(Arc::new(ReadGmailSkill::new(client.clone())));
+        registry.register(Arc::new(SendGmailSkill::new(client)));
+    }
     // Wave 7 L-mori 記憶之森:read_wiki_page LLM skill — UI Skills tab 也要列出。
     // vault_root 跟 spirit_name 從 annuli config 拿(spirit_name 預設 "mori"),
     // vault_root 失敗(沒 HOME)→ 跳過註冊(LLM 拿不到 skill,但 UI 不爆)。
@@ -3439,6 +3452,46 @@ async fn run_agent_pipeline(
             }
         }
 
+        // Wave 8 Gm-2「跨界之手」— Gmail 工具描述。只在 SharedGmailClient init 成功
+        // 時注入(避免 LLM 看到沒法用的 tool)。對齊 wiki / MCP block 的 caller-append
+        // pattern(build_system_prompt 不知道 mori-gmail 存在)。
+        if app.try_state::<SharedGmailClient>().is_some() {
+            system_prompt.push_str(
+                "\n\n# Gmail 工具(跨界之手,Wave 8 Gm-2)\n\n",
+            );
+            system_prompt.push_str(
+                "我可以代亞澤讀 / 發 email。OAuth 已設好(token 在 `~/.mori/gmail-token.json`)。\n\n",
+            );
+            system_prompt.push_str(
+                "- `list_gmail(query?, max?)`:列我最近的 thread。`query` 可用 Gmail \
+                 搜尋語法(`is:unread`、`from:alice`、`subject:meeting`、`after:2026/01/01`)。\
+                 預設 max=10。\n",
+            );
+            system_prompt.push_str(
+                "- `read_gmail(thread_id)`:展開某條 thread 全文(`thread_id` 通常從 \
+                 `list_gmail` 結果拿)。\n",
+            );
+            system_prompt.push_str(
+                "- `send_gmail(to, subject, body, reply_to_thread_id?, in_reply_to?)`:\
+                 寄信(或回某條 thread)。**destructive — 寄出收不回**,寫之前先口頭跟亞澤確認內容。\
+                 需要 `gmail.send` scope;沒授權會回 error 提示重跑 OAuth。\n\n",
+            );
+            system_prompt.push_str(
+                "使用守則:\n",
+            );
+            system_prompt.push_str(
+                "- 亞澤講「看一下我今天 email」/「有沒有 X 的信」→ 先 `list_gmail` 拿 \
+                 thread summary,挑相關的講給他聽。\n",
+            );
+            system_prompt.push_str(
+                "- 亞澤講「那封展開來看」/「details」→ `read_gmail(thread_id)` 拉全文後摘要。\n",
+            );
+            system_prompt.push_str(
+                "- 亞澤講「幫我回 X」/「寫信給 Y」→ **先草擬內容跟他確認**,確認後才 \
+                 `send_gmail`。回 thread 時帶 `reply_to_thread_id`。\n\n",
+            );
+        }
+
         // Wave 6 MCP-2:把目前連上的 MCP server / tool 描述附加到 system prompt 末尾。
         // - 不動 `build_system_prompt` 簽名,改在 caller append(讓 mori-core 不知道
         //   mori-mcp 存在,layer 維持乾淨)。
@@ -3606,6 +3659,23 @@ async fn run_agent_pipeline(
                 registry.register(Arc::new(mori_core::skill::RemindMeSkill::new(
                     svc.inner().clone(),
                 )));
+            }
+        }
+        // Wave 8 Gm-2「跨界之手」— Gmail 系列 skill dispatch path。SharedGmailClient
+        // 是 Tauri Manager 註冊的 optional state(沒 OAuth / token 沒裝 → 整組
+        // skip,LLM 看不到 Gmail 工具)。對齊 `RemindMeSkill` 的 try_state pattern;
+        // 全部受 `allows()` filter(agent profile 可逐 skill 過濾 / agent_disabled
+        // 整盤 false)。
+        if let Some(shared) = app.try_state::<SharedGmailClient>() {
+            let client = shared.0.clone();
+            if allows("list_gmail") {
+                registry.register(Arc::new(ListGmailSkill::new(client.clone())));
+            }
+            if allows("read_gmail") {
+                registry.register(Arc::new(ReadGmailSkill::new(client.clone())));
+            }
+            if allows("send_gmail") {
+                registry.register(Arc::new(SendGmailSkill::new(client)));
             }
         }
         // set_mode 永遠註冊(「晚安」「醒醒」是核心功能,無法被 disable)
@@ -5239,6 +5309,20 @@ fn main() {
         "McpRegistry ready (Wave 6 MCP-2)",
     );
 
+    // Wave 8 Gm-2「跨界之手」:啟動時 try-init GmailClient(沒 config / 沒 token
+    // 就 None,Gmail 系列 skill 不註冊;Gmail 對外 commands `gmail_oauth_start_cmd`
+    // 仍可呼叫,讓 user 跑首次 consent)。
+    let gmail_client: Option<SharedGmailClient> =
+        tauri::async_runtime::block_on(gmail_cmd::init_gmail_client_optional());
+    if gmail_client.is_some() {
+        tracing::info!("Gmail client initialised (Wave 8 Gm-2 — token present)");
+    } else {
+        tracing::info!(
+            "Gmail client NOT initialised — Gmail skills disabled. \
+             Run `gmail_oauth_start_cmd` after creating ~/.mori/gmail-config.json.",
+        );
+    }
+
     tauri::Builder::default()
         // 5J-followup: 防止 mori-tauri orphan + 新實例並存的搶 tray / hotkey 戰。
         // 第二個 instance 啟動時觸發此 callback:把焦點還給第一個然後自殺。
@@ -5339,6 +5423,12 @@ fn main() {
             reminders_cmd::snooze_reminder_cmd,
             mcp_cmd::mcp_list_tools_cmd,
             mcp_cmd::mcp_call_tool_cmd,
+            // Wave 8 Gm-2「跨界之手」— Gmail Tauri commands(OAuth + list / get / send)。
+            gmail_cmd::gmail_oauth_start_cmd,
+            gmail_cmd::gmail_oauth_status_cmd,
+            gmail_cmd::gmail_list_threads_cmd,
+            gmail_cmd::gmail_get_thread_cmd,
+            gmail_cmd::gmail_send_cmd,
             // Wave 6 DF-1:Anthropic skills install commands。前端可選用(也可走
             // DepsTab 內的 `anthropic-skills` entry)— 兩條路徑 install 結果一致。
             skill_install_cmd::install_anthropic_skills_cmd,
@@ -5385,6 +5475,14 @@ fn main() {
             }
         })
         .setup(move |app| {
+            // Wave 8 Gm-2「跨界之手」:GmailClient 若啟動時 init 成功就註冊到 Manager;
+            // None 就跳過(Gmail OAuth 還沒跑),Gmail skill registry 那邊也會看 try_state
+            // 撈不到就 skip。OAuth start command 仍可呼叫,user 跑完 → 重啟 Mori → init OK。
+            if let Some(client) = gmail_client.clone() {
+                app.manage(client);
+                tracing::info!("SharedGmailClient registered into Tauri Manager");
+            }
+
             // brand-3: ensure ~/.mori/themes/ + 內建 dark.json / light.json
             // 啟動時寫入(已存在則保留 user 編輯)
             if let Err(e) = crate::theme::ensure_builtin() {


### PR DESCRIPTION
## Summary

**Wave 8 Gm-2** — 把 Gm-1 mori-gmail crate wire 進 Mori。LLM 對 Mori 講「看 email」/「展開那封」/「回 yazelin」她會真做。

**跨界之手 Gmail 完工** — Mori 真能管 email。

Cherry-pick `c10f708` onto fresh main 後 Gm-1 (#101) merged。

## Changes

### mori-gmail 擴充
- `client.rs`:+ `send_message` / `send_reply` / `send_raw` / `SendOutcome` / `build_rfc822_message` public helper
- `oauth.rs`:+ `GMAIL_SEND_SCOPE` / `GMAIL_DEFAULT_SCOPES`,`build_auth_url` + `run_oauth_flow` 改吃 `&[&str]`
- `token.rs`:+ `GmailToken::has_scope` helper

### mori-core
- `src/skill/gmail.rs`(新):`ListGmailSkill / ReadGmailSkill / SendGmailSkill` + `SharedGmailClient` newtype + 8 tests
- `Cargo.toml`:+ mori-gmail path dep

### mori-tauri
- `src/gmail_cmd.rs`(新):`init_gmail_client_optional` + 5 Tauri commands(`gmail_oauth_start_cmd` / `gmail_oauth_status_cmd` / `gmail_list_threads_cmd` / `gmail_get_thread_cmd` / `gmail_send_cmd`)+ `do_*` helpers + 7 tests
- `src/main.rs`:啟動 try-init GmailClient → `.manage(SharedGmailClient)`;兩處 SkillRegistry 註冊 Gmail skill;system prompt caller-append 工具描述(只在 client init 成功時);invoke_handler 註冊 5 commands
- `src/deps.rs`:+ `gmail-oauth` DepSpec(Google Cloud Console setup 指引)
- `Cargo.toml`:+ mori-gmail path dep

## Test plan

- [x] **22 new tests**(spec 12+):mori-gmail 7 + mori-core skill::gmail 8 + mori-tauri gmail_cmd 7
- [x] mori-gmail:**24 passed**
- [x] mori-core:**275 passed**(+ 8)
- [x] mori-tauri:**136 passed**(+ 7)
- [x] verify.sh 全綠

## Known follow-up

- **OAuth 完成後 SharedGmailClient 不 hot-swap** — user 需重啟 Mori 才能看到新 token / scope。doc 註明
- **send 走 confirm_required = true** 仰賴 UI / agent loop 二次確認;若 agent profile 沒接 confirm UI(spec 沒列必須),destructive 動作仍會直接送 — 對齊既有 forget_memory pattern
- **HTML-only 信件 body 為空**(Gm-1 設計)—  future 加 html2text fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)