### PR TITLE
fix(annuli): use .mori runtime path on Windows

### DIFF
--- a/crates/mori-tauri/src/annuli_supervisor.rs
+++ b/crates/mori-tauri/src/annuli_supervisor.rs
@@ -171,12 +171,11 @@ fn annuli_root_dir() -> PathBuf {
     if let Ok(p) = std::env::var("MORI_ANNULI_ROOT") {
         return PathBuf::from(p);
     }
-    let home_var = if cfg!(target_os = "windows") {
-        "USERPROFILE"
-    } else {
-        "HOME"
-    };
-    if let Ok(home) = std::env::var(home_var) {
+    if cfg!(target_os = "windows") {
+        if let Some(home) = std::env::var_os("USERPROFILE").or_else(|| std::env::var_os("HOME")) {
+            return PathBuf::from(home).join(".mori").join("annuli");
+        }
+    } else if let Ok(home) = std::env::var("HOME") {
         return PathBuf::from(home).join("mori-universe").join("annuli");
     }
     PathBuf::from("annuli")

--- a/crates/mori-tauri/src/deps.rs
+++ b/crates/mori-tauri/src/deps.rs
@@ -981,7 +981,11 @@ pub fn registry() -> Vec<DepSpec> {
             check: CheckSpec::File {
                 path_template: "$HOME/mori-universe/annuli/.venv/bin/python",
             },
-            check_overrides: &[],
+            check_overrides: &[
+                ("windows", CheckSpec::File {
+                    path_template: "$USERPROFILE\\.mori\\annuli\\.venv\\Scripts\\python.exe",
+                }),
+            ],
             install: InstallSpec::Shell {
                 script: "set -e; \
                          ANNULI=\"$HOME/mori-universe/annuli\"; \
@@ -1021,13 +1025,14 @@ pub fn registry() -> Vec<DepSpec> {
                 ("windows", InstallSpec::Manual {
                     commands: &[
                         "# Windows PowerShell(需 git + Python 3.11 + uv):",
-                        "git clone https://github.com/yazelin/annuli %USERPROFILE%\\mori-universe\\annuli",
-                        "cd %USERPROFILE%\\mori-universe\\annuli",
+                        "mkdir $env:USERPROFILE\\.mori -Force",
+                        "git clone https://github.com/yazelin/annuli $env:USERPROFILE\\.mori\\annuli",
+                        "cd $env:USERPROFILE\\.mori\\annuli",
                         "uv venv .venv --python 3.11",
                         "uv pip install --python .venv\\Scripts\\python.exe -e .",
                         "$token = .\\.venv\\Scripts\\python.exe -c \"import secrets; print(secrets.token_hex(32))\"",
                         "if (!(Test-Path .env) -or !(Select-String -Path .env -Pattern '^ANNULI_SOUL_TOKEN=.' -Quiet)) { Add-Content .env \"ANNULI_SOUL_TOKEN=$token\" }",
-                        "# 回 Mori Desktop 的 Annuli tab 按「一鍵啟用」；它會把 annuli.soul_token 補進 %USERPROFILE%\\.mori\\config.json。",
+                        "# 回 Mori Desktop 的 Annuli tab 按「一鍵啟用」；它會把 annuli.soul_token 補進 $env:USERPROFILE\\.mori\\config.json。",
                     ],
                 }),
             ],
@@ -1330,5 +1335,7 @@ fn expand_home(p: &str) -> String {
     let home = std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
         .unwrap_or_else(|_| "~".into());
+    let userprofile = std::env::var("USERPROFILE").unwrap_or_else(|_| home.clone());
     p.replace("$HOME", &home)
+        .replace("$USERPROFILE", &userprofile)
 }

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -2236,7 +2236,9 @@ async fn sync_supervisor_to_config(state: &AppState, cfg: &annuli_config::Annuli
     *state.annuli_supervisor.lock() = Some(sup);
 }
 
-/// 偵測 annuli runtime 在不在(`~/mori-universe/annuli/.venv/bin/python`)。
+/// 偵測 annuli runtime 在不在。
+/// - Windows install build:`%USERPROFILE%\.mori\annuli\.venv\Scripts\python.exe`
+/// - Linux/macOS dev layout:`~/mori-universe/annuli/.venv/bin/python`
 /// AnnuliTab 用這條決定要不要顯示「一鍵啟用」按鈕。Windows fallback `Scripts/python.exe`。
 #[tauri::command]
 fn annuli_runtime_installed() -> bool {
@@ -2254,6 +2256,12 @@ fn annuli_runtime_installed() -> bool {
 fn annuli_root_dir_for_user() -> Option<std::path::PathBuf> {
     if let Ok(p) = std::env::var("MORI_ANNULI_ROOT") {
         return Some(std::path::PathBuf::from(p));
+    }
+    if cfg!(target_os = "windows") {
+        let home = std::env::var_os("USERPROFILE")
+            .or_else(|| std::env::var_os("HOME"))
+            .map(std::path::PathBuf::from)?;
+        return Some(home.join(".mori").join("annuli"));
     }
     let home = std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))


### PR DESCRIPTION
## Summary
- Move Windows Annuli runtime expectation from `%USERPROFILE%\mori-universe\annuli` to `%USERPROFILE%\.mori\annuli`.
- Align AnnuliTab runtime detection, supervisor spawn path, and DepsTab manual install/check path.
- Expand `$USERPROFILE` in dependency file checks so Windows overrides work correctly.

## Verification
- cargo check -p mori-tauri --all-targets

## Platform impact
- Windows behavior touched: Annuli runtime install/detect/spawn path changes to `%USERPROFILE%\.mori\annuli`.
- Linux/macOS behavior unchanged: dev layout remains `~/mori-universe/annuli`.

## Notes
- Existing Windows installs at `%USERPROFILE%\mori-universe\annuli` should be moved or reinstalled to `%USERPROFILE%\.mori\annuli`.