### PR TITLE
fix(character-pack): backfill missing bundled files + resize window 160→200

### DIFF
--- a/crates/mori-tauri/src/character_pack.rs
+++ b/crates/mori-tauri/src/character_pack.rs
@@ -108,13 +108,52 @@ pub fn backdrop_path(stem: &str, theme: &str) -> PathBuf {
 }
 
 /// 啟動時:確保 ~/.mori/characters/mori/ 存在 + 寫入 bundled 內容。
-/// 已存在的 manifest.json 不覆蓋(尊重 user state)。
+///
+/// 行為:
+/// - 完全沒 manifest → fresh install,extract 整個 bundled pack
+/// - 既有 manifest → 尊重 user state(不覆蓋既有 manifest / sprites — user 可能改過)
+/// - 但**補寫缺檔**:既有 mori/ 缺 `backdrop-light.png` / `backdrop-dark.png` 等新規格檔
+///   → 從 bundled extract 對應檔(因 backdrop 是新加 schema,舊 user 沒有,
+///   想看新版自帶 backdrop 不該要 user rm -rf 整個 mori/)
 pub fn ensure_default() -> Result<()> {
     let dir = pack_dir(DEFAULT_PACKAGE_NAME);
-    if manifest_path(DEFAULT_PACKAGE_NAME).exists() {
+    if !manifest_path(DEFAULT_PACKAGE_NAME).exists() {
+        // fresh install:全 extract
+        extract_bundled_default_pack(&dir)?;
         return Ok(());
     }
-    extract_bundled_default_pack(&dir)?;
+    // 既有 user state:只補寫缺檔(不動 manifest + 既有 sprites)
+    backfill_missing_bundled_files(&dir)?;
+    Ok(())
+}
+
+/// 對既有 character pack 目錄補寫 bundled 內有但目錄沒的檔(skip 已存在的)。
+/// 不動 manifest.json — 假設既有 user state 想保留。
+fn backfill_missing_bundled_files(dir: &Path) -> Result<()> {
+    backfill_dir_recursively(&BUNDLED_DEFAULT_PACK, dir)
+}
+
+fn backfill_dir_recursively(src: &include_dir::Dir<'_>, dest: &Path) -> Result<()> {
+    for file in src.files() {
+        let rel_path = file.path();
+        // 跳過 manifest.json(user 可能改過)
+        if rel_path == Path::new("manifest.json") {
+            continue;
+        }
+        let out_path = dest.join(rel_path);
+        if out_path.exists() {
+            continue; // 既有檔不覆蓋
+        }
+        if let Some(parent) = out_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&out_path, file.contents())
+            .with_context(|| format!("backfill {}", out_path.display()))?;
+        tracing::info!(path = %out_path.display(), "character_pack: backfilled missing bundled file");
+    }
+    for subdir in src.dirs() {
+        backfill_dir_recursively(subdir, dest)?;
+    }
     Ok(())
 }
 

--- a/crates/mori-tauri/src/x11_shape.rs
+++ b/crates/mori-tauri/src/x11_shape.rs
@@ -10,7 +10,7 @@
 //! through。Compositor 不參與,沒 AA、沒半透明,完全避開 WebKit 問題。
 //!
 //! 實作:用 [`shape_rectangles`] 把目標形狀拆成水平 scanline rectangles 逼近。
-//! 圓 160×160 → 160 條 1px-tall rectangles,每條 width = 2 × sqrt(r² - dy²)。
+//! 圓 200×200 → 200 條 1px-tall rectangles,每條 width = 2 × sqrt(r² - dy²)。
 //! X server 端組合成 region,效能 OK(一次性 setup 不是每幀)。
 
 use anyhow::{Context as _, Result};
