### PR TITLE
feat: in-app reminder popup + supporting fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ crates/mori-tauri/icons/StoreLogo.png
 crates/mori-tauri/icons/icon.icns
 crates/mori-tauri/icons/android/
 crates/mori-tauri/icons/ios/
+
+# Local git worktrees (created via superpowers:using-git-worktrees)
+.worktrees/

--- a/crates/mori-core/src/skill/remind_me.rs
+++ b/crates/mori-core/src/skill/remind_me.rs
@@ -147,7 +147,7 @@ mod tests {
     async fn service_in(dir: &TempDir) -> Arc<ReminderService> {
         let db = dir.path().join("reminders.db");
         Arc::new(
-            ReminderService::new(&db, Notifier::new("Mori-Test"), Arc::new(NoopEmitter))
+            ReminderService::new(&db, Notifier::disabled("Mori-Test"), Arc::new(NoopEmitter))
                 .await
                 .expect("new service"),
         )

--- a/crates/mori-core/src/skill/remind_me.rs
+++ b/crates/mori-core/src/skill/remind_me.rs
@@ -137,7 +137,7 @@ mod tests {
 
     use super::*;
     use crate::context::Context;
-    use mori_time::Notifier;
+    use mori_time::{NoopEmitter, Notifier};
     use tempfile::TempDir;
 
     fn empty_context() -> Context {
@@ -147,7 +147,7 @@ mod tests {
     async fn service_in(dir: &TempDir) -> Arc<ReminderService> {
         let db = dir.path().join("reminders.db");
         Arc::new(
-            ReminderService::new(&db, Notifier::new("Mori-Test"))
+            ReminderService::new(&db, Notifier::new("Mori-Test"), Arc::new(NoopEmitter))
                 .await
                 .expect("new service"),
         )

--- a/crates/mori-tauri/capabilities/default.json
+++ b/crates/mori-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Permissions shared by Mori windows (main + floating + chat_bubble + picker)",
-  "windows": ["main", "floating", "chat_bubble", "picker"],
+  "windows": ["main", "floating", "chat_bubble", "picker", "reminder_popup"],
   "permissions": [
     "core:default",
     "core:window:default",

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -15,6 +15,7 @@ mod file_loader_cmd;
 mod gmail_cmd;
 mod hotkey_config;
 mod mcp_cmd;
+mod notification_config;
 #[cfg(target_os = "linux")]
 mod portal_hotkey;
 mod recording;

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -68,7 +68,7 @@ use mori_core::skill::{
     RecallMemorySkill, RememberSkill, RemindMeSkill, SendGmailSkill, SetModeSkill,
     SharedGmailClient, SkillRegistry, SummarizeSkill, TranslateSkill,
 };
-use mori_time::{Notifier, ReminderService};
+use mori_time::{NoopEmitter, Notifier, ReminderService};
 use mori_core::{PHASE, VERSION};
 use parking_lot::Mutex;
 use serde::Serialize;
@@ -5271,6 +5271,7 @@ fn main() {
         tauri::async_runtime::block_on(ReminderService::new(
             &reminders_db_path,
             Notifier::new("Mori"),
+            Arc::new(NoopEmitter), // Task 5 換成真實的 TauriEventEmitter
         ))
         .unwrap_or_else(|e| {
             panic!(

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -5391,6 +5391,7 @@ fn main() {
             reminders_cmd::reminder_active_queue,
             reminders_cmd::reminder_dismiss,
             reminders_cmd::reminder_snooze,
+            reminders_cmd::get_sprite_position,
             mcp_cmd::mcp_list_tools_cmd,
             mcp_cmd::mcp_call_tool_cmd,
             // Wave 8 Gm-2「跨界之手」— Gmail Tauri commands(OAuth + list / get / send)。

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -18,6 +18,7 @@ mod mcp_cmd;
 #[cfg(target_os = "linux")]
 mod portal_hotkey;
 mod recording;
+mod reminder_emitter;
 mod reminders_cmd;
 mod x11_hotkey;
 #[cfg(target_os = "linux")]
@@ -68,7 +69,7 @@ use mori_core::skill::{
     RecallMemorySkill, RememberSkill, RemindMeSkill, SendGmailSkill, SetModeSkill,
     SharedGmailClient, SkillRegistry, SummarizeSkill, TranslateSkill,
 };
-use mori_time::{NoopEmitter, Notifier, ReminderService};
+use mori_time::{Notifier, ReminderService};
 use mori_core::{PHASE, VERSION};
 use parking_lot::Mutex;
 use serde::Serialize;
@@ -5246,45 +5247,6 @@ fn main() {
 
     let state_for_setup = state.clone();
 
-    // §9 P1 「時之鳥」K5:在 Builder 開跑前先建好 ReminderService。
-    // SQLite migrate + 重排 pending reminder 都在 async `new()` 內;Tauri 提供
-    // `block_on` 入口在 sync `main()` 裡跑 async,啟動完成才繼續往下。
-    //
-    // DB path = `~/.mori/reminders.db`,對齊既有 mori_dir() pattern。**失敗就 panic**
-    // (見下方 `.unwrap_or_else`)— 立場是「~/.mori 寫不進去 = config.json / memory
-    // 全部跟著炸,reminders 不可能比它們先撐住」,所以早死早超生,不嘗試 degrade。
-    // 對應 RemindMeSkill 註冊那邊也保證 ReminderService 一定 ready(不過註冊段仍
-    // 用 try_state 維持 defensive,即便理論上 unwrap 也行)。
-    let reminders_db_path = mori_dir().join("reminders.db");
-    if let Some(parent) = reminders_db_path.parent() {
-        if let Err(e) = std::fs::create_dir_all(parent) {
-            tracing::warn!(
-                path = %parent.display(),
-                error = %e,
-                "failed to create dir for reminders.db",
-            );
-        }
-    }
-    // 失敗就 panic — sqlite open 失敗代表 ~/.mori 整個寫不進去,連 config / memory 都會
-    // 跟著炸,reminders 反正不可能撐起來。早死早超生。
-    let reminder_service: Arc<ReminderService> = Arc::new(
-        tauri::async_runtime::block_on(ReminderService::new(
-            &reminders_db_path,
-            Notifier::new("Mori"),
-            Arc::new(NoopEmitter), // Task 5 換成真實的 TauriEventEmitter
-        ))
-        .unwrap_or_else(|e| {
-            panic!(
-                "ReminderService init failed (path={}): {e}",
-                reminders_db_path.display()
-            )
-        }),
-    );
-    tracing::info!(
-        path = %reminders_db_path.display(),
-        "ReminderService ready (時之鳥)",
-    );
-
     // Wave 6 MCP-2:啟動 McpRegistry — 從 `~/.mori/mcp.json` 載 config + 依序
     // connect 各 server。config 不存在 / 讀失敗 / 個別 server connect 失敗都不
     // 擋啟動(個別失敗只 log warn,registry 保留其餘成功的)。
@@ -5341,9 +5303,6 @@ fn main() {
             }
         }))
         .manage(state.clone())
-        // 「時之鳥」K5:把 ReminderService 註冊進 Tauri Manager。
-        // commands(remind_me_cmd 等)+ RemindMeSkill 都從這裡拿 Arc clone。
-        .manage(reminder_service.clone())
         // Wave 6 MCP-2:把 McpRegistry 註冊進 Manager。
         // mcp_cmd 內 list / call command + agent loop 內 McpToolSkill 註冊都從這裡拿 clone。
         .manage(mcp_registry.clone())
@@ -5482,6 +5441,48 @@ fn main() {
             }
         })
         .setup(move |app| {
+            // §9 P1 「時之鳥」K5:建好 ReminderService 並注入 TauriEventEmitter。
+            // 在 setup 內初始化,因為 TauriEventEmitter 需要 AppHandle(setup 前拿不到)。
+            // SQLite migrate + 重排 pending reminder 都在 async `new()` 內;
+            // block_on 讓 async 在 setup sync context 內跑完才繼續。
+            //
+            // DB path = `~/.mori/reminders.db`,對齊既有 mori_dir() pattern。
+            // 失敗就 panic — sqlite open 失敗代表 ~/.mori 整個寫不進去,
+            // 連 config / memory 都會跟著炸,reminders 反正不可能撐起來。早死早超生。
+            let reminders_db_path = mori_dir().join("reminders.db");
+            if let Some(parent) = reminders_db_path.parent() {
+                if let Err(e) = std::fs::create_dir_all(parent) {
+                    tracing::warn!(
+                        path = %parent.display(),
+                        error = %e,
+                        "failed to create dir for reminders.db",
+                    );
+                }
+            }
+            let app_handle_for_emitter = app.handle().clone();
+            let reminder_service: Arc<ReminderService> = Arc::new(
+                tauri::async_runtime::block_on(ReminderService::new(
+                    &reminders_db_path,
+                    Notifier::new("Mori"),
+                    std::sync::Arc::new(reminder_emitter::TauriEventEmitter {
+                        handle: app_handle_for_emitter,
+                    }),
+                ))
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "ReminderService init failed (path={}): {e}",
+                        reminders_db_path.display()
+                    )
+                }),
+            );
+            tracing::info!(
+                path = %reminders_db_path.display(),
+                "ReminderService ready (時之鳥)",
+            );
+            // 「時之鳥」K5:把 ReminderService 註冊進 Tauri Manager。
+            // commands(remind_me_cmd 等)+ RemindMeSkill 都從這裡拿 Arc clone。
+            app.manage(reminder_service);
+
             // Wave 8 Gm-2「跨界之手」:GmailClient 若啟動時 init 成功就註冊到 Manager;
             // None 就跳過(Gmail OAuth 還沒跑),Gmail skill registry 那邊也會看 try_state
             // 撈不到就 skip。OAuth start command 仍可呼叫,user 跑完 → 重啟 Mori → init OK。

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -5392,6 +5392,7 @@ fn main() {
             reminders_cmd::reminder_dismiss,
             reminders_cmd::reminder_snooze,
             reminders_cmd::get_sprite_position,
+            reminders_cmd::debug_reminder_popup_state,
             mcp_cmd::mcp_list_tools_cmd,
             mcp_cmd::mcp_call_tool_cmd,
             // Wave 8 Gm-2「跨界之手」— Gmail Tauri commands(OAuth + list / get / send)。

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -4575,7 +4575,7 @@ fn chinese_weekday(en: &str) -> &'static str {
 /// 跟 `crates/mori-core/src/llm/groq.rs::home_dir()` / `transcribe_cmds::mori_home_dir()`
 /// 同一條 fallback 邏輯 — 沒 `HOME` 時讀 `USERPROFILE`(Windows quirk,見 CLAUDE.md
 /// 工程注意第一點)。
-fn default_vault_root() -> Option<std::path::PathBuf> {
+pub(crate) fn default_vault_root() -> Option<std::path::PathBuf> {
     std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
         .ok()
@@ -5779,8 +5779,9 @@ fn main() {
             // dispatch skill。失敗只 warn 不卡啟動 — Tauri UI 跟語音/chat
             // pipeline 沒這個 server 也能用。
             let app_for_server = state_for_setup.clone();
+            let handle_for_server = app.handle().clone();
             tauri::async_runtime::spawn(async move {
-                match crate::skill_server::start(app_for_server).await {
+                match crate::skill_server::start(app_for_server, handle_for_server).await {
                     Ok(info) => tracing::info!(
                         port = info.port,
                         "skill HTTP server started — Bash CLI proxy ready"

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -5388,6 +5388,9 @@ fn main() {
             reminders_cmd::list_reminders_cmd,
             reminders_cmd::cancel_reminder_cmd,
             reminders_cmd::snooze_reminder_cmd,
+            reminders_cmd::reminder_active_queue,
+            reminders_cmd::reminder_dismiss,
+            reminders_cmd::reminder_snooze,
             mcp_cmd::mcp_list_tools_cmd,
             mcp_cmd::mcp_call_tool_cmd,
             // Wave 8 Gm-2「跨界之手」— Gmail Tauri commands(OAuth + list / get / send)。

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -5432,6 +5432,8 @@ fn main() {
             wake_word_restart_listener,
             annuli_runtime_installed,
             annuli_quick_enable,
+            notification_config::get_notification_config,
+            notification_config::set_notification_config,
         ])
         .on_window_event(|window, event| {
             // 關視窗時不殺 app — 隱藏到系統匣繼續跑(像 Slack / Discord)
@@ -5461,10 +5463,18 @@ fn main() {
                 }
             }
             let app_handle_for_emitter = app.handle().clone();
+            // 2026-05-22:讀 notification config,設定 notifier 的 os_notification_enabled 開關。
+            let notification_cfg =
+                notification_config::NotificationConfig::load(&mori_dir().join("config.json"));
+            let notifier = Notifier::new("Mori");
+            notifier
+                .enabled
+                .store(notification_cfg.os_notification_enabled, std::sync::atomic::Ordering::Relaxed);
+            let notifier_enabled_handle = notifier.enabled_handle();
             let reminder_service: Arc<ReminderService> = Arc::new(
                 tauri::async_runtime::block_on(ReminderService::new(
                     &reminders_db_path,
-                    Notifier::new("Mori"),
+                    notifier,
                     std::sync::Arc::new(reminder_emitter::TauriEventEmitter {
                         handle: app_handle_for_emitter,
                     }),
@@ -5483,6 +5493,9 @@ fn main() {
             // 「時之鳥」K5:把 ReminderService 註冊進 Tauri Manager。
             // commands(remind_me_cmd 等)+ RemindMeSkill 都從這裡拿 Arc clone。
             app.manage(reminder_service);
+            // 2026-05-22:把 notifier enabled handle 存進 Tauri State,
+            // set_notification_config command 可透過 State 推 os_notification_enabled toggle。
+            app.manage(notifier_enabled_handle);
 
             // Wave 8 Gm-2「跨界之手」:GmailClient 若啟動時 init 成功就註冊到 Manager;
             // None 就跳過(Gmail OAuth 還沒跑),Gmail skill registry 那邊也會看 try_state

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -5049,8 +5049,14 @@ fn main() {
 
     tracing_subscriber::fmt()
         .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "mori_tauri=debug,mori_core=debug".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                // Default filter:涵蓋整組 mori-* crate。漏 sub-crate 等於它們的
+                // tracing log 整個被吃掉(2026-05-22 踩過:reminder fire 加了 info
+                // log 結果看不到,原來 mori_time 沒在 filter 內)。
+                "mori_tauri=debug,mori_core=debug,\
+                 mori_time=info,mori_mcp=info,mori_gmail=info,mori_file_loader=info"
+                    .into()
+            }),
         )
         .init();
 

--- a/crates/mori-tauri/src/notification_config.rs
+++ b/crates/mori-tauri/src/notification_config.rs
@@ -1,0 +1,118 @@
+//! 2026-05-22:reminder 通知 toggle 設定 — `~/.mori/config.json` 的 `notifications` 子樹。
+//!
+//! 對齊 `hotkey_config.rs` / `recordings.rs` 既有 pattern:呼叫時讀檔 + 缺欄走預設,
+//! 寫入時 round-trip 整個 JSON。
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NotificationConfig {
+    /// in-app popup 視窗開關。預設 true。
+    pub popup_enabled: bool,
+    /// OS 桌面通知(notify-rust)開關。預設 true。
+    pub os_notification_enabled: bool,
+}
+
+impl Default for NotificationConfig {
+    fn default() -> Self {
+        Self {
+            popup_enabled: true,
+            os_notification_enabled: true,
+        }
+    }
+}
+
+impl NotificationConfig {
+    /// 從 `~/.mori/config.json` 的 `notifications` 子樹讀;不存在 / 壞了 → 走預設 + log warn。
+    pub fn load(config_path: &Path) -> Self {
+        let raw = match std::fs::read_to_string(config_path) {
+            Ok(s) => s,
+            Err(_) => return Self::default(),
+        };
+        let json: Value = match serde_json::from_str(&raw) {
+            Ok(j) => j,
+            Err(e) => {
+                tracing::warn!(?e, "config.json malformed, notifications fall back to defaults");
+                return Self::default();
+            }
+        };
+        let sub = match json.get("notifications") {
+            Some(v) => v.clone(),
+            None => return Self::default(),
+        };
+        serde_json::from_value(sub).unwrap_or_else(|e| {
+            tracing::warn!(?e, "notifications subtree malformed, falling back to defaults");
+            Self::default()
+        })
+    }
+
+    /// 寫回 `~/.mori/config.json` 的 `notifications` 子樹,保留其他欄位不動。
+    pub fn write(&self, config_path: &Path) -> Result<(), String> {
+        let raw = std::fs::read_to_string(config_path).unwrap_or_else(|_| "{}".to_string());
+        let mut json: Value =
+            serde_json::from_str(&raw).map_err(|e| format!("parse config.json: {e}"))?;
+        let obj = json
+            .as_object_mut()
+            .ok_or_else(|| "config.json root not object".to_string())?;
+        obj.insert(
+            "notifications".to_string(),
+            serde_json::to_value(self).map_err(|e| e.to_string())?,
+        );
+        let pretty = serde_json::to_string_pretty(&json).map_err(|e| e.to_string())?;
+        std::fs::write(config_path, pretty).map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_returns_defaults_when_file_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope.json");
+        let cfg = NotificationConfig::load(&path);
+        assert_eq!(cfg, NotificationConfig::default());
+        assert!(cfg.popup_enabled);
+        assert!(cfg.os_notification_enabled);
+    }
+
+    #[test]
+    fn load_returns_defaults_when_subtree_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        std::fs::write(&path, r#"{"other": {}}"#).unwrap();
+        let cfg = NotificationConfig::load(&path);
+        assert_eq!(cfg, NotificationConfig::default());
+    }
+
+    #[test]
+    fn write_preserves_other_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        std::fs::write(&path, r#"{"providers":{"groq":{}},"hotkeys":{"toggle":"X"}}"#).unwrap();
+        NotificationConfig {
+            popup_enabled: false,
+            os_notification_enabled: true,
+        }
+        .write(&path)
+        .unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains(r#""providers""#));
+        assert!(raw.contains(r#""hotkeys""#));
+        assert!(raw.contains(r#""popup_enabled": false"#));
+    }
+
+    #[test]
+    fn round_trip_load_after_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        std::fs::write(&path, "{}").unwrap();
+        let original = NotificationConfig { popup_enabled: false, os_notification_enabled: false };
+        original.write(&path).unwrap();
+        let loaded = NotificationConfig::load(&path);
+        assert_eq!(loaded, original);
+    }
+}

--- a/crates/mori-tauri/src/notification_config.rs
+++ b/crates/mori-tauri/src/notification_config.rs
@@ -65,6 +65,30 @@ impl NotificationConfig {
     }
 }
 
+/// 取得目前的通知 toggle 設定。
+#[tauri::command]
+pub fn get_notification_config() -> NotificationConfig {
+    NotificationConfig::load(&crate::mori_dir().join("config.json"))
+}
+
+/// 寫入通知 toggle 設定,並同步推進 notifier os_notification_enabled flag。
+///
+/// popup_enabled 是 read-on-call(emitter 每次 fire 都讀 config.json),
+/// os_notification_enabled 透過 AtomicBool State 即時推進 Notifier。
+#[tauri::command]
+pub fn set_notification_config(
+    cfg: NotificationConfig,
+    notifier_enabled: tauri::State<'_, std::sync::Arc<std::sync::atomic::AtomicBool>>,
+) -> Result<(), String> {
+    cfg.write(&crate::mori_dir().join("config.json"))?;
+    // 同步推進 notifier flag(popup_enabled emitter 是 read-on-call 不用推)
+    notifier_enabled.store(
+        cfg.os_notification_enabled,
+        std::sync::atomic::Ordering::Relaxed,
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mori-tauri/src/reminder_emitter.rs
+++ b/crates/mori-tauri/src/reminder_emitter.rs
@@ -40,6 +40,15 @@ impl EventEmitter for TauriEventEmitter {
             "TauriEventEmitter: about to emit reminder-fire-show to popup window",
         );
 
+        mori_core::event_log::append(serde_json::json!({
+            "kind": "reminder_fire",
+            "reminder_id": reminder.id,
+            "text": reminder.text,
+            "due_at": reminder.due_at.to_rfc3339(),
+            "fired_at": reminder.fired_at.map(|t| t.to_rfc3339()),
+            "popup_enabled": true,
+        }));
+
         // 加在 emit_to 前:記錄 popup window 狀態,診斷 setPosition/setSize 是否生效
         use tauri::Manager;
         if let Some(popup_win) = self.handle.get_webview_window("reminder_popup") {
@@ -70,6 +79,14 @@ impl EventEmitter for TauriEventEmitter {
             .emit_to("reminder_popup", "reminder-fire-show", payload)
             .map_err(|e| e.to_string());
         tracing::info!(?result, "emit_to reminder-fire-show result");
+
+        mori_core::event_log::append(serde_json::json!({
+            "kind": "reminder_popup_emit",
+            "reminder_id": reminder.id,
+            "ok": result.is_ok(),
+            "error": result.as_ref().err().map(|e| e.as_str()),
+        }));
+
         result
     }
 }

--- a/crates/mori-tauri/src/reminder_emitter.rs
+++ b/crates/mori-tauri/src/reminder_emitter.rs
@@ -1,0 +1,40 @@
+//! 2026-05-22:把 mori-time 的 EventEmitter trait 用 Tauri AppHandle 實作出來。
+//! 放在 mori-tauri 是因為 mori-time crate 不能 depend tauri(會循環 + 違反 cross-platform 設計)。
+
+use mori_time::{EventEmitter, schema::Reminder};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+
+/// Tauri 端的 EventEmitter 實作 — 把 reminder fire payload 透過 AppHandle.emit 送到
+/// `reminder_popup` window React listener。
+pub struct TauriEventEmitter {
+    pub handle: AppHandle,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct ReminderFirePayload<'a> {
+    id: i64,
+    text: &'a str,
+    due_at: String,
+    fired_at: String,
+}
+
+impl EventEmitter for TauriEventEmitter {
+    fn emit_reminder_fire(&self, reminder: &Reminder) -> Result<(), String> {
+        let payload = ReminderFirePayload {
+            id: reminder.id,
+            text: &reminder.text,
+            due_at: reminder.due_at.to_rfc3339(),
+            fired_at: reminder
+                .fired_at
+                .unwrap_or_else(chrono::Utc::now)
+                .to_rfc3339(),
+        };
+        // emit_to 特定 window 比較精準;若 popup 還沒 mount listener,event 丟失,
+        // 但 popup mount 時會 invoke reminder_active_queue 補抓,所以不擋。
+        self.handle
+            .emit_to("reminder_popup", "reminder-fire-show", payload)
+            .map_err(|e| e.to_string())
+    }
+}

--- a/crates/mori-tauri/src/reminder_emitter.rs
+++ b/crates/mori-tauri/src/reminder_emitter.rs
@@ -22,6 +22,17 @@ struct ReminderFirePayload<'a> {
 
 impl EventEmitter for TauriEventEmitter {
     fn emit_reminder_fire(&self, reminder: &Reminder) -> Result<(), String> {
+        // 讀當前設定 — load 是 read-on-call,user 切 toggle 即時生效
+        let cfg = crate::notification_config::NotificationConfig::load(
+            &crate::mori_dir().join("config.json"),
+        );
+        if !cfg.popup_enabled {
+            tracing::debug!(
+                reminder_id = reminder.id,
+                "skip popup emit — popup_enabled toggle off"
+            );
+            return Ok(());
+        }
         let payload = ReminderFirePayload {
             id: reminder.id,
             text: &reminder.text,

--- a/crates/mori-tauri/src/reminder_emitter.rs
+++ b/crates/mori-tauri/src/reminder_emitter.rs
@@ -33,6 +33,27 @@ impl EventEmitter for TauriEventEmitter {
             );
             return Ok(());
         }
+
+        tracing::info!(
+            reminder_id = reminder.id,
+            text = %reminder.text,
+            "TauriEventEmitter: about to emit reminder-fire-show to popup window",
+        );
+
+        // 加在 emit_to 前:記錄 popup window 狀態,診斷 setPosition/setSize 是否生效
+        use tauri::Manager;
+        if let Some(popup_win) = self.handle.get_webview_window("reminder_popup") {
+            let pos = popup_win.outer_position().ok();
+            let size = popup_win.outer_size().ok();
+            let visible = popup_win.is_visible().ok();
+            tracing::info!(
+                ?pos, ?size, ?visible,
+                "popup window state pre-emit"
+            );
+        } else {
+            tracing::warn!("reminder_popup window not registered with Manager!");
+        }
+
         let payload = ReminderFirePayload {
             id: reminder.id,
             text: &reminder.text,
@@ -44,8 +65,11 @@ impl EventEmitter for TauriEventEmitter {
         };
         // emit_to 特定 window 比較精準;若 popup 還沒 mount listener,event 丟失,
         // 但 popup mount 時會 invoke reminder_active_queue 補抓,所以不擋。
-        self.handle
+        let result = self
+            .handle
             .emit_to("reminder_popup", "reminder-fire-show", payload)
-            .map_err(|e| e.to_string())
+            .map_err(|e| e.to_string());
+        tracing::info!(?result, "emit_to reminder-fire-show result");
+        result
     }
 }

--- a/crates/mori-tauri/src/reminders_cmd.rs
+++ b/crates/mori-tauri/src/reminders_cmd.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 use chrono::Utc;
 use mori_time::{Reminder, ReminderService};
 use serde::Serialize;
+use tauri::Manager;
 
 // ─────────────────────────────────────────────────────────────────────
 // Popup-queue 型別 — 給前端 reminder popup 用的精簡 view
@@ -169,6 +170,37 @@ pub async fn reminder_snooze(
     svc.snooze_reminder(id, format!("{} minutes", minutes))
         .await
         .map_err(|e| e.to_string())
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Sprite position query — popup mount 時主動拿 sprite 位置
+// ─────────────────────────────────────────────────────────────────────
+
+/// `get_sprite_position()` — 回傳 floating sprite window 的目前邏輯座標。
+///
+/// ReminderPopup mount 時用這個補抓 sprite 位置(只在拖動後才 emit sprite-moved,
+/// mount 時 spritePos 預設 (0,0),anchor 算成 (0, 212) → 不在任何 monitor 範圍)。
+///
+/// 失敗(floating window 不存在或 Tauri API 失敗)→ 回 Err,前端 fallback 用 (0,0)。
+#[tauri::command]
+pub fn get_sprite_position(
+    app: tauri::AppHandle,
+) -> Result<SpritePosition, String> {
+    let win = app
+        .get_webview_window("floating")
+        .ok_or_else(|| "floating window not found".to_string())?;
+    let phys = win.outer_position().map_err(|e| e.to_string())?;
+    let scale = win.scale_factor().unwrap_or(1.0);
+    Ok(SpritePosition {
+        x: phys.x as f64 / scale,
+        y: phys.y as f64 / scale,
+    })
+}
+
+#[derive(Serialize)]
+pub struct SpritePosition {
+    pub x: f64,
+    pub y: f64,
 }
 
 #[cfg(test)]

--- a/crates/mori-tauri/src/reminders_cmd.rs
+++ b/crates/mori-tauri/src/reminders_cmd.rs
@@ -113,14 +113,14 @@ mod tests {
     //! Notifier 在 CI 沒 dbus 會 fire-err,但 service callback 內部只 log warn,
     //! `do_*` helpers 不會受影響(我們只測 happy + error paths,不等 fire)。
     use super::*;
-    use mori_time::Notifier;
+    use mori_time::{NoopEmitter, Notifier};
     use tempfile::TempDir;
 
     async fn make_test_service(dir: &TempDir) -> Arc<ReminderService> {
         let db = dir.path().join("test.db");
         let notifier = Notifier::new("MoriTauriTest");
         Arc::new(
-            ReminderService::new(&db, notifier)
+            ReminderService::new(&db, notifier, Arc::new(NoopEmitter))
                 .await
                 .expect("new service"),
         )

--- a/crates/mori-tauri/src/reminders_cmd.rs
+++ b/crates/mori-tauri/src/reminders_cmd.rs
@@ -23,7 +23,34 @@
 
 use std::sync::Arc;
 
+use chrono::Utc;
 use mori_time::{Reminder, ReminderService};
+use serde::Serialize;
+
+// ─────────────────────────────────────────────────────────────────────
+// Popup-queue 型別 — 給前端 reminder popup 用的精簡 view
+// ─────────────────────────────────────────────────────────────────────
+
+/// 前端 popup 收到的 reminder 快照。camelCase → TS 端 `dueAt` / `firedAt`。
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActiveReminder {
+    pub id: i64,
+    pub text: String,
+    pub due_at: String,   // ISO8601 RFC3339
+    pub fired_at: String, // ISO8601 RFC3339(若 fired_at 為 None,填 Utc::now())
+}
+
+impl From<&Reminder> for ActiveReminder {
+    fn from(r: &Reminder) -> Self {
+        Self {
+            id: r.id,
+            text: r.text.clone(),
+            due_at: r.due_at.to_rfc3339(),
+            fired_at: r.fired_at.unwrap_or_else(Utc::now).to_rfc3339(),
+        }
+    }
+}
 
 // ─────────────────────────────────────────────────────────────────────
 // 內部 helpers — 無 Tauri 依賴,可直接 unit test
@@ -101,6 +128,47 @@ pub async fn snooze_reminder_cmd(
     when: String,
 ) -> Result<(), String> {
     do_snooze_reminder(state.inner(), id, when).await
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Popup-queue commands — in-app reminder popup 系列
+// ─────────────────────────────────────────────────────────────────────
+
+/// `reminder_active_queue()` — 回傳已 fired 但尚未 dismissed 的 reminders
+/// (由 `ReminderStore::list_active_popup_queue` 過濾)。
+#[tauri::command]
+pub async fn reminder_active_queue(
+    svc: tauri::State<'_, Arc<ReminderService>>,
+) -> Result<Vec<ActiveReminder>, String> {
+    let store = svc.store.lock().await;
+    let now = Utc::now();
+    let reminders = store
+        .list_active_popup_queue(now)
+        .map_err(|e| e.to_string())?;
+    Ok(reminders.iter().map(ActiveReminder::from).collect())
+}
+
+/// `reminder_dismiss(id)` — 標記 reminder 為 user 已 dismiss(寫 `dismissed_at`)。
+#[tauri::command]
+pub async fn reminder_dismiss(
+    id: i64,
+    svc: tauri::State<'_, Arc<ReminderService>>,
+) -> Result<(), String> {
+    let store = svc.store.lock().await;
+    store.mark_dismissed(id, Utc::now()).map_err(|e| e.to_string())
+}
+
+/// `reminder_snooze(id, minutes)` — 暫緩 `minutes` 分鐘。
+/// 內部轉換成 NL 字串並走 `ReminderService::snooze_reminder` NL parser 路徑。
+#[tauri::command]
+pub async fn reminder_snooze(
+    id: i64,
+    minutes: u32,
+    svc: tauri::State<'_, Arc<ReminderService>>,
+) -> Result<(), String> {
+    svc.snooze_reminder(id, format!("{} minutes", minutes))
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[cfg(test)]
@@ -216,5 +284,76 @@ mod tests {
             err.contains("can't be snoozed"),
             "expected guard message, got: {err}",
         );
+    }
+
+    // ── popup-queue command integration tests ────────────────────────
+
+    #[tokio::test]
+    async fn dismiss_writes_dismissed_at_and_filter_takes_effect() {
+        let dir = TempDir::new().unwrap();
+        let svc = make_test_service(&dir).await;
+
+        // 建 reminder 並強迫 mark_fired(模擬排程觸發)
+        let r = {
+            let store = svc.store.lock().await;
+            let r = store
+                .create(
+                    "popup-test".to_string(),
+                    Utc::now() - chrono::Duration::minutes(1),
+                    None,
+                )
+                .unwrap();
+            store.mark_fired(r.id, Utc::now()).unwrap();
+            r
+        };
+
+        // dismiss 前,active_queue 應包含 r
+        {
+            let store = svc.store.lock().await;
+            let before = store.list_active_popup_queue(Utc::now()).unwrap();
+            assert!(
+                before.iter().any(|x| x.id == r.id),
+                "fired reminder should appear in active queue before dismiss"
+            );
+        }
+
+        // 呼叫 store.mark_dismissed — 等價 reminder_dismiss command 邏輯
+        {
+            let store = svc.store.lock().await;
+            store.mark_dismissed(r.id, Utc::now()).unwrap();
+        }
+
+        // dismiss 後,active_queue 應不含 r
+        let store = svc.store.lock().await;
+        let after = store.list_active_popup_queue(Utc::now()).unwrap();
+        assert!(
+            !after.iter().any(|x| x.id == r.id),
+            "dismissed reminder should NOT appear in active queue after dismiss"
+        );
+    }
+
+    #[tokio::test]
+    async fn active_reminder_from_converts_fields_correctly() {
+        use mori_time::schema::Reminder;
+        use chrono::TimeZone;
+
+        let due = Utc.with_ymd_and_hms(2026, 6, 1, 10, 0, 0).unwrap();
+        let fired = Utc.with_ymd_and_hms(2026, 6, 1, 10, 0, 5).unwrap();
+        let r = Reminder {
+            id: 42,
+            text: "hello".to_string(),
+            due_at: due,
+            cron_expr: None,
+            created_at: due,
+            fired_at: Some(fired),
+            snoozed_until: None,
+            status: mori_time::ReminderStatus::Fired,
+            dismissed_at: None,
+        };
+        let ar = ActiveReminder::from(&r);
+        assert_eq!(ar.id, 42);
+        assert_eq!(ar.text, "hello");
+        assert_eq!(ar.due_at, due.to_rfc3339());
+        assert_eq!(ar.fired_at, fired.to_rfc3339());
     }
 }

--- a/crates/mori-tauri/src/reminders_cmd.rs
+++ b/crates/mori-tauri/src/reminders_cmd.rs
@@ -159,16 +159,18 @@ pub async fn reminder_dismiss(
     store.mark_dismissed(id, Utc::now()).map_err(|e| e.to_string())
 }
 
-/// `reminder_snooze(id, minutes)` — 暫緩 `minutes` 分鐘。
-/// 內部轉換成 NL 字串並走 `ReminderService::snooze_reminder` NL parser 路徑。
+/// `reminder_snooze(id, minutes)` — popup [稍後 N 分] 用。
+/// 對 fired reminder 做 reschedule:dismiss 原本 + 建新一筆 N 分鐘後 fire。
+/// 使用 `ReminderService::reschedule_fired_reminder`,語義對齊「我錯過了,再提醒一次」。
 #[tauri::command]
 pub async fn reminder_snooze(
     id: i64,
     minutes: u32,
     svc: tauri::State<'_, Arc<ReminderService>>,
 ) -> Result<(), String> {
-    svc.snooze_reminder(id, format!("{} minutes", minutes))
+    svc.reschedule_fired_reminder(id, minutes as i64)
         .await
+        .map(|_| ())
         .map_err(|e| e.to_string())
 }
 

--- a/crates/mori-tauri/src/reminders_cmd.rs
+++ b/crates/mori-tauri/src/reminders_cmd.rs
@@ -156,7 +156,13 @@ pub async fn reminder_dismiss(
     svc: tauri::State<'_, Arc<ReminderService>>,
 ) -> Result<(), String> {
     let store = svc.store.lock().await;
-    store.mark_dismissed(id, Utc::now()).map_err(|e| e.to_string())
+    let result = store.mark_dismissed(id, Utc::now()).map_err(|e| e.to_string());
+    mori_core::event_log::append(serde_json::json!({
+        "kind": "reminder_dismiss",
+        "reminder_id": id,
+        "ok": result.is_ok(),
+    }));
+    result
 }
 
 /// `reminder_snooze(id, minutes)` — popup [稍後 N 分] 用。
@@ -168,10 +174,18 @@ pub async fn reminder_snooze(
     minutes: u32,
     svc: tauri::State<'_, Arc<ReminderService>>,
 ) -> Result<(), String> {
-    svc.reschedule_fired_reminder(id, minutes as i64)
+    let result = svc
+        .reschedule_fired_reminder(id, minutes as i64)
         .await
         .map(|_| ())
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string());
+    mori_core::event_log::append(serde_json::json!({
+        "kind": "reminder_reschedule",
+        "original_id": id,
+        "delay_minutes": minutes,
+        "ok": result.is_ok(),
+    }));
+    result
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/crates/mori-tauri/src/reminders_cmd.rs
+++ b/crates/mori-tauri/src/reminders_cmd.rs
@@ -205,6 +205,40 @@ pub struct SpritePosition {
     pub y: f64,
 }
 
+// ─────────────────────────────────────────────────────────────────────
+// Debug command — popup window state from Tauri's perspective
+// ─────────────────────────────────────────────────────────────────────
+
+/// `debug_reminder_popup_state()` — 從 Tauri 視角回傳 popup window 的實際位置/大小/可見性。
+/// 診斷用:可與 X11/mutter 所見對比,找出 setPosition/setSize 是否真的生效。
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PopupDebugState {
+    pub label: String,
+    pub is_visible: bool,
+    pub outer_position: (i32, i32), // physical px
+    pub outer_size: (u32, u32),     // physical px
+    pub scale_factor: f64,
+}
+
+#[tauri::command]
+pub fn debug_reminder_popup_state(app: tauri::AppHandle) -> Result<PopupDebugState, String> {
+    let win = app
+        .get_webview_window("reminder_popup")
+        .ok_or_else(|| "reminder_popup window not found".to_string())?;
+    let pos = win.outer_position().map_err(|e| e.to_string())?;
+    let size = win.outer_size().map_err(|e| e.to_string())?;
+    let visible = win.is_visible().map_err(|e| e.to_string())?;
+    let scale = win.scale_factor().map_err(|e| e.to_string())?;
+    Ok(PopupDebugState {
+        label: "reminder_popup".to_string(),
+        is_visible: visible,
+        outer_position: (pos.x, pos.y),
+        outer_size: (size.width, size.height),
+        scale_factor: scale,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     //! 對齊 `file_loader_cmd::tests` 的風格 — Tauri State / runtime mock 麻煩,

--- a/crates/mori-tauri/src/skill_server.rs
+++ b/crates/mori-tauri/src/skill_server.rs
@@ -37,10 +37,13 @@ use axum::{
 use mori_core::context::Context as MoriContext;
 use mori_core::runtime::{generate_auth_token, RuntimeInfo};
 use mori_core::skill::{
-    ComposeSkill, EditMemorySkill, ForgetMemorySkill, PolishSkill, RecallMemorySkill,
-    RememberSkill, SkillRegistry, SummarizeSkill, TranslateSkill,
+    ComposeSkill, EditMemorySkill, ForgetMemorySkill, ListGmailSkill, PolishSkill, ReadFileSkill,
+    ReadGmailSkill, ReadWikiPageSkill, RecallMemorySkill, RememberSkill, RemindMeSkill,
+    SendGmailSkill, SharedGmailClient, SkillRegistry, SummarizeSkill, TranslateSkill,
 };
+use mori_time::ReminderService;
 use serde_json::{json, Value};
+use tauri::Manager;
 
 #[derive(Clone)]
 pub struct SkillServerState {
@@ -48,9 +51,16 @@ pub struct SkillServerState {
     /// C:不直接持 Arc<dyn MemoryStore>(會被 hot-reload swap 後變 stale),
     /// 持 Arc<AppState>,每次 handler 透過 `app.memory_handle()` 拿當下 snapshot。
     pub app: Arc<crate::AppState>,
+    /// Tauri AppHandle — 從 Manager 拿 stateful service(ReminderService /
+    /// SharedGmailClient / McpRegistry)。沒這個就只能掛純 functional skill,
+    /// 時之鳥 / Gmail / MCP tool 全進不來。
+    pub app_handle: tauri::AppHandle,
 }
 
-pub async fn start(app: Arc<crate::AppState>) -> Result<RuntimeInfo> {
+pub async fn start(
+    app: Arc<crate::AppState>,
+    app_handle: tauri::AppHandle,
+) -> Result<RuntimeInfo> {
     let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
         .await
         .context("bind 127.0.0.1:random")?;
@@ -73,6 +83,7 @@ pub async fn start(app: Arc<crate::AppState>) -> Result<RuntimeInfo> {
     let state = SkillServerState {
         auth_token: Arc::from(token.as_str()),
         app,
+        app_handle,
     };
     let app = Router::new()
         .route("/skill/list", get(list_skills))
@@ -110,19 +121,30 @@ fn check_auth(headers: &HeaderMap, expected: &str) -> Result<(), (StatusCode, St
 
 // ─── 5I: 動態 registry builder ──────────────────────────────────────────
 
-/// 依當前 Agent profile build 一個臨時 SkillRegistry：
-/// - Built-in（純 LLM）skill: translate / polish / summarize / compose
-/// - Memory skill: remember / recall_memory / forget_memory / edit_memory
-/// - Action skill (Linux): open_url / open_app / send_keys / google_search /
-///   ask_chatgpt / ask_gemini / find_youtube
-/// - Shell skill: 來自 active agent profile 的 `shell_skills:` 定義
+/// 依當前 Agent profile build 一個臨時 SkillRegistry。內容必須對齊 main.rs
+/// `skills_list` 那塊 — 否則 claude-bash / gemini-bash 等走 HTTP 拿 skill list
+/// 的 provider 會看不到新 skill(LLM hallucinate「沒掛」)。
 ///
-/// 注意：set_mode / paste_selection_back 等 stateful skill 不註冊到 HTTP 入口，
-/// 它們有 AppHandle / state 依賴，且通常不適合外部觸發。
-fn build_dynamic_registry(state: &SkillServerState) -> Result<SkillRegistry> {
+/// 包含:
+/// - Built-in 純 LLM skill: translate / polish / summarize / compose / fetch_url
+/// - 萬卷之口: read_file_text
+/// - 時之鳥 K5: remind_me(需 ReminderService state)
+/// - Gmail(跨界之手): list_gmail / read_gmail / send_gmail(需 SharedGmailClient state)
+/// - 記憶之森: read_wiki_page(需 vault_root + spirit_name)
+/// - Memory: remember / recall_memory / forget_memory / edit_memory
+/// - Action skill: open_url / open_app / send_keys / google_search /
+///   ask_chatgpt / ask_gemini / find_youtube
+/// - Shell skill: active agent profile 的 `shell_skills:` 定義
+/// - Stream I Anthropic SKILL.md: prompt + 可選 scripts
+/// - Wave 6 MCP: 已連接 MCP server 的 tool
+///
+/// **故意排除**:set_mode / paste_selection_back 是 stateful + AppHandle 強耦合,
+/// 不適合外部觸發。
+async fn build_dynamic_registry(state: &SkillServerState) -> Result<SkillRegistry> {
     let routing = mori_core::llm::Routing::build_from_config(None)
         .context("build routing for skill_server dynamic registry")?;
     let memory = state.app.memory_handle();
+    let app = &state.app_handle;
     let mut registry = SkillRegistry::new();
 
     // Built-in 純 LLM skill
@@ -130,8 +152,35 @@ fn build_dynamic_registry(state: &SkillServerState) -> Result<SkillRegistry> {
     registry.register(Arc::new(PolishSkill::new(routing.skill_provider("polish"))));
     registry.register(Arc::new(SummarizeSkill::new(routing.skill_provider("summarize"))));
     registry.register(Arc::new(ComposeSkill::new(routing.skill_provider("compose"))));
-    // Phase 3B: URL fetching
     registry.register(Arc::new(mori_core::skill::FetchUrlSkill::new()));
+
+    // Stream E 萬卷之口
+    registry.register(Arc::new(ReadFileSkill));
+
+    // §9 P1 時之鳥 K5 — ReminderService 透過 Tauri Manager 拿。沒撈到就跳過
+    // (LLM 拿不到 remind_me skill,但其他不會炸)。
+    if let Some(svc) = app.try_state::<Arc<ReminderService>>() {
+        registry.register(Arc::new(RemindMeSkill::new(svc.inner().clone())));
+    }
+
+    // Wave 8 Gm-2 Gmail — optional state,沒設不註冊
+    if let Some(shared) = app.try_state::<SharedGmailClient>() {
+        let client = shared.0.clone();
+        registry.register(Arc::new(ListGmailSkill::new(client.clone())));
+        registry.register(Arc::new(ReadGmailSkill::new(client.clone())));
+        registry.register(Arc::new(SendGmailSkill::new(client)));
+    }
+
+    // Wave 7 L-mori 記憶之森
+    if let Some(vault_root) = crate::default_vault_root() {
+        let cfg = crate::annuli_config::AnnuliConfig::load(&crate::mori_dir().join("config.json"));
+        let spirit = if cfg.spirit_name.is_empty() {
+            "mori".to_string()
+        } else {
+            cfg.spirit_name
+        };
+        registry.register(Arc::new(ReadWikiPageSkill::new(vault_root, spirit)));
+    }
 
     // Memory skills
     registry.register(Arc::new(RememberSkill::new(memory.clone())));
@@ -139,8 +188,7 @@ fn build_dynamic_registry(state: &SkillServerState) -> Result<SkillRegistry> {
     registry.register(Arc::new(ForgetMemorySkill::new(memory.clone())));
     registry.register(Arc::new(EditMemorySkill::new(memory.clone())));
 
-    // 5G-6: action skills(Linux: xdg-open / gtk-launch / ydotool;
-    // Windows: cmd /c start + SendInput)
+    // 5G-6: action skills
     registry.register(Arc::new(crate::action_skills::OpenUrlSkill));
     registry.register(Arc::new(crate::action_skills::OpenAppSkill));
     registry.register(Arc::new(crate::action_skills::SendKeysSkill));
@@ -155,6 +203,34 @@ fn build_dynamic_registry(state: &SkillServerState) -> Result<SkillRegistry> {
         registry.register(Arc::new(crate::shell_skill::ShellSkill::new(def.clone())));
     }
 
+    // Stream I / Wave 6 DF-2: Anthropic SKILL.md(prompt + optional scripts)
+    let anthropic_dir = mori_core::skill::anthropic_skill::default_skills_dir();
+    for discovered in mori_core::skill::discover_anthropic_skills(&anthropic_dir) {
+        let mori_core::skill::DiscoveredSkill {
+            skill,
+            scripts_dir,
+        } = discovered;
+        if let Some(sd) = scripts_dir {
+            registry.register(Arc::new(mori_core::skill::AnthropicScriptSkill::new(
+                skill.clone(),
+                sd,
+            )));
+        }
+        registry.register(Arc::new(mori_core::skill::AnthropicPromptSkill::new(skill)));
+    }
+
+    // Wave 6 MCP-2: 已連接 MCP server 提供的 tool。沒掛 MCP 就跳過。
+    // 注意 all_tools() 是 async,所以 build_dynamic_registry 整個是 async。
+    if let Some(mcp_reg) = app.try_state::<Arc<mori_mcp::McpRegistry>>() {
+        let mcp_arc = mcp_reg.inner().clone();
+        for tool in mcp_arc.all_tools().await {
+            registry.register(Arc::new(mori_core::skill::McpToolSkill::new(
+                mcp_arc.clone(),
+                tool,
+            )));
+        }
+    }
+
     Ok(registry)
 }
 
@@ -164,7 +240,7 @@ async fn list_skills(
 ) -> Result<Json<Value>, (StatusCode, String)> {
     check_auth(&headers, &state.auth_token)?;
 
-    let registry = build_dynamic_registry(&state).map_err(|e| {
+    let registry = build_dynamic_registry(&state).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("build registry: {e:#}"),
@@ -196,7 +272,7 @@ async fn dispatch_skill(
 ) -> Result<String, (StatusCode, String)> {
     check_auth(&headers, &state.auth_token)?;
 
-    let registry = build_dynamic_registry(&state).map_err(|e| {
+    let registry = build_dynamic_registry(&state).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("build registry: {e:#}"),

--- a/crates/mori-tauri/tauri.conf.json
+++ b/crates/mori-tauri/tauri.conf.json
@@ -50,6 +50,22 @@
         "focus": false
       },
       {
+        "label": "reminder_popup",
+        "title": "Mori (reminder)",
+        "width": 320,
+        "height": 96,
+        "decorations": false,
+        "transparent": true,
+        "alwaysOnTop": true,
+        "skipTaskbar": true,
+        "resizable": false,
+        "shadow": false,
+        "visible": true,
+        "focus": false,
+        "x": -10000,
+        "y": -10000
+      },
+      {
         "label": "picker",
         "title": "Mori — 切換 Profile",
         "width": 520,

--- a/crates/mori-time/src/commands.rs
+++ b/crates/mori-time/src/commands.rs
@@ -116,7 +116,13 @@ impl ReminderService {
                 })
                 .await;
                 match fire_result {
-                    Ok(Ok(())) => {}
+                    // 2026-05-22 debug:即使 Ok user 也回報沒看到通知,加 info log
+                    // 證明 fire 路徑跑完 + 通知有 send 進 dbus(否則早就吐 Err)。
+                    Ok(Ok(())) => tracing::info!(
+                        reminder_id = reminder.id,
+                        text = %reminder.text,
+                        "notifier.fire returned Ok — notification submitted to dbus",
+                    ),
                     Ok(Err(e)) => tracing::warn!(
                         reminder_id = reminder.id,
                         error = %e,

--- a/crates/mori-time/src/commands.rs
+++ b/crates/mori-time/src/commands.rs
@@ -156,7 +156,38 @@ impl ReminderService {
         // 4) Reload pending — restart 後把 DB 裡未完成的 reminder 重新 schedule。
         //    用 due_at vs now 判斷:過去的 one-shot 立刻觸發(scheduler 內部處理)。
         let pending = store.lock().await.list_pending()?;
+        let now = Utc::now();
+        let grace_cutoff = now - chrono::Duration::days(7);
         for r in &pending {
+            // 2026-05-22:超過 7 天的 overdue one-shot reminder 自動標 dismissed,
+            // 不再 fire,避免 user 久未開 app 後被 spam。cron 不適用(週期性永遠不算 overdue)。
+            let is_super_overdue = r.cron_expr.is_none() && r.due_at < grace_cutoff;
+            if is_super_overdue {
+                let store_guard = store.lock().await;
+                let when = Utc::now();
+                if let Err(e) = store_guard.mark_fired(r.id, when) {
+                    tracing::warn!(
+                        reminder_id = r.id,
+                        error = %e,
+                        "failed to auto-mark super-overdue as fired"
+                    );
+                    continue;
+                }
+                if let Err(e) = store_guard.mark_dismissed(r.id, when) {
+                    tracing::warn!(
+                        reminder_id = r.id,
+                        error = %e,
+                        "failed to auto-mark super-overdue as dismissed"
+                    );
+                }
+                tracing::info!(
+                    reminder_id = r.id,
+                    text = %r.text,
+                    due_at = %r.due_at,
+                    "auto-dismissed super-overdue reminder (> 7d) — skipping fire to avoid spam"
+                );
+                continue;
+            }
             if let Err(e) = scheduler.schedule(r).await {
                 tracing::warn!(
                     reminder_id = r.id,
@@ -531,6 +562,44 @@ mod tests {
         }
         let after = svc.store.lock().await.get(r.id).unwrap();
         assert_eq!(after.status, ReminderStatus::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn startup_auto_dismisses_super_overdue_reminders() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let db = dir.path().join("r.db");
+
+        // 先用一個 service 寫一筆 8 天前 overdue + status=Pending
+        {
+            let store = ReminderStore::open(&db).expect("open");
+            let past = Utc::now() - chrono::Duration::days(8);
+            store.create("stale".to_string(), past, None).expect("create");
+            // 不 mark_fired,留 Pending,模擬 user 一週多沒開 app
+        }
+
+        // 開 service → reload-pending 應該把 8 天前的標 dismissed_at + Fired
+        let _svc = ReminderService::new(&db, Notifier::new("Mori-Test"))
+            .await
+            .expect("service");
+        // 留一點時間給 1ms 觸發 + spawn task 處理 mark_fired 完成
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        let store = ReminderStore::open(&db).expect("reopen");
+        let queue = store
+            .list_active_popup_queue(Utc::now())
+            .expect("list active");
+        assert!(queue.is_empty(), "super-overdue reminder should be auto-dismissed, not on popup queue");
+
+        // 而 status 應該是 fired(走完正常 fire path),dismissed_at 也填了
+        let conn = rusqlite::Connection::open(&db).unwrap();
+        let mut stmt = conn
+            .prepare("SELECT status, dismissed_at FROM reminders WHERE text = 'stale'")
+            .unwrap();
+        let (status, dismissed_at): (String, Option<String>) = stmt
+            .query_row([], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap();
+        assert_eq!(status, "fired", "super-overdue should be marked Fired");
+        assert!(dismissed_at.is_some(), "super-overdue should be marked dismissed");
     }
 
     #[tokio::test]

--- a/crates/mori-time/src/commands.rs
+++ b/crates/mori-time/src/commands.rs
@@ -386,7 +386,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn fresh_notifier() -> Notifier {
-        Notifier::new("Mori-Test")
+        Notifier::disabled("Mori-Test")
     }
 
     async fn service_in(dir: &TempDir) -> ReminderService {
@@ -578,7 +578,7 @@ mod tests {
         let db = dir.path().join("r.db");
         let svc = ReminderService::new(
             &db,
-            Notifier::new("Mori-Test"),
+            Notifier::disabled("Mori-Test"),
             Arc::new(NoopEmitter),
         )
         .await
@@ -613,7 +613,7 @@ mod tests {
         let db = dir.path().join("r.db");
         let svc = ReminderService::new(
             &db,
-            Notifier::new("Mori-Test"),
+            Notifier::disabled("Mori-Test"),
             Arc::new(NoopEmitter),
         )
         .await
@@ -699,7 +699,7 @@ mod tests {
         }
 
         // 開 service → reload-pending 應該把 8 天前的標 dismissed_at + Fired
-        let _svc = ReminderService::new(&db, Notifier::new("Mori-Test"), Arc::new(NoopEmitter))
+        let _svc = ReminderService::new(&db, Notifier::disabled("Mori-Test"), Arc::new(NoopEmitter))
             .await
             .expect("service");
         // 留一點時間給 1ms 觸發 + spawn task 處理 mark_fired 完成
@@ -771,7 +771,7 @@ mod tests {
 
         let svc = ReminderService::new(
             &db,
-            Notifier::new("Mori-Test"),
+            Notifier::disabled("Mori-Test"),
             emitter.clone() as Arc<dyn EventEmitter>,
         )
         .await

--- a/crates/mori-time/src/commands.rs
+++ b/crates/mori-time/src/commands.rs
@@ -104,12 +104,29 @@ impl ReminderService {
             // scheduler。詳見模組 doc。
             tokio::spawn(async move {
                 // K3:發桌面通知。失敗 log warn,不 throw。
-                if let Err(e) = notifier_inner.fire(&reminder) {
-                    tracing::warn!(
+                //
+                // **必須走 spawn_blocking**:`notify_rust::Notification::show()` 在 Linux
+                // 內部跑 dbus async client → 自己 build 一個 tokio Runtime。如果直接在
+                // 既有 tokio worker thread 內呼叫,會 panic
+                // 「Cannot start a runtime from within a runtime」。
+                // 觀察點:tokio-1.52.2 multi_thread/mod.rs:91。
+                let reminder_for_blk = reminder.clone();
+                let fire_result = tokio::task::spawn_blocking(move || {
+                    notifier_inner.fire(&reminder_for_blk)
+                })
+                .await;
+                match fire_result {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => tracing::warn!(
                         reminder_id = reminder.id,
                         error = %e,
                         "notifier.fire failed (reminder still mark_fired)",
-                    );
+                    ),
+                    Err(join_err) => tracing::warn!(
+                        reminder_id = reminder.id,
+                        error = %join_err,
+                        "notifier.fire spawn_blocking join failed",
+                    ),
                 }
                 // 一次性 reminder:fire 後 store 標 Fired。週期性(cron)保留 Pending。
                 if reminder.cron_expr.is_none() {

--- a/crates/mori-time/src/commands.rs
+++ b/crates/mori-time/src/commands.rs
@@ -286,6 +286,37 @@ impl ReminderService {
         Ok(())
     }
 
+    /// 2026-05-22:popup [稍後 5 分] 用 — 把 fired reminder「再提醒一次」。
+    /// 跟 snooze_reminder 不同:那個只動 due_at(僅限 Pending/Snoozed);
+    /// 這個是「原本 dismissed,新建一筆 N 分鐘後 fire」,給 fired-but-missed 的情境。
+    ///
+    /// 流程:
+    /// 1. 拿原本 reminder,確認 status=Fired(其他狀態 reject InvalidStatus)
+    /// 2. mark_dismissed 原本
+    /// 3. 建新 reminder 同 text、due_at = now + delay_minutes、cron_expr = None
+    /// 4. schedule 新 reminder
+    /// 5. 返回新 reminder
+    pub async fn reschedule_fired_reminder(
+        &self,
+        id: i64,
+        delay_minutes: i64,
+    ) -> Result<Reminder, CommandError> {
+        let store = self.store.lock().await;
+        let original = store.get(id)?;
+        if !matches!(original.status, crate::schema::ReminderStatus::Fired) {
+            return Err(CommandError::InvalidStatus {
+                id,
+                current: format!("{:?}", original.status),
+            });
+        }
+        store.mark_dismissed(id, Utc::now())?;
+        let new_due = Utc::now() + chrono::Duration::minutes(delay_minutes);
+        let new_r = store.create(original.text.clone(), new_due, None)?;
+        drop(store);
+        self.scheduler.schedule(&new_r).await?;
+        Ok(new_r)
+    }
+
     /// 把現有 reminder snooze 到指定時間。`when_expr` 同 [`remind_me`] 走 NL parser。
     ///
     /// 內部:parse → store.snooze(更新 status + snoozed_until + **due_at**)→
@@ -539,6 +570,64 @@ mod tests {
         assert_eq!(pending.len(), 1, "expected 1 reloaded pending, got {}", pending.len());
         assert_eq!(pending[0].id, r_id);
         assert_eq!(pending[0].text, "persistent");
+    }
+
+    #[tokio::test]
+    async fn reschedule_fired_reminder_dismisses_original_and_creates_new() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("r.db");
+        let svc = ReminderService::new(
+            &db,
+            Notifier::new("Mori-Test"),
+            Arc::new(NoopEmitter),
+        )
+        .await
+        .unwrap();
+
+        // 建 + 強制 fire
+        let original_id = {
+            let store = svc.store.lock().await;
+            let r = store
+                .create("test".to_string(), Utc::now() - Duration::minutes(1), None)
+                .unwrap();
+            store.mark_fired(r.id, Utc::now()).unwrap();
+            r.id
+        };
+
+        // reschedule
+        let new_r = svc.reschedule_fired_reminder(original_id, 5).await.unwrap();
+
+        // assert: original dismissed,新建 reminder due_at 約 5 分鐘後,同 text,Pending
+        let store = svc.store.lock().await;
+        let original = store.get(original_id).unwrap();
+        assert!(original.dismissed_at.is_some(), "original should be dismissed");
+        assert_eq!(new_r.text, "test");
+        assert_eq!(new_r.status, ReminderStatus::Pending);
+        let due_diff = (new_r.due_at - Utc::now()).num_minutes();
+        assert!(due_diff >= 4 && due_diff <= 5, "new due_at should be ~5 min from now, got {due_diff}");
+    }
+
+    #[tokio::test]
+    async fn reschedule_fired_reminder_rejects_non_fired() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("r.db");
+        let svc = ReminderService::new(
+            &db,
+            Notifier::new("Mori-Test"),
+            Arc::new(NoopEmitter),
+        )
+        .await
+        .unwrap();
+        // Pending reminder — 不該被 reschedule_fired
+        let r = {
+            let store = svc.store.lock().await;
+            store.create("pending".to_string(), Utc::now() + Duration::hours(1), None).unwrap()
+        };
+        let err = svc.reschedule_fired_reminder(r.id, 5).await.unwrap_err();
+        match err {
+            CommandError::InvalidStatus { id, .. } => assert_eq!(id, r.id),
+            other => panic!("expected InvalidStatus, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/mori-time/src/commands.rs
+++ b/crates/mori-time/src/commands.rs
@@ -36,6 +36,22 @@ use crate::parser;
 use crate::scheduler::{OnFireCallback, ReminderScheduler, SchedulerError};
 use crate::schema::{Reminder, ReminderError, ReminderStore};
 
+/// 2026-05-22:on_fire 觸發時對外 emit 通知事件。設計成 trait 是為了讓 mori-time
+/// 不直接依賴 tauri(會循環依賴)— `mori-tauri` 那邊用 Tauri AppHandle 實作這個 trait,
+/// 測試環境可以 mock。
+pub trait EventEmitter: Send + Sync {
+    /// Emit `reminder-fire-show` event 帶 payload。失敗回 Err(只 log warn,不擋 mark_fired)。
+    fn emit_reminder_fire(&self, reminder: &Reminder) -> Result<(), String>;
+}
+
+/// no-op 實作,給沒 emit 需求的 caller(例如純 unit test)用。
+pub struct NoopEmitter;
+impl EventEmitter for NoopEmitter {
+    fn emit_reminder_fire(&self, _reminder: &Reminder) -> Result<(), String> {
+        Ok(())
+    }
+}
+
 /// 對外錯誤類型 — 包 K4 parse / K1 store / K2 scheduler 三條 error。
 #[derive(Debug, thiserror::Error)]
 pub enum CommandError {
@@ -75,7 +91,11 @@ impl ReminderService {
     /// `db_path` 通常是 `~/.mori/reminders.db`(對齊既有 mori_dir pattern)。
     /// `notifier` 由 caller 預先建好(`Notifier::new("Mori")`),這樣 caller 可
     /// `.with_icon()` 自訂。
-    pub async fn new(db_path: &Path, notifier: Notifier) -> Result<Self, CommandError> {
+    pub async fn new(
+        db_path: &Path,
+        notifier: Notifier,
+        emitter: Arc<dyn EventEmitter>,
+    ) -> Result<Self, CommandError> {
         // 1) Open store
         let store = ReminderStore::open(db_path)?;
         let store = Arc::new(Mutex::new(store));
@@ -97,9 +117,11 @@ impl ReminderService {
         //    能拿到。我們用這個。
         let store_for_cb = Arc::clone(&store);
         let notifier_for_cb = notifier.clone();
+        let emitter_for_cb = Arc::clone(&emitter); // 2026-05-22:capture for in-app popup emit
         let on_fire: OnFireCallback = Arc::new(move |reminder: Reminder| {
             let store_inner = Arc::clone(&store_for_cb);
             let notifier_inner = notifier_for_cb.clone();
+            let emitter_inner = Arc::clone(&emitter_for_cb);
             // 仰賴 tokio task 隔離:spawned task 內 panic 只殺那條 task,不傳染
             // scheduler。詳見模組 doc。
             tokio::spawn(async move {
@@ -134,6 +156,16 @@ impl ReminderService {
                         "notifier.fire spawn_blocking join failed",
                     ),
                 }
+
+                // 2026-05-22:in-app popup emit。失敗只 warn,不擋 mark_fired。
+                if let Err(e) = emitter_inner.emit_reminder_fire(&reminder) {
+                    tracing::warn!(
+                        reminder_id = reminder.id,
+                        error = %e,
+                        "emit reminder-fire-show failed (popup will catch up via active_queue query on next mount)",
+                    );
+                }
+
                 // 一次性 reminder:fire 後 store 標 Fired。週期性(cron)保留 Pending。
                 if reminder.cron_expr.is_none() {
                     let store = store_inner.lock().await;
@@ -328,7 +360,7 @@ mod tests {
 
     async fn service_in(dir: &TempDir) -> ReminderService {
         let db = dir.path().join("reminders.db");
-        ReminderService::new(&db, fresh_notifier())
+        ReminderService::new(&db, fresh_notifier(), Arc::new(NoopEmitter))
             .await
             .expect("new service")
     }
@@ -458,7 +490,7 @@ mod tests {
         let db = dir.path().join("reminders.db");
 
         let (r_id, snooze_until) = {
-            let svc = ReminderService::new(&db, fresh_notifier()).await.unwrap();
+            let svc = ReminderService::new(&db, fresh_notifier(), Arc::new(NoopEmitter)).await.unwrap();
             let r = svc
                 .remind_me("snz-reload".into(), "30 minutes".into())
                 .await
@@ -474,7 +506,7 @@ mod tests {
         };
 
         // drop svc → 重開
-        let svc2 = ReminderService::new(&db, fresh_notifier()).await.unwrap();
+        let svc2 = ReminderService::new(&db, fresh_notifier(), Arc::new(NoopEmitter)).await.unwrap();
         let pending = svc2.list_reminders().await.unwrap();
         let reloaded = pending.iter().find(|x| x.id == r_id).expect("reloaded");
         // reload 後 due_at 仍是 snooze until(~2h 後),不是原本 30min 後
@@ -494,7 +526,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let db = dir.path().join("reminders.db");
         let r_id = {
-            let svc = ReminderService::new(&db, fresh_notifier()).await.unwrap();
+            let svc = ReminderService::new(&db, fresh_notifier(), Arc::new(NoopEmitter)).await.unwrap();
             let r = svc
                 .remind_me("persistent".into(), "1 hour".into())
                 .await
@@ -502,7 +534,7 @@ mod tests {
             r.id
         };
         // 第二次:重新開 service,pending 應該被 reload
-        let svc2 = ReminderService::new(&db, fresh_notifier()).await.unwrap();
+        let svc2 = ReminderService::new(&db, fresh_notifier(), Arc::new(NoopEmitter)).await.unwrap();
         let pending = svc2.list_reminders().await.unwrap();
         assert_eq!(pending.len(), 1, "expected 1 reloaded pending, got {}", pending.len());
         assert_eq!(pending[0].id, r_id);
@@ -578,7 +610,7 @@ mod tests {
         }
 
         // 開 service → reload-pending 應該把 8 天前的標 dismissed_at + Fired
-        let _svc = ReminderService::new(&db, Notifier::new("Mori-Test"))
+        let _svc = ReminderService::new(&db, Notifier::new("Mori-Test"), Arc::new(NoopEmitter))
             .await
             .expect("service");
         // 留一點時間給 1ms 觸發 + spawn task 處理 mark_fired 完成
@@ -626,5 +658,46 @@ mod tests {
             after.status,
         );
         assert!(after.fired_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn on_fire_calls_emitter_emit_reminder_fire() {
+        use std::sync::Mutex as StdMutex;
+
+        // 收集 emit call 的 mock emitter
+        #[derive(Default)]
+        struct CapturingEmitter {
+            calls: StdMutex<Vec<i64>>,
+        }
+        impl EventEmitter for CapturingEmitter {
+            fn emit_reminder_fire(&self, r: &Reminder) -> Result<(), String> {
+                self.calls.lock().unwrap().push(r.id);
+                Ok(())
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("r.db");
+        let emitter = Arc::new(CapturingEmitter::default());
+
+        let svc = ReminderService::new(
+            &db,
+            Notifier::new("Mori-Test"),
+            emitter.clone() as Arc<dyn EventEmitter>,
+        )
+        .await
+        .expect("svc");
+
+        // 排一個 100ms 後 fire 的 reminder
+        let when = Utc::now() + chrono::Duration::milliseconds(100);
+        let r = svc.store.lock().await.create("emit-probe".to_string(), when, None).unwrap();
+        svc.scheduler.schedule(&r).await.unwrap();
+
+        // 等 fire + spawn task 完成
+        tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+
+        let calls = emitter.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1, "emit_reminder_fire should be called once");
+        assert_eq!(calls[0], r.id);
     }
 }

--- a/crates/mori-time/src/commands.rs
+++ b/crates/mori-time/src/commands.rs
@@ -218,6 +218,10 @@ impl ReminderService {
                     due_at = %r.due_at,
                     "auto-dismissed super-overdue reminder (> 7d) — skipping fire to avoid spam"
                 );
+                // TODO(follow-up): log `reminder_auto_dismiss` event to mori_core::event_log
+                // here. Currently blocked because mori-time cannot depend on mori-core
+                // (cross-crate boundary). Options: move event_log to a leaf util crate, or
+                // pass an event callback through EventEmitter trait. Tracking: feat/reminder-popup.
                 continue;
             }
             if let Err(e) = scheduler.schedule(r).await {

--- a/crates/mori-time/src/lib.rs
+++ b/crates/mori-time/src/lib.rs
@@ -21,4 +21,4 @@ pub mod commands;
 pub use schema::{Reminder, ReminderError, ReminderStatus, ReminderStore};
 pub use scheduler::{ReminderScheduler, SchedulerError};
 pub use notifier::{Notifier, NotifyError};
-pub use commands::{CommandError, ReminderService};
+pub use commands::{CommandError, EventEmitter, NoopEmitter, ReminderService};

--- a/crates/mori-time/src/notifier.rs
+++ b/crates/mori-time/src/notifier.rs
@@ -21,6 +21,8 @@
 
 use crate::schema::Reminder;
 use notify_rust::Notification;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Notifier 發通知時可能出的錯。
 #[derive(Debug, thiserror::Error)]
@@ -49,6 +51,9 @@ pub struct Notifier {
     /// 或 absolute path;Windows/macOS 多半 ignore。`None` = 不設,讓 desktop env
     /// 用 default。
     icon_path: Option<String>,
+    /// 2026-05-22:OS 桌面通知開關。caller(mori-tauri)持同一 Arc,
+    /// 在 user 切 toggle 時更新。fire() 先檢查再走 .show()。
+    pub enabled: Arc<AtomicBool>,
 }
 
 impl Notifier {
@@ -57,7 +62,13 @@ impl Notifier {
         Self {
             app_name: app_name.into(),
             icon_path: None,
+            enabled: Arc::new(AtomicBool::new(true)),
         }
+    }
+
+    /// 取得共用的 enabled flag handle,給 caller 切 toggle 用。
+    pub fn enabled_handle(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.enabled)
     }
 
     /// Builder:設 icon 路徑 / freedesktop icon 名。
@@ -81,6 +92,14 @@ impl Notifier {
     /// summary 用 reminder text、body 是 "Mori 提醒你"。會真的呼叫 `.show()`,
     /// 在沒 dbus / 沒 display 的環境會 Err。
     pub fn fire(&self, reminder: &Reminder) -> Result<(), NotifyError> {
+        // 2026-05-22:os_notification_enabled toggle off → 直接 Ok 不發送
+        if !self.enabled.load(Ordering::Relaxed) {
+            tracing::debug!(
+                reminder_id = reminder.id,
+                "notifier.fire skipped — os_notification_enabled toggle off"
+            );
+            return Ok(());
+        }
         let n = self.build_for_reminder(reminder);
         Self::show(&n)
     }
@@ -224,5 +243,14 @@ mod tests {
         assert_eq!(built.summary, "吃藥");
         assert_eq!(built.body, "別忘記吃晚餐後的藥");
         assert_eq!(built.appname, "Mori");
+    }
+
+    #[test]
+    fn fire_returns_ok_when_disabled() {
+        // enabled=false 時 fire() return Ok 而不 attempt dbus
+        let n = Notifier::new("Mori-Test");
+        n.enabled.store(false, std::sync::atomic::Ordering::Relaxed);
+        let r = sample_reminder("disabled-test");
+        assert!(n.fire(&r).is_ok());
     }
 }

--- a/crates/mori-time/src/notifier.rs
+++ b/crates/mori-time/src/notifier.rs
@@ -71,6 +71,17 @@ impl Notifier {
         Arc::clone(&self.enabled)
     }
 
+    /// Builder:建立 OS 通知預設**關閉**的 Notifier。
+    ///
+    /// 用在 tests / CI 避免 `.fire()` 真的走 dbus 污染 user desktop。
+    /// Production code 請用 [`Self::new`](預設 enabled=true)。
+    /// 名字故意寫長以防誤用在 production。
+    pub fn disabled(app_name: impl Into<String>) -> Self {
+        let n = Self::new(app_name);
+        n.enabled.store(false, Ordering::Relaxed);
+        n
+    }
+
     /// Builder:設 icon 路徑 / freedesktop icon 名。
     pub fn with_icon(mut self, icon_path: impl Into<String>) -> Self {
         self.icon_path = Some(icon_path.into());
@@ -248,8 +259,7 @@ mod tests {
     #[test]
     fn fire_returns_ok_when_disabled() {
         // enabled=false 時 fire() return Ok 而不 attempt dbus
-        let n = Notifier::new("Mori-Test");
-        n.enabled.store(false, std::sync::atomic::Ordering::Relaxed);
+        let n = Notifier::disabled("Mori-Test");
         let r = sample_reminder("disabled-test");
         assert!(n.fire(&r).is_ok());
     }

--- a/crates/mori-time/src/notifier.rs
+++ b/crates/mori-time/src/notifier.rs
@@ -165,6 +165,7 @@ mod tests {
             cron_expr: None,
             created_at: now,
             fired_at: None,
+            dismissed_at: None,
             snoozed_until: None,
             status: ReminderStatus::Pending,
         }

--- a/crates/mori-time/src/notifier.rs
+++ b/crates/mori-time/src/notifier.rs
@@ -103,11 +103,28 @@ impl Notifier {
     }
 
     /// 組純文字通知對應的 [`Notification`] 物件 — 不發送。
+    ///
+    /// **Sticky by default**:freedesktop `Timeout::Never` + Linux Resident hint +
+    /// Critical urgency,user 必須手動點關才會消(2026-05-22 user 需求:reminder
+    /// 不能彈一下就消失,user 在錄音/講話時錯過就找不回來)。GNOME 預設對 Normal
+    /// urgency 會強制 auto-dismiss,所以一定要 Critical 才留得住;KDE 對 Resident
+    /// hint 就聽話,不一定要 Critical。三層下去最穩。
+    ///
+    /// Windows/macOS:.timeout() / .urgency() / .hint() 在那兩平台是 no-op
+    /// (notify-rust 在 cfg 上會 strip 掉 Linux 專屬的 hint / urgency)。
     pub(crate) fn build_text(&self, summary: &str, body: &str) -> Notification {
         let mut n = Notification::new();
         n.appname(&self.app_name).summary(summary).body(body);
         if let Some(icon) = &self.icon_path {
             n.icon(icon);
+        }
+        // freedesktop 標準「永不超時」— 0 = 不自動關
+        n.timeout(notify_rust::Timeout::Never);
+        // Linux/BSD 才有 Hint / Urgency type,Windows/macOS 沒這個概念
+        #[cfg(all(unix, not(target_os = "macos")))]
+        {
+            n.hint(notify_rust::Hint::Resident(true));
+            n.urgency(notify_rust::Urgency::Critical);
         }
         n.finalize()
     }

--- a/crates/mori-time/src/schema.rs
+++ b/crates/mori-time/src/schema.rs
@@ -27,6 +27,9 @@ pub struct Reminder {
     pub created_at: DateTime<Utc>,
     /// 上次實際觸發時間;`None` = 還沒響過。
     pub fired_at: Option<DateTime<Utc>>,
+    /// 用戶明確關掉 popup 的時間;`None` = 還沒 dismiss 過。
+    /// 區分「fired 但 user 沒看」vs「user 已關掉」。
+    pub dismissed_at: Option<DateTime<Utc>>,
     /// 暫緩到何時(snooze 後 status = Snoozed,到時間才繼續排程)。
     pub snoozed_until: Option<DateTime<Utc>>,
     pub status: ReminderStatus,
@@ -120,6 +123,21 @@ impl ReminderStore {
             CREATE INDEX IF NOT EXISTS idx_reminders_due_at ON reminders(due_at);
             "#,
         )?;
+
+        // 2026-05-22: dismissed_at 區分「fired 但 user 沒看」vs「user 已關掉」
+        // SQLite 沒 ADD COLUMN IF NOT EXISTS,用 table_info pragma 檢查
+        let has_dismissed_at: bool = self
+            .conn
+            .prepare("SELECT 1 FROM pragma_table_info('reminders') WHERE name = 'dismissed_at'")
+            .and_then(|mut s| s.query_row([], |_| Ok(true)))
+            .unwrap_or(false);
+        if !has_dismissed_at {
+            self.conn.execute(
+                "ALTER TABLE reminders ADD COLUMN dismissed_at TEXT",
+                [],
+            )?;
+        }
+
         Ok(())
     }
 
@@ -151,6 +169,7 @@ impl ReminderStore {
             cron_expr: cron,
             created_at: now,
             fired_at: None,
+            dismissed_at: None,
             snoozed_until: None,
             status,
         })
@@ -159,7 +178,7 @@ impl ReminderStore {
     /// 列出仍需排程的 reminder(status = Pending 或 Snoozed)。
     pub fn list_pending(&self) -> Result<Vec<Reminder>, ReminderError> {
         let mut stmt = self.conn.prepare(
-            r#"SELECT id, text, due_at, cron_expr, created_at, fired_at, snoozed_until, status
+            r#"SELECT id, text, due_at, cron_expr, created_at, fired_at, dismissed_at, snoozed_until, status
                FROM reminders
                WHERE status IN ('pending', 'snoozed')
                ORDER BY due_at ASC"#,
@@ -173,7 +192,7 @@ impl ReminderStore {
     /// 列出所有 reminder(含 fired / cancelled),由舊到新。
     pub fn list_all(&self) -> Result<Vec<Reminder>, ReminderError> {
         let mut stmt = self.conn.prepare(
-            r#"SELECT id, text, due_at, cron_expr, created_at, fired_at, snoozed_until, status
+            r#"SELECT id, text, due_at, cron_expr, created_at, fired_at, dismissed_at, snoozed_until, status
                FROM reminders
                ORDER BY id ASC"#,
         )?;
@@ -186,7 +205,7 @@ impl ReminderStore {
     /// 拿單筆。找不到回 `NotFound(id)`。
     pub fn get(&self, id: i64) -> Result<Reminder, ReminderError> {
         let mut stmt = self.conn.prepare(
-            r#"SELECT id, text, due_at, cron_expr, created_at, fired_at, snoozed_until, status
+            r#"SELECT id, text, due_at, cron_expr, created_at, fired_at, dismissed_at, snoozed_until, status
                FROM reminders
                WHERE id = ?1"#,
         )?;
@@ -249,6 +268,10 @@ impl ReminderStore {
 }
 
 /// 把 sqlite row 拆成 `Reminder`。回傳 nested Result 因為 status 解析可能失敗。
+///
+/// 欄位順序(對應 SELECT 的 column 位置):
+/// 0=id, 1=text, 2=due_at, 3=cron_expr, 4=created_at,
+/// 5=fired_at, 6=dismissed_at, 7=snoozed_until, 8=status
 fn row_to_reminder(row: &Row<'_>) -> rusqlite::Result<Result<Reminder, ReminderError>> {
     let id: i64 = row.get(0)?;
     let text: String = row.get(1)?;
@@ -256,8 +279,9 @@ fn row_to_reminder(row: &Row<'_>) -> rusqlite::Result<Result<Reminder, ReminderE
     let cron_expr: Option<String> = row.get(3)?;
     let created_at: String = row.get(4)?;
     let fired_at: Option<String> = row.get(5)?;
-    let snoozed_until: Option<String> = row.get(6)?;
-    let status: String = row.get(7)?;
+    let dismissed_at: Option<String> = row.get(6)?;
+    let snoozed_until: Option<String> = row.get(7)?;
+    let status: String = row.get(8)?;
 
     Ok((|| -> Result<Reminder, ReminderError> {
         Ok(Reminder {
@@ -267,6 +291,7 @@ fn row_to_reminder(row: &Row<'_>) -> rusqlite::Result<Result<Reminder, ReminderE
             cron_expr,
             created_at: parse_rfc3339(&created_at)?,
             fired_at: fired_at.as_deref().map(parse_rfc3339).transpose()?,
+            dismissed_at: dismissed_at.as_deref().map(parse_rfc3339).transpose()?,
             snoozed_until: snoozed_until.as_deref().map(parse_rfc3339).transpose()?,
             status: ReminderStatus::from_db_str(&status)?,
         })
@@ -456,5 +481,17 @@ mod tests {
             .unwrap();
         let fetched = s.get(r.id).unwrap();
         assert_eq!(fetched.cron_expr.as_deref(), Some("0 0 8 * * *"));
+    }
+
+    #[test]
+    fn migration_adds_dismissed_at_idempotent() {
+        let store = ReminderStore::open_in_memory().expect("open");
+        // 二次 migrate 不爆
+        store.migrate().expect("migrate 2nd time");
+        // 寫進去之後讀得到 None
+        let r = store
+            .create("test".to_string(), Utc::now(), None)
+            .expect("create");
+        assert!(r.dismissed_at.is_none(), "new reminder dismissed_at should be None");
     }
 }

--- a/crates/mori-time/src/schema.rs
+++ b/crates/mori-time/src/schema.rs
@@ -265,6 +265,43 @@ impl ReminderStore {
         }
         Ok(())
     }
+
+    /// 標 reminder 為 user 已 dismiss(從 popup 點 [關閉] 後寫入)。
+    /// 寫入時間,reminder.status 不動(`Fired` 不變),只是 popup 不再列出。
+    pub fn mark_dismissed(&self, id: i64, at: DateTime<Utc>) -> Result<(), ReminderError> {
+        let affected = self.conn.execute(
+            "UPDATE reminders SET dismissed_at = ?1 WHERE id = ?2",
+            params![at.to_rfc3339(), id],
+        )?;
+        if affected == 0 {
+            return Err(ReminderError::NotFound(id));
+        }
+        Ok(())
+    }
+
+    /// 給 in-app popup 用的 active queue:
+    /// - status = Fired
+    /// - dismissed_at IS NULL
+    /// - fired_at > now - 7 days(grace,超過自動忽略,不再 popup)
+    /// 排序 fired_at DESC(最新先)。
+    pub fn list_active_popup_queue(
+        &self,
+        now: DateTime<Utc>,
+    ) -> Result<Vec<Reminder>, ReminderError> {
+        let grace_cutoff = now - chrono::Duration::days(7);
+        let mut stmt = self.conn.prepare(
+            "SELECT id, text, due_at, cron_expr, created_at, fired_at, dismissed_at, snoozed_until, status
+             FROM reminders
+             WHERE status = 'fired'
+               AND dismissed_at IS NULL
+               AND fired_at > ?1
+             ORDER BY fired_at DESC",
+        )?;
+        let rows = stmt.query_map(params![grace_cutoff.to_rfc3339()], row_to_reminder)?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(ReminderError::from)
+            .and_then(|v| v.into_iter().collect::<Result<Vec<_>, _>>())
+    }
 }
 
 /// 把 sqlite row 拆成 `Reminder`。回傳 nested Result 因為 status 解析可能失敗。
@@ -493,5 +530,41 @@ mod tests {
             .create("test".to_string(), Utc::now(), None)
             .expect("create");
         assert!(r.dismissed_at.is_none(), "new reminder dismissed_at should be None");
+    }
+
+    #[test]
+    fn mark_dismissed_sets_timestamp() {
+        let store = ReminderStore::open_in_memory().expect("open");
+        let r = store
+            .create("hello".to_string(), Utc::now(), None)
+            .expect("create");
+        store.mark_fired(r.id, Utc::now()).expect("mark fired");
+        let when = Utc::now();
+        store.mark_dismissed(r.id, when).expect("mark dismissed");
+        let got = store.get(r.id).expect("get");
+        assert!(got.dismissed_at.is_some(), "dismissed_at should be Some after mark_dismissed");
+    }
+
+    #[test]
+    fn list_active_popup_queue_filters_dismissed_and_super_overdue() {
+        let store = ReminderStore::open_in_memory().expect("open");
+        let now = Utc::now();
+        let week_plus_one = now - chrono::Duration::days(8);
+        let recent = now - chrono::Duration::minutes(5);
+
+        // 一筆 7 天前 fired 沒 dismiss → 不算 active(超過 grace)
+        let stale = store.create("stale".to_string(), week_plus_one, None).unwrap();
+        store.mark_fired(stale.id, week_plus_one).unwrap();
+        // 一筆 5 分鐘前 fired 沒 dismiss → active
+        let active = store.create("active".to_string(), recent, None).unwrap();
+        store.mark_fired(active.id, recent).unwrap();
+        // 一筆 fired + dismissed → 不算 active
+        let done = store.create("done".to_string(), recent, None).unwrap();
+        store.mark_fired(done.id, recent).unwrap();
+        store.mark_dismissed(done.id, now).unwrap();
+
+        let queue = store.list_active_popup_queue(now).expect("list");
+        let ids: Vec<i64> = queue.iter().map(|r| r.id).collect();
+        assert_eq!(ids, vec![active.id], "only the recent unsmissed reminder should appear");
     }
 }

--- a/docs/superpowers/plans/2026-05-22-in-app-reminder-popup.md
+++ b/docs/superpowers/plans/2026-05-22-in-app-reminder-popup.md
@@ -1,0 +1,1705 @@
+# In-app Reminder Popup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Mori 自家 in-app reminder popup window 取代不可靠的 OS 通知作為主路徑;OS 通知留 backup 可 toggle;DB 加 `dismissed_at` 區分「fired 但 user 沒看」。
+
+**Architecture:** 新 Tauri window `reminder_popup` + React 元件 listen Rust on_fire emit;ReminderService::new 注入 AppHandle;`~/.mori/config.json` 新增 `notifications` 子樹存 toggle;catch-up >7 天 silent dismiss。
+
+**Tech Stack:** Rust + tokio-cron-scheduler + rusqlite + Tauri 2 + React + TS;對齊 mori-desktop 既有 `ChatBubble.tsx` window pattern + `hotkey_config.rs` config subtree pattern。
+
+**Spec:** `docs/superpowers/specs/2026-05-22-in-app-reminder-popup-design.md`
+
+---
+
+## Task 1: DB schema — add `dismissed_at` column (idempotent migration)
+
+**Files:**
+- Modify: `crates/mori-time/src/schema.rs`(`ReminderStore::migrate` + `Reminder` struct)
+- Test: `crates/mori-time/src/schema.rs`(下方 `#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: 加 failing test:migration idempotent + Reminder struct 有 dismissed_at**
+
+加在 `schema.rs` 既有 tests 區段(`mod tests` 內):
+
+```rust
+#[test]
+fn migration_adds_dismissed_at_idempotent() {
+    let store = ReminderStore::open_in_memory().expect("open");
+    // 二次 migrate 不爆
+    store.migrate().expect("migrate 2nd time");
+    // 寫進去之後讀得到 None
+    let r = store
+        .create("test".to_string(), Utc::now(), None)
+        .expect("create");
+    assert!(r.dismissed_at.is_none(), "new reminder dismissed_at should be None");
+}
+```
+
+- [ ] **Step 2: 跑 test 看 fail**
+
+Run: `cargo test -p mori-time migration_adds_dismissed_at_idempotent -- --nocapture`
+Expected: FAIL(`dismissed_at` 不存在 / `Reminder` 沒此欄)
+
+- [ ] **Step 3: 加 `dismissed_at` 到 `Reminder` struct**
+
+`Reminder` struct 已有 `fired_at: Option<DateTime<Utc>>`,在它旁邊加:
+
+```rust
+pub struct Reminder {
+    // ... 既有欄位 ...
+    pub fired_at: Option<DateTime<Utc>>,
+    pub dismissed_at: Option<DateTime<Utc>>,  // 新增
+    // ... 既有 ...
+}
+```
+
+- [ ] **Step 4: migrate 加 `dismissed_at` 欄(idempotent 用 PRAGMA table_info 檢查)**
+
+在 `migrate` 內,既有 `CREATE TABLE IF NOT EXISTS reminders ...` 之後加:
+
+```rust
+// 2026-05-22: dismissed_at 區分「fired 但 user 沒看」vs「user 已關掉」
+// SQLite 沒 ADD COLUMN IF NOT EXISTS,用 table_info pragma 檢查
+let has_dismissed_at: bool = conn
+    .prepare("SELECT 1 FROM pragma_table_info('reminders') WHERE name = 'dismissed_at'")
+    .and_then(|mut s| s.query_row([], |_| Ok(true)))
+    .unwrap_or(false);
+if !has_dismissed_at {
+    conn.execute(
+        "ALTER TABLE reminders ADD COLUMN dismissed_at TEXT",
+        [],
+    )
+    .map_err(|e| ReminderError::Sql(e.to_string()))?;
+}
+```
+
+- [ ] **Step 5: 改 row → Reminder mapping(`row_to_reminder` 或同等 helper)**
+
+找到所有 `Reminder { id: ..., ... }` 構造(主要在 `row_to_reminder` 或 `create` / `get` / `list_pending` 等內 SQLite row mapping),加:
+
+```rust
+dismissed_at: row.get::<_, Option<String>>("dismissed_at")?
+    .and_then(|s| chrono::DateTime::parse_from_rfc3339(&s).ok())
+    .map(|dt| dt.with_timezone(&Utc)),
+```
+
+- [ ] **Step 6: 跑 test pass**
+
+Run: `cargo test -p mori-time migration_adds_dismissed_at_idempotent -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 7: 確認既有 tests 都還過**
+
+Run: `cargo test -p mori-time --lib`
+Expected: PASS(全部,包含既有 44 tests + 新 1 test)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/mori-time/src/schema.rs
+git commit -m "feat(mori-time): add dismissed_at column to reminders with idempotent migration"
+```
+
+---
+
+## Task 2: ReminderStore methods — `mark_dismissed` + `list_active_popup_queue`
+
+**Files:**
+- Modify: `crates/mori-time/src/schema.rs`(`impl ReminderStore` 加 method)
+- Test: 同檔內 `mod tests`
+
+- [ ] **Step 1: 加 failing tests**
+
+```rust
+#[test]
+fn mark_dismissed_sets_timestamp() {
+    let store = ReminderStore::open_in_memory().expect("open");
+    let r = store
+        .create("hello".to_string(), Utc::now(), None)
+        .expect("create");
+    store.mark_fired(r.id, Utc::now()).expect("mark fired");
+    let when = Utc::now();
+    store.mark_dismissed(r.id, when).expect("mark dismissed");
+    let got = store.get(r.id).expect("get").expect("exists");
+    assert!(got.dismissed_at.is_some(), "dismissed_at should be Some after mark_dismissed");
+}
+
+#[test]
+fn list_active_popup_queue_filters_dismissed_and_super_overdue() {
+    let store = ReminderStore::open_in_memory().expect("open");
+    let now = Utc::now();
+    let week_plus_one = now - chrono::Duration::days(8);
+    let recent = now - chrono::Duration::minutes(5);
+
+    // 一筆 7 天前 fired 沒 dismiss → 不算 active(超過 grace)
+    let stale = store.create("stale".to_string(), week_plus_one, None).unwrap();
+    store.mark_fired(stale.id, week_plus_one).unwrap();
+    // 一筆 5 分鐘前 fired 沒 dismiss → active
+    let active = store.create("active".to_string(), recent, None).unwrap();
+    store.mark_fired(active.id, recent).unwrap();
+    // 一筆 fired + dismissed → 不算 active
+    let done = store.create("done".to_string(), recent, None).unwrap();
+    store.mark_fired(done.id, recent).unwrap();
+    store.mark_dismissed(done.id, now).unwrap();
+
+    let queue = store.list_active_popup_queue(now).expect("list");
+    let ids: Vec<i64> = queue.iter().map(|r| r.id).collect();
+    assert_eq!(ids, vec![active.id], "only the recent unsmissed reminder should appear");
+}
+```
+
+- [ ] **Step 2: 跑 tests 看 fail**
+
+Run: `cargo test -p mori-time mark_dismissed_sets_timestamp list_active_popup_queue -- --nocapture`
+Expected: FAIL(methods 不存在)
+
+- [ ] **Step 3: 實作 methods**
+
+在 `impl ReminderStore`(`schema.rs`)內加:
+
+```rust
+/// 標 reminder 為 user 已 dismiss(從 popup 點 [關閉] 後寫入)。
+/// 寫入時間,reminder.status 不動(`Fired` 不變),只是 popup 不再列出。
+pub fn mark_dismissed(&self, id: i64, at: DateTime<Utc>) -> Result<(), ReminderError> {
+    let conn = self.conn.lock();
+    let affected = conn
+        .execute(
+            "UPDATE reminders SET dismissed_at = ?1 WHERE id = ?2",
+            rusqlite::params![at.to_rfc3339(), id],
+        )
+        .map_err(|e| ReminderError::Sql(e.to_string()))?;
+    if affected == 0 {
+        return Err(ReminderError::NotFound(id));
+    }
+    Ok(())
+}
+
+/// 給 in-app popup 用的 active queue:
+/// - status = Fired
+/// - dismissed_at IS NULL
+/// - fired_at > now - 7 days(grace,超過自動忽略,不再 popup)
+/// 排序 fired_at DESC(最新先)。
+pub fn list_active_popup_queue(
+    &self,
+    now: DateTime<Utc>,
+) -> Result<Vec<Reminder>, ReminderError> {
+    let grace_cutoff = now - chrono::Duration::days(7);
+    let conn = self.conn.lock();
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, text, due_at, cron_expr, created_at, fired_at, snoozed_until, status, dismissed_at
+             FROM reminders
+             WHERE status = 'Fired'
+               AND dismissed_at IS NULL
+               AND fired_at > ?1
+             ORDER BY fired_at DESC",
+        )
+        .map_err(|e| ReminderError::Sql(e.to_string()))?;
+    let rows = stmt
+        .query_map(rusqlite::params![grace_cutoff.to_rfc3339()], row_to_reminder)
+        .map_err(|e| ReminderError::Sql(e.to_string()))?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|e| ReminderError::Sql(e.to_string()))
+}
+```
+
+注意 `row_to_reminder` 是現有 helper(或寫在 `query_map` closure 內,看既有 pattern)— 確認返回 Reminder 時包含新加的 `dismissed_at` 欄。
+
+- [ ] **Step 4: 跑 tests pass**
+
+Run: `cargo test -p mori-time mark_dismissed_sets_timestamp list_active_popup_queue -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 5: 全 lib tests 還過**
+
+Run: `cargo test -p mori-time --lib`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/mori-time/src/schema.rs
+git commit -m "feat(mori-time): add mark_dismissed + list_active_popup_queue store methods"
+```
+
+---
+
+## Task 3: Catch-up grace — startup 自動 dismiss > 7 天 overdue reminder
+
+**Files:**
+- Modify: `crates/mori-time/src/commands.rs`(`ReminderService::new` reload-pending 段)
+- Test: 同檔 `mod tests`
+
+- [ ] **Step 1: 加 failing test**
+
+```rust
+#[tokio::test]
+async fn startup_auto_dismisses_super_overdue_reminders() {
+    use std::sync::Arc;
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let db = dir.path().join("r.db");
+
+    // 先用一個 service 寫一筆 8 天前 overdue + status=Pending
+    {
+        let store = ReminderStore::open(&db).expect("open");
+        let past = Utc::now() - chrono::Duration::days(8);
+        store.create("stale".to_string(), past, None).expect("create");
+        // 不 mark_fired,留 Pending,模擬 user 一週多沒開 app
+    }
+
+    // 開 service → reload-pending 應該把 8 天前的標 dismissed_at + Fired
+    let _svc = ReminderService::new(&db, Notifier::new("Mori-Test"))
+        .await
+        .expect("service");
+    // 留一點時間給 1ms 觸發 + spawn task 處理 mark_fired 完成
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let store = ReminderStore::open(&db).expect("reopen");
+    let queue = store
+        .list_active_popup_queue(Utc::now())
+        .expect("list active");
+    assert!(queue.is_empty(), "super-overdue reminder should be auto-dismissed, not on popup queue");
+
+    // 而 status 應該是 Fired(走完正常 fire path),dismissed_at 也填了
+    let conn = rusqlite::Connection::open(&db).unwrap();
+    let mut stmt = conn
+        .prepare("SELECT status, dismissed_at FROM reminders WHERE text = 'stale'")
+        .unwrap();
+    let (status, dismissed_at): (String, Option<String>) = stmt
+        .query_row([], |r| Ok((r.get(0)?, r.get(1)?)))
+        .unwrap();
+    assert_eq!(status, "Fired", "super-overdue should be marked Fired");
+    assert!(dismissed_at.is_some(), "super-overdue should be marked dismissed");
+}
+```
+
+注意 `ReminderService::new` 簽名 Task 4 才會加 `app_handle`。這個 test 在 Task 4 之前還能跑(用既有簽名)。
+
+- [ ] **Step 2: 跑 test 看 fail**
+
+Run: `cargo test -p mori-time startup_auto_dismisses_super_overdue -- --nocapture`
+Expected: FAIL(reminder 還在 active queue,因為 catch-up 邏輯還沒寫)
+
+- [ ] **Step 3: 在 `ReminderService::new` reload-pending 內加 grace logic**
+
+找 `commands.rs` 內現有的:
+
+```rust
+let pending = store.lock().await.list_pending()?;
+for r in &pending {
+    if let Err(e) = scheduler.schedule(r).await {
+        // ... log ...
+    }
+}
+```
+
+改成:
+
+```rust
+let pending = store.lock().await.list_pending()?;
+let now = Utc::now();
+let grace_cutoff = now - chrono::Duration::days(7);
+for r in &pending {
+    // 2026-05-22:超過 7 天的 overdue one-shot reminder 自動標 dismissed,
+    // 不再 fire,避免 user 久未開 app 後被 spam。cron 不適用(週期性永遠不算 overdue)。
+    let is_super_overdue = r.cron_expr.is_none() && r.due_at < grace_cutoff;
+    if is_super_overdue {
+        let store_guard = store.lock().await;
+        let when = Utc::now();
+        if let Err(e) = store_guard.mark_fired(r.id, when) {
+            tracing::warn!(
+                reminder_id = r.id,
+                error = %e,
+                "failed to auto-mark super-overdue as fired"
+            );
+            continue;
+        }
+        if let Err(e) = store_guard.mark_dismissed(r.id, when) {
+            tracing::warn!(
+                reminder_id = r.id,
+                error = %e,
+                "failed to auto-mark super-overdue as dismissed"
+            );
+        }
+        tracing::info!(
+            reminder_id = r.id,
+            text = %r.text,
+            due_at = %r.due_at,
+            "auto-dismissed super-overdue reminder (> 7d) — skipping fire to avoid spam"
+        );
+        continue;
+    }
+    if let Err(e) = scheduler.schedule(r).await {
+        tracing::warn!(
+            reminder_id = r.id,
+            error = %e,
+            "failed to schedule pending reminder on startup",
+        );
+    }
+}
+```
+
+- [ ] **Step 4: 跑 test pass**
+
+Run: `cargo test -p mori-time startup_auto_dismisses_super_overdue -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 5: 全 lib tests 還過**
+
+Run: `cargo test -p mori-time --lib`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/mori-time/src/commands.rs
+git commit -m "feat(mori-time): auto-dismiss super-overdue reminders (>7d) on startup reload-pending"
+```
+
+---
+
+## Task 4: `ReminderService::new` 加 `AppHandle` 參數 + on_fire emit event
+
+**Files:**
+- Modify: `crates/mori-time/src/commands.rs`(`ReminderService::new` 簽名 + on_fire callback)
+- Modify: `crates/mori-time/src/lib.rs`(re-export 不變,但 doc 提到)
+- Modify: `crates/mori-tauri/src/main.rs`(caller 帶 `app.handle().clone()`)
+- Modify: `crates/mori-core/src/skill/remind_me.rs` tests(若 caller `ReminderService::new(&db, Notifier::new(...))` 要改)
+
+> **依賴注入策略**:`ReminderService` 在 `mori-time` crate,**不能 depend on tauri**(會循環,而且 mori-time 是 cross-platform leaf crate)。所以 `app_handle` 用 trait 包裝,實作在 caller(`mori-tauri`)那邊。
+
+- [ ] **Step 1: 在 `mori-time/src/commands.rs` 定義 `EventEmitter` trait**
+
+加在檔頂 use 區後面:
+
+```rust
+/// 2026-05-22:on_fire 觸發時對外 emit 通知事件。設計成 trait 是為了讓 mori-time
+/// 不直接依賴 tauri(會循環依賴)— `mori-tauri` 那邊用 Tauri AppHandle 實作這個 trait,
+/// 測試環境可以 mock。
+pub trait EventEmitter: Send + Sync {
+    /// Emit `reminder-fire-show` event 帶 payload。失敗回 Err(只 log warn,不擋 mark_fired)。
+    fn emit_reminder_fire(&self, reminder: &Reminder) -> Result<(), String>;
+}
+
+/// no-op 實作,給沒 emit 需求的 caller(例如純 unit test)用。
+pub struct NoopEmitter;
+impl EventEmitter for NoopEmitter {
+    fn emit_reminder_fire(&self, _reminder: &Reminder) -> Result<(), String> { Ok(()) }
+}
+```
+
+- [ ] **Step 2: `ReminderService::new` 簽名加 `emitter: Arc<dyn EventEmitter>` 參數**
+
+```rust
+impl ReminderService {
+    pub async fn new(
+        db_path: &Path,
+        notifier: Notifier,
+        emitter: Arc<dyn EventEmitter>,   // 新增
+    ) -> Result<Self, CommandError> {
+        // ... 原本 store 開檔等不變 ...
+
+        let store_for_cb = Arc::clone(&store);
+        let notifier_for_cb = notifier.clone();
+        let emitter_for_cb = Arc::clone(&emitter);  // 新增 capture
+        let on_fire: OnFireCallback = Arc::new(move |reminder: Reminder| {
+            let store_inner = Arc::clone(&store_for_cb);
+            let notifier_inner = notifier_for_cb.clone();
+            let emitter_inner = Arc::clone(&emitter_for_cb);
+            tokio::spawn(async move {
+                // 既有 spawn_blocking notifier.fire 保留 ──────────
+                let reminder_for_blk = reminder.clone();
+                let fire_result = tokio::task::spawn_blocking(move || {
+                    notifier_inner.fire(&reminder_for_blk)
+                })
+                .await;
+                match fire_result {
+                    Ok(Ok(())) => tracing::info!(
+                        reminder_id = reminder.id,
+                        text = %reminder.text,
+                        "notifier.fire returned Ok — notification submitted to dbus",
+                    ),
+                    Ok(Err(e)) => tracing::warn!(
+                        reminder_id = reminder.id,
+                        error = %e,
+                        "notifier.fire failed (reminder still mark_fired)",
+                    ),
+                    Err(join_err) => tracing::warn!(
+                        reminder_id = reminder.id,
+                        error = %join_err,
+                        "notifier.fire spawn_blocking join failed",
+                    ),
+                }
+
+                // 2026-05-22:in-app popup emit。失敗只 warn,不擋 mark_fired。
+                if let Err(e) = emitter_inner.emit_reminder_fire(&reminder) {
+                    tracing::warn!(
+                        reminder_id = reminder.id,
+                        error = %e,
+                        "emit reminder-fire-show failed (popup will catch up via active_queue query on next mount)",
+                    );
+                }
+
+                // 既有 mark_fired ──────────
+                if reminder.cron_expr.is_none() {
+                    let store = store_inner.lock().await;
+                    if let Err(e) = store.mark_fired(reminder.id, Utc::now()) {
+                        tracing::warn!(
+                            reminder_id = reminder.id,
+                            error = %e,
+                            "mark_fired failed",
+                        );
+                    }
+                }
+            });
+        });
+
+        // ... 其餘 scheduler.start + reload-pending 不變 ...
+    }
+}
+```
+
+- [ ] **Step 3: 加 failing test:emit 確實被叫**
+
+加在 `commands.rs` tests mod 內:
+
+```rust
+#[tokio::test]
+async fn on_fire_calls_emitter_emit_reminder_fire() {
+    use std::sync::Mutex as StdMutex;
+
+    // 收集 emit call 的 mock emitter
+    #[derive(Default)]
+    struct CapturingEmitter {
+        calls: StdMutex<Vec<i64>>,
+    }
+    impl EventEmitter for CapturingEmitter {
+        fn emit_reminder_fire(&self, r: &Reminder) -> Result<(), String> {
+            self.calls.lock().unwrap().push(r.id);
+            Ok(())
+        }
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("r.db");
+    let emitter = Arc::new(CapturingEmitter::default());
+
+    let svc = ReminderService::new(
+        &db,
+        Notifier::new("Mori-Test"),
+        emitter.clone() as Arc<dyn EventEmitter>,
+    )
+    .await
+    .expect("svc");
+
+    // 排一個 100ms 後 fire 的 reminder
+    let when = Utc::now() + chrono::Duration::milliseconds(100);
+    let r = svc.store.lock().await.create("emit-probe".to_string(), when, None).unwrap();
+    svc.scheduler.schedule(&r).await.unwrap();
+
+    // 等 fire + spawn task 完成
+    tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+
+    let calls = emitter.calls.lock().unwrap();
+    assert_eq!(calls.len(), 1, "emit_reminder_fire should be called once");
+    assert_eq!(calls[0], r.id);
+}
+```
+
+- [ ] **Step 4: 跑 test**
+
+Run: `cargo test -p mori-time on_fire_calls_emitter_emit -- --nocapture`
+Expected: 改完後 PASS。先跑看會不會因 caller 沒改而編譯爆。
+
+- [ ] **Step 5: 修補編譯錯誤 — 既有 test caller + mori-tauri caller**
+
+預期會看到 compile error:
+- `mori-time/src/commands.rs` 內既有 `ReminderService::new` test caller 全部要加第 3 個參數
+- `mori-core/src/skill/remind_me.rs` tests(`ReminderService::new(...).await`)同樣
+- `mori-tauri/src/main.rs`(5265 行附近 `tauri::async_runtime::block_on(ReminderService::new(...))`)同樣
+
+全改用 `NoopEmitter` 或 `Arc::new(NoopEmitter) as Arc<dyn EventEmitter>`,**除了 mori-tauri caller 等 Task 5 才接真實 emitter**。臨時先用 NoopEmitter 讓編譯過。
+
+例:既有 test
+```rust
+let svc = ReminderService::new(&db, Notifier::new("Mori-Test")).await?;
+```
+改:
+```rust
+let svc = ReminderService::new(&db, Notifier::new("Mori-Test"), Arc::new(NoopEmitter)).await?;
+```
+
+`main.rs` 5265 行附近改:
+```rust
+tauri::async_runtime::block_on(ReminderService::new(
+    &mori_dir().join("reminders.db"),
+    notifier,
+    Arc::new(mori_time::NoopEmitter),    // Task 5 換成真實的 TauriEventEmitter
+))
+```
+
+`mori_time` lib.rs 需要 re-export:
+```rust
+pub use commands::{CommandError, EventEmitter, NoopEmitter, ReminderService};
+```
+
+- [ ] **Step 6: 跑全部 tests pass**
+
+Run: `cargo test -p mori-time --lib`
+Expected: PASS(原 44 + 新 2 = 46+)
+
+Run: `cargo check -p mori-tauri`
+Expected: 通過
+
+Run: `cargo test -p mori-core --lib`
+Expected: PASS(remind_me skill tests 也對齊)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/mori-time crates/mori-core crates/mori-tauri/src/main.rs
+git commit -m "feat(mori-time): inject EventEmitter trait so on_fire can notify in-app popup
+
+mori-time 是 leaf crate,不能 depend tauri (循環依賴 + cross-platform invariant)。
+加 EventEmitter trait,具體實作(用 Tauri AppHandle 真的 emit)留 mori-tauri 端。
+caller (main.rs / tests) 暫用 NoopEmitter 過編譯,Task 5 接真實 emitter。"
+```
+
+---
+
+## Task 5: `mori-tauri` 端實作 `TauriEventEmitter`
+
+**Files:**
+- Create: `crates/mori-tauri/src/reminder_emitter.rs`(新)
+- Modify: `crates/mori-tauri/src/main.rs`(注入 emitter + mod declaration)
+
+- [ ] **Step 1: 寫新 emitter**
+
+`crates/mori-tauri/src/reminder_emitter.rs`:
+
+```rust
+//! 2026-05-22:把 mori-time 的 EventEmitter trait 用 Tauri AppHandle 實作出來。
+//! 放在 mori-tauri 是因為 mori-time crate 不能 depend tauri(會循環 + 違反 cross-platform 設計)。
+
+use mori_time::{EventEmitter, schema::Reminder};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager};
+
+/// Tauri 端的 EventEmitter 實作 — 把 reminder fire payload 透過 AppHandle.emit 送到
+/// `reminder_popup` window React listener。
+pub struct TauriEventEmitter {
+    pub handle: AppHandle,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ReminderFirePayload<'a> {
+    id: i64,
+    text: &'a str,
+    due_at: String,
+    fired_at: String,
+}
+
+impl EventEmitter for TauriEventEmitter {
+    fn emit_reminder_fire(&self, reminder: &Reminder) -> Result<(), String> {
+        let payload = ReminderFirePayload {
+            id: reminder.id,
+            text: &reminder.text,
+            due_at: reminder.due_at.to_rfc3339(),
+            fired_at: reminder
+                .fired_at
+                .unwrap_or_else(chrono::Utc::now)
+                .to_rfc3339(),
+        };
+        // emit_to 特定 window 比較精準;若 popup 還沒 mount listener,event 丟失,
+        // 但 popup mount 時會 invoke reminder_active_queue 補抓,所以不擋。
+        self.handle
+            .emit_to("reminder_popup", "reminder-fire-show", payload)
+            .map_err(|e| e.to_string())
+    }
+}
+```
+
+- [ ] **Step 2: `main.rs` 加 mod + 換掉 NoopEmitter**
+
+`main.rs` 檔頂加:
+```rust
+mod reminder_emitter;
+```
+
+5265 行附近 `ReminderService::new` block_on 改 — 但這條改不了,因為 block_on 在 main() sync 內、AppHandle 還沒 setup。**需要把 ReminderService 初始化往後挪到 .setup() closure 內(已經有 AppHandle)**。
+
+實際做法:把 5265 那塊抽出 to a setup closure。看現有 main.rs 5265 上下文確定怎麼接。最簡單:
+
+```rust
+// 改用 .setup() 內初始化
+.setup(move |app| {
+    // ... 原有 setup code ...
+    let app_handle_for_emitter = app.handle().clone();
+    let reminder_service = tauri::async_runtime::block_on(ReminderService::new(
+        &mori_dir().join("reminders.db"),
+        Notifier::new("Mori").with_icon(/* ... */),
+        std::sync::Arc::new(reminder_emitter::TauriEventEmitter {
+            handle: app_handle_for_emitter,
+        }),
+    ))?;
+    app.manage(std::sync::Arc::new(reminder_service));
+    // ...
+})
+```
+
+如果 main.rs 5265 已經在 setup 內,直接改 NoopEmitter → TauriEventEmitter 即可。否則挪一下位置。
+
+- [ ] **Step 3: 編譯確認**
+
+Run: `cargo check -p mori-tauri`
+Expected: PASS
+
+- [ ] **Step 4: 全 workspace 編譯**
+
+Run: `cargo check --workspace --all-targets`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mori-tauri
+git commit -m "feat(mori-tauri): wire TauriEventEmitter into ReminderService — fire emits to popup window"
+```
+
+---
+
+## Task 6: Notification config — `~/.mori/config.json` `notifications` 子樹
+
+**Files:**
+- Create: `crates/mori-tauri/src/notification_config.rs`(新)
+- Modify: `crates/mori-tauri/src/main.rs`(mod declaration)
+
+對齊 `hotkey_config.rs` pattern — read-on-call,不 cache,user 改 config.json 即時生效。
+
+- [ ] **Step 1: 寫 notification_config.rs**
+
+```rust
+//! 2026-05-22:reminder 通知 toggle 設定 — `~/.mori/config.json` 的 `notifications` 子樹。
+//!
+//! 對齊 `hotkey_config.rs` / `recordings.rs` 既有 pattern:呼叫時讀檔 + 缺欄走預設,
+//! 寫入時 round-trip 整個 JSON。
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NotificationConfig {
+    /// in-app popup 視窗開關。預設 true。
+    pub popup_enabled: bool,
+    /// OS 桌面通知(notify-rust)開關。預設 true。
+    pub os_notification_enabled: bool,
+}
+
+impl Default for NotificationConfig {
+    fn default() -> Self {
+        Self {
+            popup_enabled: true,
+            os_notification_enabled: true,
+        }
+    }
+}
+
+impl NotificationConfig {
+    /// 從 `~/.mori/config.json` 的 `notifications` 子樹讀;不存在 / 壞了 → 走預設 + log warn。
+    pub fn load(config_path: &Path) -> Self {
+        let raw = match std::fs::read_to_string(config_path) {
+            Ok(s) => s,
+            Err(_) => return Self::default(),
+        };
+        let json: Value = match serde_json::from_str(&raw) {
+            Ok(j) => j,
+            Err(e) => {
+                tracing::warn!(?e, "config.json malformed, notifications fall back to defaults");
+                return Self::default();
+            }
+        };
+        let sub = match json.get("notifications") {
+            Some(v) => v.clone(),
+            None => return Self::default(),
+        };
+        serde_json::from_value(sub).unwrap_or_else(|e| {
+            tracing::warn!(?e, "notifications subtree malformed, falling back to defaults");
+            Self::default()
+        })
+    }
+
+    /// 寫回 `~/.mori/config.json` 的 `notifications` 子樹,保留其他欄位不動。
+    pub fn write(&self, config_path: &Path) -> Result<(), String> {
+        let raw = std::fs::read_to_string(config_path).unwrap_or_else(|_| "{}".to_string());
+        let mut json: Value =
+            serde_json::from_str(&raw).map_err(|e| format!("parse config.json: {e}"))?;
+        let obj = json
+            .as_object_mut()
+            .ok_or_else(|| "config.json root not object".to_string())?;
+        obj.insert(
+            "notifications".to_string(),
+            serde_json::to_value(self).map_err(|e| e.to_string())?,
+        );
+        let pretty = serde_json::to_string_pretty(&json).map_err(|e| e.to_string())?;
+        std::fs::write(config_path, pretty).map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_returns_defaults_when_file_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope.json");
+        let cfg = NotificationConfig::load(&path);
+        assert_eq!(cfg, NotificationConfig::default());
+        assert!(cfg.popup_enabled);
+        assert!(cfg.os_notification_enabled);
+    }
+
+    #[test]
+    fn load_returns_defaults_when_subtree_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        std::fs::write(&path, r#"{"other": {}}"#).unwrap();
+        let cfg = NotificationConfig::load(&path);
+        assert_eq!(cfg, NotificationConfig::default());
+    }
+
+    #[test]
+    fn write_preserves_other_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        std::fs::write(&path, r#"{"providers":{"groq":{}},"hotkeys":{"toggle":"X"}}"#).unwrap();
+        NotificationConfig {
+            popup_enabled: false,
+            os_notification_enabled: true,
+        }
+        .write(&path)
+        .unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains(r#""providers""#));
+        assert!(raw.contains(r#""hotkeys""#));
+        assert!(raw.contains(r#""popup_enabled": false"#));
+    }
+
+    #[test]
+    fn round_trip_load_after_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        std::fs::write(&path, "{}").unwrap();
+        let original = NotificationConfig { popup_enabled: false, os_notification_enabled: false };
+        original.write(&path).unwrap();
+        let loaded = NotificationConfig::load(&path);
+        assert_eq!(loaded, original);
+    }
+}
+```
+
+- [ ] **Step 2: `main.rs` 加 mod**
+
+```rust
+mod notification_config;
+```
+
+- [ ] **Step 3: 跑 tests**
+
+Run: `cargo test -p mori-tauri --lib notification_config -- --nocapture`
+Expected: PASS(4 tests)
+
+- [ ] **Step 4: 全 workspace 編譯**
+
+Run: `cargo check --workspace --all-targets`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mori-tauri/src/notification_config.rs crates/mori-tauri/src/main.rs
+git commit -m "feat(mori-tauri): notification_config module — ~/.mori/config.json notifications subtree"
+```
+
+---
+
+## Task 7: Wire `popup_enabled` / `os_notification_enabled` toggle 到 fire path
+
+**Files:**
+- Modify: `crates/mori-tauri/src/reminder_emitter.rs`(emit 前看 popup_enabled)
+- Modify: `crates/mori-time/src/notifier.rs` OR `crates/mori-time/src/commands.rs`(看 os_notification_enabled)
+
+兩 toggle 在哪檢查、由誰讀 config:
+- `popup_enabled`:`TauriEventEmitter::emit_reminder_fire` 內檢查(emitter 知道 AppHandle,讀 config 容易)
+- `os_notification_enabled`:**mori-time 不能讀 mori-tauri 的 config.json 路徑**(crate boundary)。簡單做法:`Notifier` 加 `enabled: Arc<AtomicBool>`,`mori-tauri` 端定期或事件式更新它,fire 時讀
+
+更乾淨做法:同樣走 trait — `Notifier` 改成從 trait `NotificationSink` 拿,mori-tauri 端實作會 check config。但這 refactor 太大,Task 7 用 AtomicBool 即可。
+
+- [ ] **Step 1: `Notifier` 加 `enabled: Arc<AtomicBool>`**
+
+`mori-time/src/notifier.rs`:
+
+```rust
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[derive(Debug, Clone)]
+pub struct Notifier {
+    app_name: String,
+    icon_path: Option<String>,
+    /// 2026-05-22:OS 桌面通知開關。caller(mori-tauri)持 weak ref 一樣 Arc,
+    /// 在 user 切 toggle 時更新。fire() 先檢查再走 .show()。
+    pub enabled: Arc<AtomicBool>,
+}
+
+impl Notifier {
+    pub fn new(app_name: impl Into<String>) -> Self {
+        Self {
+            app_name: app_name.into(),
+            icon_path: None,
+            enabled: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    /// 取得共用的 enabled flag handle,給 caller 切 toggle 用。
+    pub fn enabled_handle(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.enabled)
+    }
+
+    // ... 既有 with_icon / app_name / icon_path / build_text 等不變 ...
+
+    pub fn fire(&self, reminder: &Reminder) -> Result<(), NotifyError> {
+        // 2026-05-22:os_notification_enabled toggle off → 直接 Ok 不發送
+        if !self.enabled.load(Ordering::Relaxed) {
+            tracing::debug!(
+                reminder_id = reminder.id,
+                "notifier.fire skipped — os_notification_enabled toggle off"
+            );
+            return Ok(());
+        }
+        let n = self.build_for_reminder(reminder);
+        Self::show(&n)
+    }
+}
+```
+
+- [ ] **Step 2: `TauriEventEmitter` 看 `popup_enabled` 才 emit**
+
+`reminder_emitter.rs`:
+
+```rust
+impl EventEmitter for TauriEventEmitter {
+    fn emit_reminder_fire(&self, reminder: &Reminder) -> Result<(), String> {
+        // 讀當前設定 — load 是 read-on-call,user 切 toggle 即時生效
+        let cfg = crate::notification_config::NotificationConfig::load(
+            &crate::mori_dir().join("config.json"),
+        );
+        if !cfg.popup_enabled {
+            tracing::debug!(
+                reminder_id = reminder.id,
+                "skip popup emit — popup_enabled toggle off"
+            );
+            return Ok(());
+        }
+        // ... 既有 emit 邏輯 ...
+    }
+}
+```
+
+- [ ] **Step 3: `main.rs` 啟動時把 `notifier.enabled` 設成 config 值 + 加 Tauri command 改 toggle**
+
+在 setup 內 `ReminderService::new` 之前讀 config:
+
+```rust
+let cfg = notification_config::NotificationConfig::load(&mori_dir().join("config.json"));
+let notifier = Notifier::new("Mori").with_icon(/* ... */);
+notifier.enabled.store(cfg.os_notification_enabled, std::sync::atomic::Ordering::Relaxed);
+let notifier_enabled_handle = notifier.enabled_handle();
+// 注 manage 進 Tauri:
+app.manage(notifier_enabled_handle.clone());  // 給 Tauri command 切 toggle 用
+// ... 接著 ReminderService::new(..., notifier, ...) ...
+```
+
+- [ ] **Step 4: 加 Tauri commands `get_notification_config` / `set_notification_config`**
+
+在 `notification_config.rs`(或 `main.rs` 接近其他 commands 處)加:
+
+```rust
+#[tauri::command]
+pub fn get_notification_config() -> NotificationConfig {
+    NotificationConfig::load(&crate::mori_dir().join("config.json"))
+}
+
+#[tauri::command]
+pub fn set_notification_config(
+    cfg: NotificationConfig,
+    notifier_enabled: tauri::State<'_, std::sync::Arc<std::sync::atomic::AtomicBool>>,
+) -> Result<(), String> {
+    cfg.write(&crate::mori_dir().join("config.json"))?;
+    // 同步推進 notifier flag(popup_enabled emitter 是 read-on-call 不用推)
+    notifier_enabled.store(cfg.os_notification_enabled, std::sync::atomic::Ordering::Relaxed);
+    Ok(())
+}
+```
+
+- [ ] **Step 5: 註冊 commands 進 `invoke_handler!`**
+
+`main.rs` 內 `tauri::generate_handler!` 加 `get_notification_config, set_notification_config`。
+
+- [ ] **Step 6: 加 unit test 確認 enabled=false 時 fire 不去 dbus**
+
+在 `mori-time/src/notifier.rs` `mod tests` 加:
+
+```rust
+#[test]
+#[ignore]  // 需 real dbus,平時不跑;手動驗證用
+fn fire_skipped_when_enabled_false_does_not_send() {
+    // 沒法直接驗證「沒 send」(只能 mock dbus),這條留 manual smoke。
+    // 但至少 fire() return Ok 而不爆。
+    let n = Notifier::new("Mori-Test");
+    n.enabled.store(false, std::sync::atomic::Ordering::Relaxed);
+    let r = sample_reminder("disabled-test");
+    assert!(n.fire(&r).is_ok());
+}
+```
+
+- [ ] **Step 7: workspace check + tests**
+
+Run: `cargo check --workspace --all-targets && cargo test -p mori-time --lib && cargo test -p mori-tauri --lib`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/mori-time crates/mori-tauri
+git commit -m "feat(notifications): wire popup_enabled + os_notification_enabled toggles to fire path
+
+popup_enabled: TauriEventEmitter read-on-call config.json
+os_notification_enabled: Notifier.enabled AtomicBool, set_notification_config command 推 toggle"
+```
+
+---
+
+## Task 8: Tauri commands — `reminder_active_queue` / `reminder_dismiss` / `reminder_snooze`
+
+**Files:**
+- Modify: `crates/mori-tauri/src/reminders_cmd.rs`(加新 commands)
+- Modify: `crates/mori-tauri/src/main.rs`(`invoke_handler!` 註冊)
+
+- [ ] **Step 1: 加 commands 跟 ActiveReminder type**
+
+`reminders_cmd.rs`(新增,既有檔):
+
+```rust
+use std::sync::Arc;
+use chrono::Utc;
+use mori_time::{schema::Reminder, ReminderService};
+use serde::Serialize;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActiveReminder {
+    pub id: i64,
+    pub text: String,
+    pub due_at: String,    // ISO8601
+    pub fired_at: String,
+}
+
+impl From<&Reminder> for ActiveReminder {
+    fn from(r: &Reminder) -> Self {
+        Self {
+            id: r.id,
+            text: r.text.clone(),
+            due_at: r.due_at.to_rfc3339(),
+            fired_at: r.fired_at.unwrap_or_else(Utc::now).to_rfc3339(),
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn reminder_active_queue(
+    svc: tauri::State<'_, Arc<ReminderService>>,
+) -> Result<Vec<ActiveReminder>, String> {
+    let store = svc.store.lock().await;
+    let now = Utc::now();
+    let reminders = store
+        .list_active_popup_queue(now)
+        .map_err(|e| e.to_string())?;
+    Ok(reminders.iter().map(ActiveReminder::from).collect())
+}
+
+#[tauri::command]
+pub async fn reminder_dismiss(
+    id: i64,
+    svc: tauri::State<'_, Arc<ReminderService>>,
+) -> Result<(), String> {
+    let store = svc.store.lock().await;
+    store.mark_dismissed(id, Utc::now()).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn reminder_snooze(
+    id: i64,
+    minutes: u32,
+    svc: tauri::State<'_, Arc<ReminderService>>,
+) -> Result<(), String> {
+    svc.snooze_reminder(id, minutes as i64)
+        .await
+        .map_err(|e| e.to_string())
+}
+```
+
+注意 `svc.snooze_reminder` 在 mori-time `commands.rs` 應該已有(若 method 名不同,對齊既有名)。
+
+- [ ] **Step 2: `main.rs` `invoke_handler!` 註冊**
+
+加 `reminders_cmd::reminder_active_queue, reminders_cmd::reminder_dismiss, reminders_cmd::reminder_snooze`(對齊既有 reminders_cmd commands 列法)。
+
+- [ ] **Step 3: 加 integration test(in-memory store)**
+
+`reminders_cmd.rs` tests:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mori_time::{schema::ReminderStore, notifier::Notifier};
+    use std::path::PathBuf;
+
+    async fn make_svc(db_path: PathBuf) -> Arc<ReminderService> {
+        Arc::new(
+            ReminderService::new(
+                &db_path,
+                Notifier::new("Mori-Test"),
+                Arc::new(mori_time::NoopEmitter),
+            )
+            .await
+            .expect("svc"),
+        )
+    }
+
+    #[tokio::test]
+    async fn dismiss_writes_dismissed_at_and_filter_takes_effect() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("r.db");
+        let svc = make_svc(db.clone()).await;
+
+        // 建 + 強迫 fired
+        let r = {
+            let store = svc.store.lock().await;
+            let r = store
+                .create("x".to_string(), Utc::now() - chrono::Duration::minutes(1), None)
+                .unwrap();
+            store.mark_fired(r.id, Utc::now()).unwrap();
+            r
+        };
+
+        // dismiss 前 active_queue 包含 r
+        let store = svc.store.lock().await;
+        let before = store.list_active_popup_queue(Utc::now()).unwrap();
+        assert!(before.iter().any(|x| x.id == r.id));
+        drop(store);
+
+        // call dismiss command 等價:直接呼叫 store.mark_dismissed
+        let store = svc.store.lock().await;
+        store.mark_dismissed(r.id, Utc::now()).unwrap();
+        let after = store.list_active_popup_queue(Utc::now()).unwrap();
+        assert!(!after.iter().any(|x| x.id == r.id));
+    }
+}
+```
+
+(Tauri command body 直接走 store API,所以這個 test 等價於 cover command 邏輯。)
+
+- [ ] **Step 4: 跑 tests + workspace check**
+
+Run: `cargo test -p mori-tauri --lib reminders_cmd && cargo check --workspace`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mori-tauri
+git commit -m "feat(mori-tauri): Tauri commands for in-app popup — active_queue / dismiss / snooze"
+```
+
+---
+
+## Task 9: 註冊 `reminder_popup` Tauri window + capabilities
+
+**Files:**
+- Modify: `crates/mori-tauri/tauri.conf.json`
+- Modify: `crates/mori-tauri/capabilities/default.json`
+
+- [ ] **Step 1: `tauri.conf.json` windows array 加 entry**
+
+在既有 `chat_bubble` window 旁加(對齊既有屬性):
+
+```json
+{
+  "label": "reminder_popup",
+  "url": "index.html",
+  "title": "Mori (reminder)",
+  "transparent": true,
+  "decorations": false,
+  "alwaysOnTop": true,
+  "skipTaskbar": true,
+  "resizable": false,
+  "visible": true,
+  "x": -10000,
+  "y": -10000,
+  "width": 320,
+  "height": 96,
+  "focus": false
+}
+```
+
+- [ ] **Step 2: `capabilities/default.json` windows array 加 `"reminder_popup"`**
+
+既有檔內:
+
+```json
+"windows": ["main", "floating", "chat_bubble", "picker", "reminder_popup"]
+```
+
+- [ ] **Step 3: 編譯確認**
+
+Run: `cargo check -p mori-tauri`
+Expected: PASS
+
+- [ ] **Step 4: 啟動 mori-tauri 確認新 window 存在(不會崩 / capability 過得了)**
+
+Run: `cd /home/ct/mori-universe/mori-desktop && npm run tauri dev`
+
+啟動後 terminal 不該有 capability error 或 `unknown window label`。可手動驗證:
+
+```bash
+xdotool search --name "Mori (reminder)" 2>&1 | head
+```
+
+應該有一個 XID 回來(window 在 -10000,-10000 位置看不到但存在)。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mori-tauri/tauri.conf.json crates/mori-tauri/capabilities/default.json
+git commit -m "feat(mori-tauri): register reminder_popup window config + capabilities"
+```
+
+---
+
+## Task 10: `ReminderPopup.tsx` React 元件 + main.tsx routing
+
+**Files:**
+- Create: `src/ReminderPopup.tsx`
+- Create: `src/reminder-popup.css`
+- Modify: `src/main.tsx`(label routing)
+
+- [ ] **Step 1: 寫 `src/ReminderPopup.tsx`**
+
+```tsx
+// 2026-05-22:in-app reminder popup window — Mori 自家通知,因為 Linux GNOME
+// 對「有 ABOVE 視窗的 app」會抑制 OS 通知 banner。
+//
+// 由 mori-time on_fire callback → TauriEventEmitter → emit "reminder-fire-show"
+// 觸發;mount 時也 invoke reminder_active_queue 補抓未 dismissed reminders。
+//
+// 對齊 ChatBubble.tsx pattern:transparent + decorationless + alwaysOnTop;
+// 隱藏雙保險 = setPosition(-10000, -10000) + setSize(1, 1)。
+
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow, LogicalPosition, LogicalSize } from "@tauri-apps/api/window";
+import { listen } from "@tauri-apps/api/event";
+
+type ActiveReminder = {
+  id: number;
+  text: string;
+  dueAt: string;     // ISO8601
+  firedAt: string;
+};
+
+type SpriteMoved = { x: number; y: number };
+
+const POPUP_WIDTH = 320;
+const POPUP_MAX_HEIGHT = 480;
+const CHIP_SIZE = 32;
+const POPUP_TO_CHIP_MINUTES = 5;
+const DEBOUNCE_MS = 200;
+const SPRITE_GAP = 12;
+// MVP sprite 預設大小(對齊 FloatingMori),sprite 寬高都 200,gap 12 後 popup 在下方
+const SPRITE_HEIGHT = 200;
+
+function ReminderPopup() {
+  const [queue, setQueue] = useState<ActiveReminder[]>([]);
+  const [mode, setMode] = useState<"popup" | "chip">("popup");
+  const [spritePos, setSpritePos] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const debounceTimer = useRef<number | null>(null);
+  const inactivityTimer = useRef<number | null>(null);
+
+  // === debounce buffer:多個 emit 同瞬間進來時合成一次 setQueue ===
+  const pendingNew = useRef<ActiveReminder[]>([]);
+  const flushPending = () => {
+    if (pendingNew.current.length === 0) return;
+    setQueue((prev) => {
+      const merged = [...prev];
+      for (const r of pendingNew.current) {
+        if (!merged.some((x) => x.id === r.id)) merged.push(r);
+      }
+      return merged;
+    });
+    pendingNew.current = [];
+  };
+
+  // === listen + 啟動補抓 ===
+  useEffect(() => {
+    let unlistenFire: (() => void) | null = null;
+    let unlistenSpriteMoved: (() => void) | null = null;
+
+    (async () => {
+      // 1) 補抓 mount 前 emit 過、popup 還沒 ready 收到的 reminder
+      try {
+        const active = await invoke<ActiveReminder[]>("reminder_active_queue");
+        if (active.length > 0) {
+          setQueue(active);
+          setMode("popup");
+        }
+      } catch (e) {
+        console.warn("[reminder_popup] active_queue fetch failed", e);
+      }
+
+      // 2) 訂閱新 fire 事件
+      const u1 = await listen<ActiveReminder>("reminder-fire-show", (e) => {
+        pendingNew.current.push(e.payload);
+        if (debounceTimer.current !== null) window.clearTimeout(debounceTimer.current);
+        debounceTimer.current = window.setTimeout(() => {
+          flushPending();
+          setMode("popup");  // 新 fire 進來,從 chip 拉回 popup
+        }, DEBOUNCE_MS);
+      });
+      unlistenFire = u1;
+
+      // 3) sprite 拖動同步位置
+      const u2 = await listen<SpriteMoved>("sprite-moved", (e) => {
+        setSpritePos(e.payload);
+      });
+      unlistenSpriteMoved = u2;
+    })();
+
+    return () => {
+      if (debounceTimer.current !== null) window.clearTimeout(debounceTimer.current);
+      if (inactivityTimer.current !== null) window.clearTimeout(inactivityTimer.current);
+      unlistenFire?.();
+      unlistenSpriteMoved?.();
+    };
+  }, []);
+
+  // === queue 變化 → setSize / setPosition / show ===
+  useEffect(() => {
+    const win = getCurrentWindow();
+    if (queue.length === 0) {
+      // 完全 dismiss 過渡 — 雙保險:移 off-screen + 縮 1x1
+      win.setPosition(new LogicalPosition(-10000, -10000)).catch(() => {});
+      win.setSize(new LogicalSize(1, 1)).catch(() => {});
+      return;
+    }
+    // sprite 旁 anchor:預設貼 sprite 下方
+    const anchorX = spritePos.x;
+    const anchorY = spritePos.y + SPRITE_HEIGHT + SPRITE_GAP;
+    win.setPosition(new LogicalPosition(anchorX, anchorY)).catch(() => {});
+
+    if (mode === "chip") {
+      win.setSize(new LogicalSize(CHIP_SIZE, CHIP_SIZE)).catch(() => {});
+      return;
+    }
+    // popup mode:跟著 card 內容高度
+    requestAnimationFrame(() => {
+      const measured = cardRef.current?.offsetHeight ?? 0;
+      if (measured <= 0) return;  // 沿用 ChatBubble pattern,offsetHeight=0 skip
+      const h = Math.min(POPUP_MAX_HEIGHT, measured);
+      win.setSize(new LogicalSize(POPUP_WIDTH, h)).catch(() => {});
+    });
+  }, [queue, mode, spritePos]);
+
+  // === inactivity timer:popup → chip 自動退場 ===
+  useEffect(() => {
+    if (mode !== "popup" || queue.length === 0) return;
+    if (inactivityTimer.current !== null) window.clearTimeout(inactivityTimer.current);
+    inactivityTimer.current = window.setTimeout(() => {
+      setMode("chip");
+    }, POPUP_TO_CHIP_MINUTES * 60 * 1000);
+    return () => {
+      if (inactivityTimer.current !== null) window.clearTimeout(inactivityTimer.current);
+    };
+  }, [mode, queue.length]);
+
+  const onSnooze = async (id: number) => {
+    try {
+      await invoke("reminder_snooze", { id, minutes: 5 });
+      setQueue((q) => q.filter((r) => r.id !== id));
+    } catch (e) {
+      console.error("[reminder_popup] snooze failed", e);
+      alert(`稍後失敗:${e}`);  // MVP:粗暴 alert,follow-up 改 inline 紅 chip
+    }
+  };
+
+  const onDismiss = async (id: number) => {
+    try {
+      await invoke("reminder_dismiss", { id });
+      setQueue((q) => q.filter((r) => r.id !== id));
+    } catch (e) {
+      console.error("[reminder_popup] dismiss failed", e);
+      alert(`關閉失敗:${e}`);
+    }
+  };
+
+  if (queue.length === 0) return null;
+
+  // === chip mode render ===
+  if (mode === "chip") {
+    return (
+      <div
+        className="reminder-chip"
+        onClick={() => setMode("popup")}
+        title={`${queue.length} 條未讀提醒`}
+      >
+        🔔 {queue.length}
+      </div>
+    );
+  }
+
+  // === popup mode render ===
+  // 折疊:queue ≥ 2 條 → list view;只 1 條 → 單筆 card
+  const visible = queue.slice(0, 5);
+  const overflow = Math.max(0, queue.length - 5);
+
+  return (
+    <div ref={cardRef} className="reminder-card">
+      {visible.map((r) => (
+        <div key={r.id} className="reminder-row">
+          <div className="reminder-row-head">
+            <span className="reminder-bell">🔔</span>
+            <span className="reminder-text">{r.text}</span>
+          </div>
+          <div className="reminder-row-meta">
+            <span className="reminder-due">原定 {formatDueChip(r.dueAt)}</span>
+            <button onClick={() => onSnooze(r.id)}>稍後 5 分</button>
+            <button onClick={() => onDismiss(r.id)}>關閉</button>
+          </div>
+        </div>
+      ))}
+      {overflow > 0 && (
+        <div className="reminder-overflow-chip">+{overflow} 條歷史提醒</div>
+      )}
+    </div>
+  );
+}
+
+function formatDueChip(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+  } catch {
+    return "?";
+  }
+}
+
+export default ReminderPopup;
+```
+
+- [ ] **Step 2: 寫 `src/reminder-popup.css`**
+
+```css
+/* 2026-05-22:in-app reminder popup 樣式 — 對齊 chat-bubble.css 既有風格 */
+
+.reminder-card {
+  background: rgba(20, 24, 28, 0.96);
+  color: #f1eee0;
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 320px;
+}
+
+.reminder-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 6px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.reminder-row:last-child {
+  border-bottom: none;
+}
+
+.reminder-row-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.reminder-bell {
+  font-size: 16px;
+}
+
+.reminder-text {
+  font-weight: 500;
+  word-break: break-word;
+}
+
+.reminder-row-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.reminder-due {
+  color: #c9a24d;
+  margin-right: auto;
+}
+
+.reminder-row-meta button {
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  padding: 4px 10px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.reminder-row-meta button:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.reminder-overflow-chip {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.55);
+  align-self: flex-start;
+  margin-top: 4px;
+}
+
+.reminder-chip {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(201, 162, 77, 0.95);
+  color: #1a1410;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+html.reminder-popup-window,
+body.reminder-popup-window {
+  background: transparent !important;
+  margin: 0;
+  padding: 0;
+}
+```
+
+- [ ] **Step 3: 改 `src/main.tsx` label routing**
+
+對齊既有 `chat_bubble` / `picker` 分支(看現有 main.tsx 內 label 條件):
+
+```tsx
+import ReminderPopup from "./ReminderPopup";
+import "./reminder-popup.css";
+
+// 既有 label 分支內加:
+} else if (label === "reminder_popup") {
+  document.documentElement.classList.add("reminder-popup-window");
+  document.body.classList.add("reminder-popup-window");
+  createRoot(document.getElementById("root")!).render(<ReminderPopup />);
+}
+```
+
+- [ ] **Step 4: TS check**
+
+Run: `cd /home/ct/mori-universe/mori-desktop && npx tsc --noEmit`
+Expected: 0 errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ReminderPopup.tsx src/reminder-popup.css src/main.tsx
+git commit -m "feat(ui): ReminderPopup React component — in-app reminder window with snooze/dismiss"
+```
+
+---
+
+## Task 11: ConfigTab Settings UI — popup_enabled / os_notification_enabled toggle
+
+**Files:**
+- Modify: `src/tabs/ConfigTab.tsx`(加新「通知」區段)
+
+- [ ] **Step 1: 加 form section 在 ConfigTab 內**
+
+ConfigTab.tsx 既有 form view 有 providers / hotkeys 等 section;對齊既有 pattern 加一個 `<section>` 區塊。具體插入位置由 ConfigTab 既有結構決定,大約在 hotkeys section 之後。
+
+```tsx
+// 通知區段 — 2026-05-22 新增
+type NotificationConfig = {
+  popup_enabled: boolean;
+  os_notification_enabled: boolean;
+};
+
+// 在 ConfigTab function 內加 state + load:
+const [notifCfg, setNotifCfg] = useState<NotificationConfig>({
+  popup_enabled: true,
+  os_notification_enabled: true,
+});
+
+useEffect(() => {
+  invoke<NotificationConfig>("get_notification_config")
+    .then(setNotifCfg)
+    .catch((e) => console.warn("get_notification_config failed", e));
+}, []);
+
+const saveNotif = async (next: NotificationConfig) => {
+  setNotifCfg(next);
+  try {
+    await invoke("set_notification_config", { cfg: next });
+  } catch (e) {
+    console.error("set_notification_config failed", e);
+    alert(`儲存失敗:${e}`);
+  }
+};
+
+// JSX section(放在合適位置,例如 hotkeys 後 / annuli 前):
+<section className="config-section">
+  <h3>通知</h3>
+  <label className="config-toggle">
+    <input
+      type="checkbox"
+      checked={notifCfg.popup_enabled}
+      onChange={(e) => saveNotif({ ...notifCfg, popup_enabled: e.target.checked })}
+    />
+    <span>In-app popup 視窗</span>
+  </label>
+  <label className="config-toggle">
+    <input
+      type="checkbox"
+      checked={notifCfg.os_notification_enabled}
+      onChange={(e) => saveNotif({ ...notifCfg, os_notification_enabled: e.target.checked })}
+    />
+    <span>OS 桌面通知</span>
+    <small className="config-hint">
+      ⚠ 在 Linux GNOME 上可能被 shell 抑制(若 Mori 有 alwaysOnTop 視窗)。
+      建議 in-app popup 保持開啟為主路徑。
+    </small>
+  </label>
+  {!notifCfg.popup_enabled && !notifCfg.os_notification_enabled && (
+    <div className="config-warning">
+      ⚠ 你關掉了所有通知方式 — reminder fire 後不會主動告訴你。
+    </div>
+  )}
+</section>
+```
+
+(`config-section` / `config-toggle` class 沿用 ConfigTab.tsx 既有 CSS class — 對齊既有 form section 樣式;如果沒有 reuse,寫 minimal style 即可。)
+
+- [ ] **Step 2: TS check**
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tabs/ConfigTab.tsx
+git commit -m "feat(ui): ConfigTab notification toggle section — popup_enabled / os_notification_enabled"
+```
+
+---
+
+## Task 12: 全 workspace verify + manual smoke + final summary commit
+
+- [ ] **Step 1: 跑既有 verify 腳本**
+
+Run: `bash scripts/verify.sh`
+Expected: PASS(`npm run build` + `cargo test -p mori-core --lib` + `cargo check --workspace --all-targets`)
+
+- [ ] **Step 2: Manual smoke**(逐項 user 互動驗證,**勾不到就回頭修**)
+
+啟動 `npm run tauri dev`,然後:
+
+- [ ] 設「1 分鐘後提醒我說 smoke1」→ fire 時 popup 出現貼 sprite,且**不會自動消失**
+- [ ] popup 上 [稍後 5 分] 按下 → popup 該筆消 + 5 分後再 fire 一次出現
+- [ ] popup 上 [關閉] 按下 → popup 該筆消 + DB `dismissed_at` 寫入(`sqlite3 ~/.mori/reminders.db "select id,text,dismissed_at from reminders where id=N"`)
+- [ ] 設 reminder 後 5 分鐘無互動 → popup 縮成右上角小 chip,chip 點一下 → 拉回完整 popup
+- [ ] 重啟 mori-tauri → 上次未 dismiss 的 reminder 重新進 popup queue + 顯示
+- [ ] 連設 3 條 5 分鐘內 fire 的 reminder,在 fire 前重啟 → popup 折疊顯示 3 筆
+- [ ] ConfigTab 把「OS 桌面通知」toggle off → fire 一次 → 只 popup 不發 OS(用 `busctl --user list 2>&1 | grep -i notif` 對應時間視窗不該有 Notify call;或直接看 GNOME 通知抽屜該秒沒新條目)
+- [ ] ConfigTab 把「In-app popup」toggle off → fire 一次 → popup 視窗保持離屏不彈,只有 OS 通知出現(若 OS 也工作)
+- [ ] 兩個 toggle 都 off → ConfigTab 顯示警告區塊,fire 一次 → 系統內無任何通知(預期)
+- [ ] 直接 sqlite 塞一筆 8 天前 due_at 的 Pending reminder,重啟 mori-tauri → reload-pending 自動 mark dismissed,**不該** popup
+  ```bash
+  sqlite3 ~/.mori/reminders.db "insert into reminders (text, due_at, created_at, status) values ('stale-test', datetime('now', '-8 days'), datetime('now', '-8 days'), 'Pending');"
+  ```
+  重啟後檢查:
+  ```bash
+  sqlite3 ~/.mori/reminders.db "select text, status, fired_at, dismissed_at from reminders where text='stale-test';"
+  ```
+  期望 status=Fired + 兩個 timestamp 都有值
+
+- [ ] **Step 3: 全部 smoke 過 → 最終 commit(若還有 lint 修補)**
+
+```bash
+git status  # 看有沒有 lint/format 殘留
+# 若有殘留改動:
+git add -A
+git commit -m "chore: smoke verify pass — in-app reminder popup MVP ready"
+```
+
+- [ ] **Step 4: PR / 整理**
+
+把 plan + spec link 寫進 PR body,checklist 直接從 smoke 段抄過去。
+
+```bash
+git log --oneline main ^origin/main
+# 預期看到一連串:
+#  fix(chat-bubble) ...
+#  chore(observability) ...
+#  docs(spec) ...
+#  fix(skill_server) ...
+#  fix(mori-time): spawn_blocking ...
+#  feat(mori-time): sticky notifications ...
+#  ... 加上本 plan 12 條 task 的 commit
+```
+
+---
+
+## Self-review checklist(plan 寫完自查)
+
+- [x] 每 task 有 file paths 明確
+- [x] 每 step 有 verbatim code / command,沒有「按 X 風格實作」這種模糊
+- [x] TDD:Task 1-4, 6-8 都先寫 failing test 再實作
+- [x] DRY:trait `EventEmitter` 抽掉 mori-time / mori-tauri 循環依賴,不重複定義 emit logic
+- [x] Spec coverage:
+  - §4.1 (5 處修改)→ Tasks 1-5, 8-11
+  - §4.2 data flow → Task 4, 5, 10
+  - §4.3 catch-up 折疊 → Tasks 3 (grace), 10 (UI 折疊)
+  - §4.4 active queue / mode → Task 10
+  - §4.5 動作 → Tasks 8, 10
+  - §4.6 視窗位置 → Tasks 9, 10
+  - §5 error handling → Tasks 4 (emit 失敗 log), 7 (toggle), 10 (alert)
+  - §6 testing → Tasks 1-8 unit;Task 12 manual smoke
+- [x] 命名一致:`reminder_popup`(window label)、`reminder-fire-show`(event name)、`ActiveReminder`(type)、`reminder_active_queue` / `reminder_dismiss` / `reminder_snooze`(commands)
+- [x] Type 一致:Rust `serde(rename_all = "camelCase")` + TS camelCase 全文對齊

--- a/docs/superpowers/specs/2026-05-22-in-app-reminder-popup-design.md
+++ b/docs/superpowers/specs/2026-05-22-in-app-reminder-popup-design.md
@@ -1,0 +1,198 @@
+# In-app Reminder Popup — Design Spec
+
+**Status**: Approved (2026-05-22)
+**Owner**: yazelin
+**Source brainstorm**: 2026-05-22 session(skill_server + sticky 通知系列 follow-up)
+
+## 1. 背景
+
+時之鳥(`mori-time`)的 reminder fire 路徑目前依賴 `notify-rust` → libdbus → GNOME shell。Linux GNOME 環境下 trace 證實:即使 hint 完整(`urgency=Critical` + `resident=true` + `timeout=Never`),GNOME shell 在 30ms 內 emit `NotificationClosed reason=2` — banner 沒機會 surface,通知抽屜也沒入庫。根因是 mori-tauri 自身有 2 個 `_NET_WM_STATE=ABOVE` 視窗(`Mori (floating)` + `Mori (chat)`),GNOME 對「有 ABOVE 視窗的 app」直接抑制 banner。Critical urgency 在這條路徑被吃掉。
+
+User 設的 reminder 沒人看得到,reminder 等於失效。OS notification 在 Linux 上脆弱性太多(per-DE / per-shell-extension / focus / fullscreen / ABOVE state),不能單押。
+
+## 2. 目標
+
+讓 reminder fire 時 user **一定看得到**,而且能 actionable(稍後 / 關閉)。同時保留 OS 通知作 backup(user 切到其他 app 時還能 surface),並提供診斷給 user 知道 OS 那條當下是否被 DE 抑制。
+
+## 3. 非目標
+
+- LLM skill 開放 cron reminder 設定(`remind_me_cron`)— 框架 popup 吃得下,但 user-facing 設定 path 不在此 MVP
+- 通知歷史頁 `/reminders` history view — popup 折疊「+N 條歷史」link 預留入口,實際 history 頁 follow-up
+- 評分按鈕(👍/👎/✏️)— Q2 follow-up,放在 voice-input chat panel,不在此 popup
+- 跨 app / 跨 fullscreen 強推送(MVP 決定 only-in-Mori-app group)
+
+## 4. 設計
+
+### 4.1 架構與元件
+
+**5 處修改**(2 新檔 + 3 既有檔改):
+
+1. **`reminder_popup` Tauri window**(新)
+   - `tauri.conf.json` 內 windows array 加 entry
+   - 設定:`transparent: true`, `decorations: false`, `alwaysOnTop: true`, `skipTaskbar: true`, `visible: true`
+   - 初始位置:`(-10000, -10000)` 離屏
+   - 初始尺寸:`320×96`(被動 chip 為 `32×32`)
+
+2. **`src/ReminderPopup.tsx`**(新)
+   - 對齊 `ChatBubble.tsx` 既有 pattern(`emit`/`listen` 加位置同步)
+   - listener:`reminder-fire-show`(新增 reminder push 進 queue) + `sprite-moved`(隨 sprite 拖動更新位置)
+   - 啟動 mount 後 invoke `reminder_active_queue` 主動拉「fired 但未 dismissed」reminders
+   - 內部 state:`queue: ActiveReminder[]` + `mode: 'popup' | 'chip'`
+
+3. **`crates/mori-tauri/src/reminders_cmd.rs` 新 Tauri commands**(改既有檔)
+   - `reminder_active_queue() -> Vec<ActiveReminder>` — 回傳「status=Fired 且 dismissed_at IS NULL 且 fired_at > now - 7d」的 list
+   - `reminder_dismiss(id: i64)` — DB 寫 `dismissed_at = now`
+   - `reminder_snooze(id: i64, minutes: u32)` — 走既有 `ReminderService::snooze_reminder`
+
+4. **`crates/mori-time/src/commands.rs` `ReminderService::on_fire` callback 修改**(改既有檔)
+   - 新增 `app_handle: AppHandle` 注入 `ReminderService::new` 簽名
+   - on_fire 內除 spawn_blocking notifier.fire(),**並 emit `reminder-fire-show`** 帶 payload `{ id, text, due_at, fired_at }`
+   - emit 失敗只 log warn,不擋 mark_fired
+
+5. **DB schema migration**(改 `mori-time/src/schema.rs`)
+   - reminders 表加 `dismissed_at TIMESTAMP NULL` 欄(default NULL)
+   - SQLite 沒有 `ADD COLUMN IF NOT EXISTS`,migrate 用 `PRAGMA table_info(reminders)` 檢查欄是否存在,沒有才 `ALTER TABLE ADD COLUMN dismissed_at TEXT`(SQLite TIMESTAMP 實際存 ISO8601 text)
+   - 對齊既有 migrate idempotent pattern
+
+**Capabilities**:`crates/mori-tauri/capabilities/default.json` 內 `windows` array 加 `"reminder_popup"`,沿用既有 permissions(無需新增 permission key)。
+
+**Settings**(在 Settings/Deps 頁加「通知」區段):
+
+MVP 要實際出 UI 的:
+- `popup_enabled: bool = true` — **MVP 含 toggle UI**(checkbox / switch)
+- `os_notification_enabled: bool = true` — **MVP 含 toggle UI**
+
+MVP 寫死 default 不出 UI 的(follow-up 加):
+- `popup_position` MVP **只實作 `sprite-adjacent`**(其他選項 `top-center` / `top-right` / `bottom-right` follow-up,連 enum 本身都 MVP 不引入,避免假象有得選)
+- `popup_auto_chip_minutes: u32 = 5`
+
+Diagnostic chip(MVP 靜態說明):Settings 頁「桌面通知」toggle 旁附小字「⚠ 在 Linux GNOME 上可能被 shell 抑制,建議 in-app popup 保持開啟」。**主動偵測** follow-up
+
+**Edge case**:user 把 popup + OS 兩個 toggle 都關掉 → reminder fire 後 silent mark_fired,user 收不到任何通知。**這是 user 的選擇,不做強制至少留一個** — 但 Settings UI 兩個 toggle 都 off 時 inline 顯示警告「⚠ 你關掉了所有通知,reminder fire 不會主動告訴你」
+
+### 4.2 Data flow
+
+```
+ReminderService::on_fire (mori-time/commands.rs)
+   ├─ spawn_blocking → notifier.fire()         ← OS 通知(可 toggle 關)
+   └─ app_handle.emit("reminder-fire-show", payload)
+
+ReminderPopup.tsx
+   listen("reminder-fire-show") → debounce 200ms → setQueue(prev => [...prev, new])
+   useEffect on queue/mode → resize + reposition + show
+```
+
+**Mount 時 ready 競態解法**:popup window React 元件 mount 完 → invoke `reminder_active_queue` 主動拉資料(對 Rust 端是 idempotent query,可隨時呼叫)。這條 path **同時 cover 三種情境**:
+- mori-tauri 啟動 reload-pending 過早 emit、popup webview 還沒 ready → mount 後 query 補上
+- mori-tauri 重啟,user 重看「上次未 dismiss」reminder
+- popup webview 自己 crash 重啟
+
+### 4.3 Catch-up 折疊行為
+
+- mori-tauri restart → `ReminderService::new` 既有 reload-pending logic 不動
+- overdue reminder(delta ≤ 0)依 due_at 時間順序排,1ms 內各自觸發 on_fire callback,各自 emit
+- popup 200ms debounce 把多條 emit 合成一次 render
+- popup queue ≥ 2 條 → 折疊 list view,每筆一行(text + 「原定 HH:MM」chip + [稍後] [關閉]),最多 5 筆
+- > 5 條 → 顯示「+N 條歷史提醒」chip(MVP 不可互動,只是視覺指示 history 頁 follow-up 才開放)
+- **超過 grace 7 天**的 overdue reminder:reload-pending 時 silently 寫 `dismissed_at = fired_at`,不 emit,不 popup,user 不會被 7+ 天前的 spam 淹
+
+### 4.4 Active queue & Mode 切換
+
+Tauri 預設 serde 不做 case 轉換,Rust struct 用 `serde(rename_all = "camelCase")` 一致對外 → TS 收到 camelCase:
+
+```rust
+// crates/mori-tauri/src/reminders_cmd.rs
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActiveReminder {
+    pub id: i64,
+    pub text: String,
+    pub due_at: String,    // ISO8601
+    pub fired_at: String,
+}
+```
+
+```ts
+// src/ReminderPopup.tsx
+type ActiveReminder = { id: number; text: string; dueAt: string; firedAt: string }
+const [queue, setQueue] = useState<ActiveReminder[]>([])
+const [mode, setMode] = useState<'popup' | 'chip'>('popup')
+```
+
+`emit("reminder-fire-show", ...)` 那筆 payload 同此 shape。
+
+- `queue.length === 0` → setSize(1, 1) + 移 off-screen(完全 dismiss 過渡)
+- `queue.length > 0` 且 `mode === 'popup'` → setSize(320, dynamic) + 貼 sprite 顯示
+- `mode === 'chip'` → setSize(32, 32) + sprite 旁固定 anchor + render 小 badge「N」
+- `popup_auto_chip_minutes` 計時內無互動 → setMode('chip');chip 點一下 → setMode('popup')
+- chip 留到 user 處理完(無限,不要違背「不能錯過」初衷)
+
+### 4.5 動作
+
+**[稍後 5 分]**(snooze button):
+- invoke `reminder_snooze({id, minutes: 5})` → 既有 `ReminderService::snooze_reminder` 走完(更新 due_at + 重排 scheduler job)
+- popup queue 內這筆移除
+- 5 分鐘後 scheduler 重新 fire → 走相同 emit path 再進 queue
+
+**[關閉]**(dismiss button):
+- invoke `reminder_dismiss({id})` → DB 寫 `dismissed_at = now`
+- popup queue 內這筆移除
+- queue 空 → setSize(1,1) + 移 off-screen
+
+**錯誤路徑**:command 回 `Result<(), String> = Err(e)` → popup inline 紅字 chip「動作失敗,reminder 仍在」,不從 queue 移除,user 重試
+
+### 4.6 視窗位置策略
+
+- 沿用 `ChatBubble.tsx` 同套機制:Rust 端拿 sprite 位置算 absolute logical position,透過 event 帶給 popup
+- popup `setPosition(spritePos.x, spritePos.y + spriteHeight + gap)` — 貼 sprite 下方
+- sprite 拖動 → emit `sprite-moved` → popup 跟著 reposition
+- hide 雙保險:`setPosition(-10000, -10000)` + `setSize(1, 1)`(Wayland mutter 對 transparent+decorationless window setPosition 偶爾沒成功,1×1 確保 click 不擋)
+
+## 5. Error handling
+
+| 情境 | 處理 |
+|---|---|
+| popup webview 還沒 mount,emit 來了 | `reminder_active_queue` query 補抓未 dismissed |
+| AppHandle 拿不到(理論不會發生 — 構造時注入) | log error,reminder 走純 OS path,不擋 mark_fired |
+| Snooze / dismiss command 失敗 | popup 顯示 inline 錯誤 chip,reminder 留 queue |
+| Catch-up storm > 5 條 | 折疊 list + 「+N 條」link |
+| Overdue > 7 天 | 自動 mark dismissed,不 emit |
+| Settings 讀檔失敗 | 用 defaults,log warn |
+
+## 6. Testing
+
+**Unit / integration**(`cargo test -p mori-time --lib` / `cargo test -p mori-tauri --lib` 必過):
+
+- `mori-time/commands.rs::on_fire_emits_event` — mock AppHandle 收 event,assert payload 對
+- `mori-time/schema.rs::migration_adds_dismissed_at_idempotent` — 新欄重複 migrate 不爆
+- `mori-tauri/reminders_cmd.rs::reminder_dismiss_writes_dismissed_at`
+- `mori-tauri/reminders_cmd.rs::reminder_active_queue_filters_dismissed_and_super_overdue`
+- `mori-tauri/reminders_cmd.rs::reminder_snooze_reschedules` — 用 in-memory store
+- popup queue dedup + 折疊 TS test(`src/ReminderPopup.test.tsx`)
+
+**Manual smoke**(寫進 PR description checklist):
+- [ ] 設「1 分鐘後」→ fire 時 popup 出現貼 sprite + 不自動消失(5 分內可手動 dismiss)
+- [ ] 點 [稍後 5 分] → popup 消 + 5 分後重彈
+- [ ] 點 [關閉] → popup 消 + DB `dismissed_at` 寫入
+- [ ] 5 分無互動 → popup 縮 chip,點 chip 拉回完整 popup
+- [ ] 重啟 mori-tauri → 未 dismiss reminder 重新進 queue + popup
+- [ ] 連設 3 條 5 分鐘內 + 重啟 → popup 折疊顯示 3 筆
+- [ ] OS notification toggle off → fire 時只 popup 不發 OS
+- [ ] popup toggle off → fire 時只發 OS,popup 視窗保持離屏不彈
+- [ ] popup + OS 都 off → Settings UI 顯示警告 chip,fire 後無任何通知(預期行為)
+- [ ] DB 塞 1 筆 8 天前 overdue → 重啟 reload-pending 不 popup + 自動 mark dismissed
+
+## 7. 開放決定 / Follow-up
+
+- **Settings 完整 UI**:位置 dropdown(`popup_position`)/ chip 自動退場分鐘輸入框(`popup_auto_chip_minutes`)。MVP 兩個核心 toggle 出 UI,其他預設寫死
+- **History 頁 `/reminders`**:列所有 fired / dismissed / cancelled reminder
+- **LLM skill `remind_me_cron`**:NL → cron 表達式 parser
+- **OS 通知健康診斷主動偵測**:listen `org.freedesktop.Notifications.NotificationClosed`,reason=2 在 fire 後 < 100ms 內收到 N 次 → 標「被抑制」,Settings 頁 chip 變紅。MVP 不做,先顯示靜態警示文字
+- **評分按鈕(Q2 follow-up)**:位置在 voice-input chat panel / 歷史紀錄 copy 按鈕旁,獨立 brainstorm
+
+## 8. 變更影響
+
+- DB schema:`reminders` 表加 `dismissed_at` 欄(idempotent migration)
+- Rust API:`ReminderService::new` 簽名加 `app_handle: AppHandle` 參數 — caller(`main.rs` 5265 行附近的 init)要跟著改
+- Tauri config:`tauri.conf.json` 加 window,`capabilities/default.json` 加 window 名
+- 既有 `notifier.fire` / sticky / spawn_blocking 修法**不動**(那條 OS 通知保留為 backup,toggle 可關)

--- a/src/ChatBubble.tsx
+++ b/src/ChatBubble.tsx
@@ -100,7 +100,12 @@ function ChatBubble() {
       // + border)走;不然短文字時 window > card 會看到底部 body bg 條,
       // 長文字逐漸縮短時 window 也不會跟著縮。MAX_HEIGHT 上限保留,避免
       // 超長 transcript / response 鋪滿整個螢幕。
-      const h = Math.min(MAX_HEIGHT, bubble.offsetHeight);
+      // 第一次 mount 時 layout 還沒跑完,offsetHeight=0 → setSize(W,0) 會被
+      // GTK 拒絕並 spam `Gtk-CRITICAL: gtk_window_resize: assertion 'height > 0'`。
+      // ResizeObserver 馬上會再 fire 拿到真值,所以這邊直接 skip 0 即可。
+      const measured = bubble.offsetHeight;
+      if (measured <= 0) return;
+      const h = Math.min(MAX_HEIGHT, measured);
       win.setSize(new LogicalSize(WIDTH, h)).catch(() => {});
     };
     sync();

--- a/src/ReminderPopup.tsx
+++ b/src/ReminderPopup.tsx
@@ -109,6 +109,50 @@ function ReminderPopup() {
     };
   }, []);
 
+  // === polling fallback:listener 漏接 emit 時 5 秒內補正 ===
+  // merge by id:避免 race 覆蓋使用者剛 dismiss 的條目。
+  useEffect(() => {
+    const pollId = window.setInterval(async () => {
+      try {
+        const active = await invoke<ActiveReminder[]>("reminder_active_queue");
+        setQueue((prev) => {
+          const activeIds = new Set(active.map((a) => a.id));
+          // 保留 prev 內 active 還在的
+          const kept = prev.filter((r) => activeIds.has(r.id));
+          // 加入 active 中 prev 還沒有的(listener 漏掉的 fire)
+          const prevIds = new Set(prev.map((r) => r.id));
+          const fresh = active.filter((r) => !prevIds.has(r.id));
+          if (fresh.length > 0) {
+            console.log("[reminder_popup] polling found fresh reminders:", fresh);
+          }
+          return [...kept, ...fresh];
+        });
+      } catch (e) {
+        console.warn("[reminder_popup] polling active_queue failed", e);
+      }
+    }, 5000);
+    return () => window.clearInterval(pollId);
+  }, []);
+
+  // === queue 從空變非空 → re-fetch sprite position(popup hidden 期間 sprite 可能被拖動)===
+  const hadEmptyQueue = useRef(true);
+  useEffect(() => {
+    const isEmptyNow = queue.length === 0;
+    if (hadEmptyQueue.current && !isEmptyNow) {
+      // 從空變非空
+      (async () => {
+        try {
+          const pos = await invoke<{ x: number; y: number }>("get_sprite_position");
+          console.log("[reminder_popup] sprite position refreshed on queue resurrect:", pos);
+          setSpritePos(pos);
+        } catch (e) {
+          console.warn("[reminder_popup] sprite_position refresh failed", e);
+        }
+      })();
+    }
+    hadEmptyQueue.current = isEmptyNow;
+  }, [queue.length]);
+
   // === queue 變化 → setSize / setPosition / show ===
   useEffect(() => {
     const win = getCurrentWindow();

--- a/src/ReminderPopup.tsx
+++ b/src/ReminderPopup.tsx
@@ -59,8 +59,10 @@ function ReminderPopup() {
 
     (async () => {
       // 1) 補抓 mount 前 emit 過、popup 還沒 ready 收到的 reminder
+      console.log("[reminder_popup] mount: invoking get_sprite_position");
       try {
         const active = await invoke<ActiveReminder[]>("reminder_active_queue");
+        console.log("[reminder_popup] active_queue:", active);
         if (active.length > 0) {
           setQueue(active);
           setMode("popup");
@@ -73,6 +75,7 @@ function ReminderPopup() {
       //     mount 時 spritePos 預設 (0,0) → anchor 算成 (0,212) → 不在任何 monitor。
       try {
         const pos = await invoke<{ x: number; y: number }>("get_sprite_position");
+        console.log("[reminder_popup] sprite position:", pos);
         setSpritePos(pos);
       } catch (e) {
         console.warn("[reminder_popup] get_sprite_position failed, using (0,0)", e);
@@ -80,9 +83,11 @@ function ReminderPopup() {
 
       // 2) 訂閱新 fire 事件
       const u1 = await listen<ActiveReminder>("reminder-fire-show", (e) => {
+        console.log("[reminder_popup] fire event received:", e.payload);
         pendingNew.current.push(e.payload);
         if (debounceTimer.current !== null) window.clearTimeout(debounceTimer.current);
         debounceTimer.current = window.setTimeout(() => {
+          console.log("[reminder_popup] debounce flush, pending count:", pendingNew.current.length);
           flushPending();
           setMode("popup");  // 新 fire 進來,從 chip 拉回 popup
         }, DEBOUNCE_MS);
@@ -107,27 +112,31 @@ function ReminderPopup() {
   // === queue 變化 → setSize / setPosition / show ===
   useEffect(() => {
     const win = getCurrentWindow();
+    console.log("[reminder_popup] resize effect, queue.length:", queue.length, "mode:", mode, "spritePos:", spritePos);
     if (queue.length === 0) {
       // 完全 dismiss 過渡 — 雙保險:移 off-screen + 縮 1x1
-      win.setPosition(new LogicalPosition(-10000, -10000)).catch(() => {});
-      win.setSize(new LogicalSize(1, 1)).catch(() => {});
+      console.log("[reminder_popup] empty → hide off-screen");
+      win.setPosition(new LogicalPosition(-10000, -10000)).catch((e) => console.error("[reminder_popup] setPosition fail:", e));
+      win.setSize(new LogicalSize(1, 1)).catch((e) => console.error("[reminder_popup] setSize fail:", e));
       return;
     }
     // sprite 旁 anchor:預設貼 sprite 下方
     const anchorX = spritePos.x;
     const anchorY = spritePos.y + SPRITE_HEIGHT + SPRITE_GAP;
-    win.setPosition(new LogicalPosition(anchorX, anchorY)).catch(() => {});
+    console.log("[reminder_popup] anchor:", { anchorX, anchorY });
+    win.setPosition(new LogicalPosition(anchorX, anchorY)).catch((e) => console.error("[reminder_popup] setPosition fail:", e));
 
     if (mode === "chip") {
-      win.setSize(new LogicalSize(CHIP_SIZE, CHIP_SIZE)).catch(() => {});
+      win.setSize(new LogicalSize(CHIP_SIZE, CHIP_SIZE)).catch((e) => console.error("[reminder_popup] setSize chip fail:", e));
       return;
     }
     // popup mode:跟著 card 內容高度
     requestAnimationFrame(() => {
       const measured = cardRef.current?.offsetHeight ?? 0;
+      console.log("[reminder_popup] measured offsetHeight:", measured);
       if (measured <= 0) return;  // 沿用 ChatBubble pattern,offsetHeight=0 skip
       const h = Math.min(POPUP_MAX_HEIGHT, measured);
-      win.setSize(new LogicalSize(POPUP_WIDTH, h)).catch(() => {});
+      win.setSize(new LogicalSize(POPUP_WIDTH, h)).catch((e) => console.error("[reminder_popup] setSize popup fail:", e));
     });
   }, [queue, mode, spritePos]);
 

--- a/src/ReminderPopup.tsx
+++ b/src/ReminderPopup.tsx
@@ -69,6 +69,15 @@ function ReminderPopup() {
         console.warn("[reminder_popup] active_queue fetch failed", e);
       }
 
+      // 1b) 主動查 sprite 位置 — 只在拖動後才 emit sprite-moved,
+      //     mount 時 spritePos 預設 (0,0) → anchor 算成 (0,212) → 不在任何 monitor。
+      try {
+        const pos = await invoke<{ x: number; y: number }>("get_sprite_position");
+        setSpritePos(pos);
+      } catch (e) {
+        console.warn("[reminder_popup] get_sprite_position failed, using (0,0)", e);
+      }
+
       // 2) 訂閱新 fire 事件
       const u1 = await listen<ActiveReminder>("reminder-fire-show", (e) => {
         pendingNew.current.push(e.payload);

--- a/src/ReminderPopup.tsx
+++ b/src/ReminderPopup.tsx
@@ -1,0 +1,207 @@
+// 2026-05-22:in-app reminder popup window — Mori 自家通知,因為 Linux GNOME
+// 對「有 ABOVE 視窗的 app」會抑制 OS 通知 banner。
+//
+// 由 mori-time on_fire callback → TauriEventEmitter → emit "reminder-fire-show"
+// 觸發;mount 時也 invoke reminder_active_queue 補抓未 dismissed reminders。
+//
+// 對齊 ChatBubble.tsx pattern:transparent + decorationless + alwaysOnTop;
+// 隱藏雙保險 = setPosition(-10000, -10000) + setSize(1, 1)。
+
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow, LogicalPosition, LogicalSize } from "@tauri-apps/api/window";
+import { listen } from "@tauri-apps/api/event";
+
+type ActiveReminder = {
+  id: number;
+  text: string;
+  dueAt: string;     // ISO8601
+  firedAt: string;
+};
+
+type SpriteMoved = { x: number; y: number };
+
+const POPUP_WIDTH = 320;
+const POPUP_MAX_HEIGHT = 480;
+const CHIP_SIZE = 32;
+const POPUP_TO_CHIP_MINUTES = 5;
+const DEBOUNCE_MS = 200;
+const SPRITE_GAP = 12;
+// MVP sprite 預設大小(對齊 FloatingMori),sprite 寬高都 200,gap 12 後 popup 在下方
+const SPRITE_HEIGHT = 200;
+
+function ReminderPopup() {
+  const [queue, setQueue] = useState<ActiveReminder[]>([]);
+  const [mode, setMode] = useState<"popup" | "chip">("popup");
+  const [spritePos, setSpritePos] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const debounceTimer = useRef<number | null>(null);
+  const inactivityTimer = useRef<number | null>(null);
+
+  // === debounce buffer:多個 emit 同瞬間進來時合成一次 setQueue ===
+  const pendingNew = useRef<ActiveReminder[]>([]);
+  const flushPending = () => {
+    if (pendingNew.current.length === 0) return;
+    setQueue((prev) => {
+      const merged = [...prev];
+      for (const r of pendingNew.current) {
+        if (!merged.some((x) => x.id === r.id)) merged.push(r);
+      }
+      return merged;
+    });
+    pendingNew.current = [];
+  };
+
+  // === listen + 啟動補抓 ===
+  useEffect(() => {
+    let unlistenFire: (() => void) | null = null;
+    let unlistenSpriteMoved: (() => void) | null = null;
+
+    (async () => {
+      // 1) 補抓 mount 前 emit 過、popup 還沒 ready 收到的 reminder
+      try {
+        const active = await invoke<ActiveReminder[]>("reminder_active_queue");
+        if (active.length > 0) {
+          setQueue(active);
+          setMode("popup");
+        }
+      } catch (e) {
+        console.warn("[reminder_popup] active_queue fetch failed", e);
+      }
+
+      // 2) 訂閱新 fire 事件
+      const u1 = await listen<ActiveReminder>("reminder-fire-show", (e) => {
+        pendingNew.current.push(e.payload);
+        if (debounceTimer.current !== null) window.clearTimeout(debounceTimer.current);
+        debounceTimer.current = window.setTimeout(() => {
+          flushPending();
+          setMode("popup");  // 新 fire 進來,從 chip 拉回 popup
+        }, DEBOUNCE_MS);
+      });
+      unlistenFire = u1;
+
+      // 3) sprite 拖動同步位置
+      const u2 = await listen<SpriteMoved>("sprite-moved", (e) => {
+        setSpritePos(e.payload);
+      });
+      unlistenSpriteMoved = u2;
+    })();
+
+    return () => {
+      if (debounceTimer.current !== null) window.clearTimeout(debounceTimer.current);
+      if (inactivityTimer.current !== null) window.clearTimeout(inactivityTimer.current);
+      unlistenFire?.();
+      unlistenSpriteMoved?.();
+    };
+  }, []);
+
+  // === queue 變化 → setSize / setPosition / show ===
+  useEffect(() => {
+    const win = getCurrentWindow();
+    if (queue.length === 0) {
+      // 完全 dismiss 過渡 — 雙保險:移 off-screen + 縮 1x1
+      win.setPosition(new LogicalPosition(-10000, -10000)).catch(() => {});
+      win.setSize(new LogicalSize(1, 1)).catch(() => {});
+      return;
+    }
+    // sprite 旁 anchor:預設貼 sprite 下方
+    const anchorX = spritePos.x;
+    const anchorY = spritePos.y + SPRITE_HEIGHT + SPRITE_GAP;
+    win.setPosition(new LogicalPosition(anchorX, anchorY)).catch(() => {});
+
+    if (mode === "chip") {
+      win.setSize(new LogicalSize(CHIP_SIZE, CHIP_SIZE)).catch(() => {});
+      return;
+    }
+    // popup mode:跟著 card 內容高度
+    requestAnimationFrame(() => {
+      const measured = cardRef.current?.offsetHeight ?? 0;
+      if (measured <= 0) return;  // 沿用 ChatBubble pattern,offsetHeight=0 skip
+      const h = Math.min(POPUP_MAX_HEIGHT, measured);
+      win.setSize(new LogicalSize(POPUP_WIDTH, h)).catch(() => {});
+    });
+  }, [queue, mode, spritePos]);
+
+  // === inactivity timer:popup → chip 自動退場 ===
+  useEffect(() => {
+    if (mode !== "popup" || queue.length === 0) return;
+    if (inactivityTimer.current !== null) window.clearTimeout(inactivityTimer.current);
+    inactivityTimer.current = window.setTimeout(() => {
+      setMode("chip");
+    }, POPUP_TO_CHIP_MINUTES * 60 * 1000);
+    return () => {
+      if (inactivityTimer.current !== null) window.clearTimeout(inactivityTimer.current);
+    };
+  }, [mode, queue.length]);
+
+  const onSnooze = async (id: number) => {
+    try {
+      await invoke("reminder_snooze", { id, minutes: 5 });
+      setQueue((q) => q.filter((r) => r.id !== id));
+    } catch (e) {
+      console.error("[reminder_popup] snooze failed", e);
+      alert(`稍後失敗:${e}`);  // MVP:粗暴 alert,follow-up 改 inline 紅 chip
+    }
+  };
+
+  const onDismiss = async (id: number) => {
+    try {
+      await invoke("reminder_dismiss", { id });
+      setQueue((q) => q.filter((r) => r.id !== id));
+    } catch (e) {
+      console.error("[reminder_popup] dismiss failed", e);
+      alert(`關閉失敗:${e}`);
+    }
+  };
+
+  if (queue.length === 0) return null;
+
+  // === chip mode render ===
+  if (mode === "chip") {
+    return (
+      <div
+        className="reminder-chip"
+        onClick={() => setMode("popup")}
+        title={`${queue.length} 條未讀提醒`}
+      >
+        🔔 {queue.length}
+      </div>
+    );
+  }
+
+  // === popup mode render ===
+  const visible = queue.slice(0, 5);
+  const overflow = Math.max(0, queue.length - 5);
+
+  return (
+    <div ref={cardRef} className="reminder-card">
+      {visible.map((r) => (
+        <div key={r.id} className="reminder-row">
+          <div className="reminder-row-head">
+            <span className="reminder-bell">🔔</span>
+            <span className="reminder-text">{r.text}</span>
+          </div>
+          <div className="reminder-row-meta">
+            <span className="reminder-due">原定 {formatDueChip(r.dueAt)}</span>
+            <button onClick={() => onSnooze(r.id)}>稍後 5 分</button>
+            <button onClick={() => onDismiss(r.id)}>關閉</button>
+          </div>
+        </div>
+      ))}
+      {overflow > 0 && (
+        <div className="reminder-overflow-chip">+{overflow} 條歷史提醒</div>
+      )}
+    </div>
+  );
+}
+
+function formatDueChip(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+  } catch {
+    return "?";
+  }
+}
+
+export default ReminderPopup;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import MainShell from "./MainShell";
 import FloatingMori from "./FloatingMori";
 import ChatBubble from "./ChatBubble";
 import Picker from "./Picker";
+import ReminderPopup from "./ReminderPopup";
 import { subscribeTheme } from "./theme";
 // A i18n:第一個 import 就讓 i18next init(zh-TW + en),之後 syncLocaleFromConfig
 // 才用 ~/.mori/config.json 的 `locale` 欄位覆寫(避免啟動白屏等 IPC)。
@@ -16,6 +17,7 @@ import "./chat-panel.css";
 import "./floating.css";
 import "./chat-bubble.css";
 import "./picker.css";
+import "./reminder-popup.css";
 
 const label = getCurrentWindow().label;
 const root = document.getElementById("root")!;
@@ -68,6 +70,15 @@ if (label === "floating") {
   ReactDOM.createRoot(root).render(
     <React.StrictMode>
       <Picker />
+    </React.StrictMode>,
+  );
+} else if (label === "reminder_popup") {
+  // in-app reminder popup — Linux GNOME 抑制 OS 通知 banner 替代方案
+  document.documentElement.classList.add("reminder-popup-window");
+  document.body.classList.add("reminder-popup-window");
+  ReactDOM.createRoot(root).render(
+    <React.StrictMode>
+      <ReminderPopup />
     </React.StrictMode>,
   );
 } else {

--- a/src/reminder-popup.css
+++ b/src/reminder-popup.css
@@ -1,0 +1,98 @@
+/* 2026-05-22:in-app reminder popup 樣式 — 對齊 chat-bubble.css 既有風格 */
+
+.reminder-card {
+  background: rgba(20, 24, 28, 0.96);
+  color: #f1eee0;
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 320px;
+}
+
+.reminder-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 6px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.reminder-row:last-child {
+  border-bottom: none;
+}
+
+.reminder-row-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.reminder-bell {
+  font-size: 16px;
+}
+
+.reminder-text {
+  font-weight: 500;
+  word-break: break-word;
+}
+
+.reminder-row-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.reminder-due {
+  color: #c9a24d;
+  margin-right: auto;
+}
+
+.reminder-row-meta button {
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  padding: 4px 10px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.reminder-row-meta button:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.reminder-overflow-chip {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.55);
+  align-self: flex-start;
+  margin-top: 4px;
+}
+
+.reminder-chip {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(201, 162, 77, 0.95);
+  color: #1a1410;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+html.reminder-popup-window,
+body.reminder-popup-window {
+  background: transparent !important;
+  margin: 0;
+  padding: 0;
+}

--- a/src/tabs/ConfigTab.tsx
+++ b/src/tabs/ConfigTab.tsx
@@ -24,6 +24,7 @@ import {
   IconClipboard,
   IconPencil,
   IconAnnuli,
+  IconLightning,
 } from "../icons";
 
 // 5P-6: character pack picker
@@ -245,6 +246,7 @@ type SubTabId =
   | "x11"
   | "annuli"
   | "corrections"
+  | "notifications"
   | "raw";
 
 interface SubTabSpec {
@@ -581,7 +583,7 @@ function CharacterPicker() {
 }
 
 const ALL_SUBTAB_IDS: SubTabId[] = [
-  "quick", "llm", "voice", "appearance", "hotkey", "x11", "annuli", "corrections", "raw",
+  "quick", "llm", "voice", "appearance", "hotkey", "x11", "annuli", "corrections", "notifications", "raw",
 ];
 
 // ── Wake-ack 音效設定(Phase 3A.1.2)──────────────────────────────────────
@@ -1190,6 +1192,31 @@ function ConfigTab({
   const [corrOrig, setCorrOrig] = useState<string>("");
   const [corrStatus, setCorrStatus] = useState<SaveStatus>({ kind: "idle" });
 
+  // 通知區段 — 2026-05-22 新增(Task 11)
+  // i18n follow-up:目前 inline 中文字串,對齊本檔其他 hardcode 中文 section 的 pattern。
+  type NotificationConfig = {
+    popup_enabled: boolean;
+    os_notification_enabled: boolean;
+  };
+  const [notifCfg, setNotifCfg] = useState<NotificationConfig>({
+    popup_enabled: true,
+    os_notification_enabled: true,
+  });
+  useEffect(() => {
+    invoke<NotificationConfig>("get_notification_config")
+      .then(setNotifCfg)
+      .catch((e) => console.warn("get_notification_config failed", e));
+  }, []);
+  const saveNotif = async (next: NotificationConfig) => {
+    setNotifCfg(next);
+    try {
+      await invoke("set_notification_config", { cfg: next });
+    } catch (e) {
+      console.error("set_notification_config failed", e);
+      alert(`儲存失敗:${e}`);
+    }
+  };
+
   useEffect(() => {
     invoke<string>("config_read")
       .then((t) => { setRaw(t); setOrig(t); })
@@ -1311,6 +1338,8 @@ function ConfigTab({
     ...(isX11 ? [{ id: "x11" as SubTabId, label: t("config_tab.subtabs.x11"), Icon: IconKeyboard }] : []),
     { id: "annuli" as SubTabId, label: t("config_tab.subtabs.annuli"), Icon: IconAnnuli },
     { id: "corrections" as SubTabId, label: t("config_tab.subtabs.corrections"), Icon: IconClipboard },
+    // i18n follow-up:通知 sub-tab label 暫用 inline 中文
+    { id: "notifications" as SubTabId, label: "通知", Icon: IconLightning },
     { id: "raw", label: t("config_tab.subtabs.raw"), Icon: IconPencil },
   ];
 
@@ -2253,6 +2282,37 @@ function ConfigTab({
               >{t("common.revert")}</button>
               <StatusBadge status={corrStatus} />
             </div>
+          </Section>
+          </>}
+
+          {/* ── 通知(popup / OS notification)── 2026-05-22 Task 11 ── */}
+          {subTab === "notifications" && <>
+          <Section
+            title="通知"
+            hint="Reminder 到期時要如何告訴你。In-app popup 是主路徑(最可靠);OS 桌面通知為輔。"
+          >
+            <FormRow label="In-app popup" hint="Reminder fire 時在 Mori 視窗內彈出 popup 視窗。建議保持開啟作為主通知路徑。">
+              <input
+                type="checkbox"
+                checked={notifCfg.popup_enabled}
+                onChange={(e) => saveNotif({ ...notifCfg, popup_enabled: e.target.checked })}
+              />
+            </FormRow>
+            <FormRow
+              label="OS 桌面通知"
+              hint="透過作業系統通知中心顯示通知。⚠ 在 Linux GNOME 上若 Mori 有 alwaysOnTop 視窗可能被 shell 抑制。建議 in-app popup 保持開啟為主路徑。"
+            >
+              <input
+                type="checkbox"
+                checked={notifCfg.os_notification_enabled}
+                onChange={(e) => saveNotif({ ...notifCfg, os_notification_enabled: e.target.checked })}
+              />
+            </FormRow>
+            {!notifCfg.popup_enabled && !notifCfg.os_notification_enabled && (
+              <p className="mori-config-section-hint" style={{ marginTop: "0.4em", borderLeft: "3px solid var(--mori-danger, #c66)", paddingLeft: "0.6em", color: "var(--mori-danger, #c66)" }}>
+                ⚠ 你關掉了所有通知方式 — reminder fire 後不會主動告訴你。
+              </p>
+            )}
           </Section>
           </>}
 


### PR DESCRIPTION
## Summary

Build Mori 自家 in-app reminder popup window 取代不可靠的 OS 桌面通知作為主路徑。Linux GNOME 對「有 ABOVE 視窗的 app」會抑制 OS notification banner(trace 證實 30ms 內 NotificationClosed reason=2),導致時之鳥 reminder fire 後 user 看不到。改用 Tauri transparent decorationless window 貼 sprite 下方顯示,支援 [稍後 5 分] / [關閉] + 5 分無互動縮 chip + 重啟 catch-up。

OS 通知保留為 backup,user 可在 Settings/通知 sub-tab 個別 toggle。

**Spec**: `docs/superpowers/specs/2026-05-22-in-app-reminder-popup-design.md`
**Plan**: `docs/superpowers/plans/2026-05-22-in-app-reminder-popup.md`

## What landed

### Popup feature(主要 12 tasks)

- DB schema:`dismissed_at` 欄 + idempotent migration
- `ReminderStore` 方法:`mark_dismissed` / `list_active_popup_queue`(filter status=fired AND dismissed_at IS NULL AND fired_at > now-7d)
- Catch-up grace:reload-pending 自動 dismiss > 7d overdue
- `EventEmitter` trait inject into `ReminderService::new`(cross-crate boundary,trait 在 mori-time、實作在 mori-tauri)
- `TauriEventEmitter`:on_fire → `app.emit_to("reminder_popup", "reminder-fire-show", payload)`
- `notification_config` module:`~/.mori/config.json` notifications subtree(popup_enabled / os_notification_enabled toggle,read-on-call)
- Tauri commands:`reminder_active_queue` / `reminder_dismiss` / `reminder_snooze`(走新 `reschedule_fired_reminder` 語義 = dismiss 原本 + 建新)
- `reminder_popup` Tauri window + capabilities
- `src/ReminderPopup.tsx` + `reminder-popup.css`:React popup with queue / chip mode / debounce / polling fallback
- ConfigTab → 通知 sub-tab:popup_enabled + os_notification_enabled toggle + 兩個都 off 警告 chip + GNOME 抑制提示

### Supporting fixes(實作期間發現的相關問題)

- `fix(skill_server)`:暴露 remind_me / read_file_text / read_wiki_page 等新 skill 給 bash-cli-agent provider
- `fix(mori-time)`:`spawn_blocking` 包 notify-rust fire 避免 Runtime-in-Runtime panic
- `feat(mori-time)`:sticky OS notification(timeout Never + resident + critical urgency)
- `fix(chat-bubble)`:offsetHeight=0 時 skip setSize 避免 GTK CRITICAL spam
- `chore(observability)`:default tracing filter 包 mori-time / mori-mcp / mori-gmail / mori-file-loader
- `feat(reminder-popup)`:event_log 記 reminder_fire / popup_emit / dismiss / reschedule(LogsTab 可見)

## Test plan

### Automated(全綠)

- [x] `cargo check --workspace --all-targets` PASS
- [x] `cargo test -p mori-time --lib` 52 PASS
- [x] `cargo test -p mori-core --lib` 275 PASS  
- [x] `cargo test -p mori-tauri` 142 PASS
- [x] `npm run build` PASS
- [x] `bash scripts/verify.sh` PASS

### Manual smoke(實機驗過)

- [x] 設「1 分鐘後」→ fire 時 popup 出現貼 sprite + sticky 不消
- [x] [關閉] → popup 消 + DB `dismissed_at` 寫入
- [x] [稍後 5 分] → reschedule,5 分後再 fire 新 reminder
- [x] 5 分無互動 → popup 縮成 sprite 旁小 chip,點 chip 拉回
- [x] 重啟 mori-tauri → 未 dismiss 的 reminder 自動進 popup queue(catch-up backfill)
- [x] Polling fallback 5 秒 reconcile(listen miss 時兜底)
- [ ] OS toggle off → 只 popup 不發 OS(沒測,Linux GNOME 本來就抑制)
- [ ] popup toggle off → 只 OS(沒測)
- [ ] 兩 toggle off 警告 chip(沒測)
- [ ] 8 天 overdue 自動 dismiss(沒測,unit test 已 cover)

## Known limitations / Follow-up

- **OS 桌面通知 Linux GNOME 抑制**:GNOME 對「有 ABOVE 視窗的 app」會吞 banner(reason=2 立刻 close),所以 OS 那條在本機看不到。**這正是做 in-app popup 的原因**。Settings UI 有警告文字。主動偵測 follow-up
- **LLM cron skill**(`remind_me_cron`):框架 popup 已能吃 cron fire,但 user-facing 設定 path 還沒做(LLM 還只能設 one-shot)
- **History `/reminders` 頁**:折疊「+N 條」chip MVP 不可互動,完整 history 頁 follow-up
- **評分 👍/👎/✏️**:Q2 follow-up,放在 voice-input chat panel,獨立 brainstorm
- **Diagnostic instrumentation**(commit 779ab3f):console.log + debug Tauri command 留著,未來 debug 用,無 perf 影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)