### PR TITLE
[codex] Use themed selects in self-dev tab

### DIFF
--- a/src/shell.css
+++ b/src/shell.css
@@ -2041,17 +2041,10 @@
   min-width: 180px;
 }
 
-.mori-self-dev-controls select.mori-select {
+.mori-self-dev-controls .mori-self-dev-select {
   flex: 0 1 160px;
   width: auto;
   min-width: 140px;
-  background: var(--c-input-bg);
-  border: 1px solid var(--c-border);
-  border-radius: 6px;
-  color: var(--c-text);
-  padding: 6px 10px;
-  font-family: system-ui, "Noto Sans CJK TC", "Microsoft JhengHei", sans-serif;
-  font-size: 12px;
 }
 
 .mori-self-dev-capability {

--- a/src/tabs/SelfDevTab.tsx
+++ b/src/tabs/SelfDevTab.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useTranslation } from "react-i18next";
+import { Select } from "../Select";
 
 type VerifyProfile = "none" | "quick" | "full";
 
@@ -438,11 +439,19 @@ export default function SelfDevTab() {
 
       <div className="mori-self-dev-controls">
         <input className="mori-input" value={prompt} onChange={(e) => setPrompt(e.target.value)} placeholder={t("self_dev_tab.prompt_placeholder")} />
-        <select className="mori-select" value={verify} onChange={(e) => { setVerify(e.target.value as VerifyProfile); setConfirmFull(false); }}>
-          <option value="none">{t("self_dev_tab.verify_none")}</option>
-          <option value="quick">{t("self_dev_tab.verify_quick")}</option>
-          <option value="full">{t("self_dev_tab.verify_full")}</option>
-        </select>
+        <Select
+          className="mori-self-dev-select"
+          value={verify}
+          onChange={(value) => {
+            setVerify(value as VerifyProfile);
+            setConfirmFull(false);
+          }}
+          options={[
+            { value: "none", label: t("self_dev_tab.verify_none") },
+            { value: "quick", label: t("self_dev_tab.verify_quick") },
+            { value: "full", label: t("self_dev_tab.verify_full") },
+          ]}
+        />
         <button className="mori-btn" onClick={start} disabled={!prompt.trim()}>{busy ? t("self_dev_tab.busy") : t("self_dev_tab.start")}</button>
         <button className="mori-btn" onClick={refresh}>{t("self_dev_tab.refresh")}</button>
         <button className="mori-btn" onClick={() => setAutoRefresh((v) => !v)}>
@@ -471,11 +480,16 @@ export default function SelfDevTab() {
           onChange={(e) => setQuery(e.target.value)}
           placeholder={t("self_dev_tab.search_placeholder")}
         />
-        <select className="mori-select" value={statusFilter} onChange={(e) => setStatusFilter(e.target.value as "all" | "running" | "done")}>
-          <option value="all">{t("self_dev_tab.filter_all")}</option>
-          <option value="running">{t("self_dev_tab.filter_running")}</option>
-          <option value="done">{t("self_dev_tab.filter_done")}</option>
-        </select>
+        <Select
+          className="mori-self-dev-select"
+          value={statusFilter}
+          onChange={(value) => setStatusFilter(value as "all" | "running" | "done")}
+          options={[
+            { value: "all", label: t("self_dev_tab.filter_all") },
+            { value: "running", label: t("self_dev_tab.filter_running") },
+            { value: "done", label: t("self_dev_tab.filter_done") },
+          ]}
+        />
       </div>
 
       <div className="mori-list">


### PR DESCRIPTION
## Summary
- Replace Self-Dev native select controls with the repo's themed Select component.
- Keep the existing Self-Dev control layout sizing via a small wrapper class.

## Root Cause
Self-Dev still used native <select> elements. On Linux WebKit/GTK those dropdown panels are rendered by the system widget, so they do not reliably follow Mori theme variables.

## Validation
- Opened both Self-Dev dropdowns in npm run tauri dev and confirmed the custom panel, selected state, and hover styling use Mori theme colors.
- bash scripts/verify.sh passed.