@@ -176,10 +176,10 @@ mod tests {
 
     #[test]
     fn circle_scanlines_count() {
-        let rects = circle_scanlines(80.0, 80.0, 80.0, 160);
-        // 整圓垂直跨 160 行,中間每行都有 rect,邊緣 row 可能因為 dx≈0 被
-        // 過濾。預期 ~160 條,不能少於 100。
-        assert!(rects.len() > 100, "got {} rects", rects.len());
+        let rects = circle_scanlines(100.0, 100.0, 100.0, 200);
+        // 整圓垂直跨 200 行,中間每行都有 rect,邊緣 row 可能因為 dx≈0 被
+        // 過濾。預期 ~200 條,不能少於 120。
+        assert!(rects.len() > 120, "got {} rects", rects.len());
     }
 
     #[test]

--- a/crates/mori-tauri/tauri.conf.json
+++ b/crates/mori-tauri/tauri.conf.json
@@ -24,8 +24,8 @@
       {
         "label": "floating",
         "title": "Mori (floating)",
-        "width": 160,
-        "height": 160,
+        "width": 200,
+        "height": 200,
         "decorations": false,
         "transparent": true,
         "alwaysOnTop": true,

--- a/src/FloatingMori.tsx
+++ b/src/FloatingMori.tsx
@@ -239,7 +239,7 @@ function FloatingMori() {
   const [currentProfileLabel, setCurrentProfileLabel] = useState<string>("");
 
   // 5J: 完整 chat bubble 改用獨立 chat_bubble window 顯示
-  // (sprite window 永遠 160×160 不動,bubble 走另一個 Tauri window)。
+  // (sprite window 永遠 200×200 不動,bubble 走另一個 Tauri window)。
   // 這裡只保留「目前是否有 bubble」的旗標 + dwell timer 控制。
   const [hasChatBubble, setHasChatBubble] = useState(false);
 
@@ -435,10 +435,10 @@ function FloatingMori() {
   // - VoiceInput mode: 短轉錄(≤40 字)→ infoLabel(頂端 chip);長轉錄 → chat_bubble window
   // - Agent mode: Mori 完整回應一律走 chat_bubble window(獨立 window,不受 sprite 限制)
 
-  // sprite 視窗在 tauri.conf.json 寫死 160×160 且 resizable:false。
+  // sprite 視窗在 tauri.conf.json 寫死 200×200 且 resizable:false。
   // 不問 outerSize() — GNOME mutter 對 transparent+decorationless 視窗的 outerSize
   // 在不同時刻可能加上不同 shadow margin,會讓 bubble 每次距離 sprite 越來越遠。
-  const SPRITE_SIZE = 160;
+  const SPRITE_SIZE = 200;
   const BUBBLE_WIDTH = 360;
   const BUBBLE_GAP_PX = 8;
 
@@ -551,8 +551,8 @@ function FloatingMori() {
         const sx = pos.x / factor;
         const sy = pos.y / factor;
 
-        const WIN_W = 160;
-        const WIN_H = 160;
+        const WIN_W = 200;
+        const WIN_H = 200;
         const PAD = 40;
 
         // 多螢幕:用 Mori 中心點找目前在哪台螢幕,wander 限制在那台範圍內。
@@ -732,7 +732,7 @@ function FloatingMori() {
       onDoubleClick={onDoubleClick}
       title={`Mori — ${visualLabel(visual)}\n${t("floating.title_hint")}`}
     >
-      {/* 5J: sprite-area — 永遠固定在 widget 左上 160×160,讓 sprite 不會
+      {/* 5J: sprite-area — 永遠固定在 widget 左上 200×200,讓 sprite 不會
           因為 window 變寬 / 變高而跑位置。bubble / chip 浮在這之外。 */}
       <div className="mori-sprite-area">
         {/* 背板:可選的角色背景圖(character pack / user global / shipped fallback) */}
@@ -741,7 +741,7 @@ function FloatingMori() {
         <div className="mori-aura" style={auraStyle} />
 
         {/* 5F-3A: 音量波紋層 — 音量超過門檻時 spawn ripple，向外擴散後 fade。
-            最大擴張到 145px（< 160px 視窗），不會被切。 */}
+            最大擴張到 145px（< 200px 視窗），不會被切。 */}
         {visual === "recording" &&
           ripples.map((r) => (
             <div

--- a/src/floating.css
+++ b/src/floating.css
@@ -153,12 +153,12 @@ html[data-theme-base="light"] .mori-backdrop {
 
 .mori-aura {
   position: absolute;
-  /* Window is 200×200. Aura 160 + blur 8 means the visual halo
-     extends to ~176px diameter at scale 1, leaving ~12px on each
-     side. At max animation scale 1.1 → 176 + blur 8 = ~192px,
-     just inside the window with no clip. */
-  width: 160px;
-  height: 160px;
+  /* Window is 200×200. Aura 130 + blur 8 means the visual halo
+     extends to ~146px diameter at scale 1, leaving ~27px on each
+     side(從 window 200 邊緣)。Sprite 也 130 — aura 跟 sprite 同 size
+     讓光暈剛好圍 sprite。 */
+  width: 130px;
+  height: 130px;
   border-radius: 50%;
   pointer-events: none;
   opacity: 0;

--- a/src/floating.css
+++ b/src/floating.css
@@ -17,7 +17,7 @@ body.floating-window {
   margin: 0;
   padding: 0;
   /* 5J: 跟著 window 的實際大小走(FloatingMori.tsx 會 setSize):
-     idle = 160×160,有 chat bubble 時拉到 360 寬 + 動態高 */
+     idle = 200×200,有 chat bubble 時拉到 360 寬 + 動態高 */
   width: 100vw;
   height: 100vh;
   background: transparent !important;
@@ -80,7 +80,7 @@ body.floating-window.x11-fallback::before {
     inset 0 0 0 1px rgba(255, 255, 255, 0.06);
 }
 
-/* X11 上強制 sprite-area 置中 — 原本 fixed top-left 假設 window 剛好 160×160,
+/* X11 上強制 sprite-area 置中 — 原本 fixed top-left 假設 window 剛好 200×200,
    但 mutter 對 transparent+decorationless 視窗的 inner/outer size 有時差幾 px,
    sprite 就跑位。translate(-50%,-50%) 配 top/left 50% 不管 body 大小都置中。 */
 body.floating-window.x11-fallback .mori-sprite-area {
@@ -90,7 +90,7 @@ body.floating-window.x11-fallback .mori-sprite-area {
 }
 /* X11 上 floating 是 XShape 圓形 clip — chip 在 top:4 那麼上方圓很窄(~50px)
    會被切。下移到圓較寬處 + 配合圓的弧度橫向延伸,完整可見。
-   top:30 處圓內寬 ~125px(dx = sqrt(80²-50²) × 2),left/right:18 給 124px
+   top:30 處圓內寬 ~155px(dx = sqrt(100²-70²) × 2),left/right:22 給 156px
    chip 剛好填滿。Wayland 維持原本 top:4 緊貼上緣。 */
 body.floating-window.x11-fallback .mori-info-label {
   top: 22px;
@@ -112,7 +112,7 @@ body.floating-window #root {
 /* ─── stage(整個 96×96 容器) ───────────────────────────────────── */
 
 .mori-stage {
-  /* 5J: stage 是整個視窗的 click target;sprite-area 內部固定 160×160,
+  /* 5J: stage 是整個視窗的 click target;sprite-area 內部固定 200×200,
      bubble 從 sprite-area 下方延伸出去(window 動態長大時)。 */
   position: absolute;
   inset: 0;
@@ -121,8 +121,8 @@ body.floating-window #root {
   position: absolute;
   top: 0;
   left: 0;
-  width: 160px;
-  height: 160px;
+  width: 200px;
+  height: 200px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -133,7 +133,7 @@ body.floating-window #root {
 /* DOM 元素,跨平台。CSS variable 從 React 餵 — applyBackdrop 跑 resolveBackdropUrl
    拿到 data URL 寫進 --mori-backdrop-{dark,light}。模式 "plain" 時 variable
    被清,background-image 變 none(無背板)。
-   inset:0 蓋滿 sprite-area(160×160),也就是 sprite + drop-shadow + aura 全
+   inset:0 蓋滿 sprite-area(200×200),也就是 sprite + drop-shadow + aura 全
    蓋住 — X11 上 logo 模式可以順便緩解 WebKit half-alpha bug(整個 region
    都是 opaque pixel)。 */
 .mori-backdrop {
@@ -153,12 +153,12 @@ html[data-theme-base="light"] .mori-backdrop {
 
 .mori-aura {
   position: absolute;
-  /* Window is 160×160. Aura 130 + blur 8 means the visual halo
-     extends to ~146px diameter at scale 1, leaving ~7px on each
-     side. At max animation scale 1.1 → 143 + blur 8 = ~159px,
+  /* Window is 200×200. Aura 160 + blur 8 means the visual halo
+     extends to ~176px diameter at scale 1, leaving ~12px on each
+     side. At max animation scale 1.1 → 176 + blur 8 = ~192px,
      just inside the window with no clip. */
-  width: 130px;
-  height: 130px;
+  width: 160px;
+  height: 160px;
   border-radius: 50%;
   pointer-events: none;
   opacity: 0;
@@ -172,8 +172,8 @@ html[data-theme-base="light"] .mori-backdrop {
 
 .mori-sprite {
   position: relative;
-  width: 124px;
-  height: 124px;
+  width: 130px;
+  height: 130px;
   object-fit: contain;
   pointer-events: none; /* drag/click handled by .mori-stage */
   filter: drop-shadow(0 3px 5px rgba(0, 0, 0, 0.4));
@@ -409,8 +409,8 @@ html[data-theme-base="light"] .mori-backdrop {
 }
 
 @keyframes mori-listen-pulse {
-  /* 130px aura at scale 1.1 = 143px + ~8px blur extension = ~159px,
-     comfortably inside the 160px window. */
+  /* 160px aura at scale 1.1 = 176px + ~8px blur extension = ~184px,
+     comfortably inside the 200px window. */
   0%   { transform: scale(0.9);  opacity: 0.85; }
   100% { transform: scale(1.1);  opacity: 0; }
 }
@@ -425,8 +425,8 @@ html[data-theme-base="light"] .mori-backdrop {
 }
 
 @keyframes mori-done-glow {
-  /* 130px aura at scale 1.1 = 143px + blur 8 = ~159px, fits inside
-     the 160px window so the warm glow fades out cleanly past the
+  /* 160px aura at scale 1.1 = 176px + blur 8 = ~184px, fits inside
+     the 200px window so the warm glow fades out cleanly past the
      character without clipping. */
   0%   { transform: scale(0.8); opacity: 0; }
   30%  { transform: scale(1.0); opacity: 1; }
@@ -461,7 +461,7 @@ html[data-theme-base="light"] .mori-backdrop {
 }
 
 /* 從基底環大小（130px）擴張到 145px，opacity 同時淡出。
-   145/130 = 1.115，乘以 130 = 144.95px；視窗 160px，邊界留 ~7.5px 不會被切。 */
+   145/130 = 1.115，乘以 130 = 144.95px；視窗 200px，邊界留 ~27px 不會被切。 */
 @keyframes mori-ripple-out {
   0%   { transform: scale(1.00); opacity: var(--ripple-intensity, 0.5); }
   100% { transform: scale(1.115); opacity: 0; }


### PR DESCRIPTION
## Summary

PR #107 (character pack overhaul) merge 後兩個發現的問題,修在一起:

### 1. ensure_default migration backfill 缺檔

PR #107 前既有 user 的 \`~/.mori/characters/mori/\` 只有 256×256 placeholder sprite + 沒 backdrop。新版 ensure_default 看到 manifest 存在就 skip → bundled 新加的 \`backdrop-{light,dark}.png\` 沒寫進去 → FloatingMori fallback chain step 1 撈空 → backdrop 看不到。

**修法**:ensure_default 既有 manifest 時改 call \`backfill_missing_bundled_files\` — 遞迴掃 bundled examples,只寫 user 目錄沒有的檔(不動 manifest + sprites)。漸進 migration 不破壞 user state。

### 2. Floating window 160→200, sprite 124→130

PR #107 bundled backdrop 是 1024×1024 高解析,在 160×160 window 內被 scale 太小看不到內容。Sprite 124×124 蓋住大部分。

**修法**:
- window 160 → 200(更大顯示面積)
- sprite 124 → 130(略放大)
- backdrop 自動 fill 200×200(inset:0 + cover)
- aura 130 不動(跟 sprite 同 size 圍光暈)

4 處同步:tauri.conf.json sprite window / FloatingMori.tsx SPRITE_SIZE+WIN_W/H / floating.css / x11_shape.rs unit test scanlines

## Test plan

- [x] cargo check + test character_pack:11 PASS
- [x] tsc + npm build:clean
- [ ] 重啟 mori-tauri 看 floating window 是 200×200,backdrop 顯示完整

🤖 Generated with Claude Code