### PR TITLE
ci: allow manual release workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` to the Release workflow so existing release tags can be rebuilt manually when tag push events do not enqueue Actions.

## Verification
- Not run; workflow trigger-only YAML change.

## Platform impact
- No app runtime behavior changed.
- Enables manual installer build/release upload for v0.7.3.