### PR TITLE
release: v0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@
 
 ---
 
+## v0.7.4 — Windows Annuli runtime path hotfix(2026-05-26)
+
+這版修掉 v0.7.3 發現的 Windows Annuli runtime 路徑錯置。Windows installer 版不該把 Annuli clone 到 `%USERPROFILE%\mori-universe\annuli`;它應該跟 Mori 其他 runtime 一樣放在 `%USERPROFILE%\.mori\annuli`。
+
+### Windows Annuli runtime
+
+- **runtime root 改回 `.mori`** — Windows 上 AnnuliTab 偵測、quick-enable、supervisor spawn 都改用 `%USERPROFILE%\.mori\annuli`。
+- **Deps 安裝指令補搬移** — 若 v0.7.3 已經把 Annuli 放在 `%USERPROFILE%\mori-universe\annuli`,新的 Windows PowerShell 指令會在 `.mori\annuli` 不存在時搬過去。
+- **Deps 檢測修正 `$USERPROFILE` 展開** — Windows override path 不再因只展開 `$HOME` 而偵測不到已安裝 runtime。
+- **Annuli 文件同步** — `docs/annuli.html` 的 Windows 安裝、token `.env`、手動啟動路徑全部改成 `.mori\annuli`。
+
+### Verified
+
+- `cargo check -p mori-tauri --all-targets`
+
+### 升級
+
+Windows 使用者若已經有 `%USERPROFILE%\mori-universe\annuli`,請搬到 `%USERPROFILE%\.mori\annuli`,或重新照 Deps / Annuli 文件的 PowerShell 指令安裝。Linux / macOS 的 `~/mori-universe/annuli` 開發機 layout 不變。
+
+---
+
 ## v0.7.3 — Annuli token setup + FLAC recordings 修補(2026-05-26)
 
 這版收斂 v0.7.2 之後的三個 release-ready fix:Annuli 一鍵啟用時把 soul token setup 做完整,錄音 cleanup / dependency UI 對齊 FLAC 實際需求,並補上 reminder cancel / snooze 的 stale callback race guard。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "mori-cli"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "mori-core"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "mori-file-loader"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "calamine",
  "chrono",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "mori-gmail"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "mori-mcp"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "rmcp",
  "serde",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "mori-tauri"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "mori-time"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "chrono",
  "chrono-english",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 license = "MIT"
 authors = ["yazelin"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Tauri 2 + Rust + React,Whisper 是耳朵,LLM 是腦袋,你是同伴。
 
 📖 **完整介紹 + 互動 demo**:[**yazelin.github.io/mori-desktop**](https://yazelin.github.io/mori-desktop/)
 
-🌲 **Latest** — [**v0.7.3**](https://github.com/yazelin/mori-desktop/releases/tag/v0.7.3):**Annuli token setup + FLAC recordings 修補**(Annuli 一鍵啟用會自動產生 / 同步 soul token,錄音 cleanup/deps 對齊 FLAC,提醒取消/稍後提醒後不再觸發過期 callback)· v0.7.2 → Release gate + 角色背板預設修正 · v0.7.0 → Windows port 全面修補 + verifier-trained wake-word · v0.6.6 → Annuli transparent setup + 召喚師身分 · v0.6.0 → Hey Mori 喚醒生態 · 完整 changelog 看 [`CHANGELOG.md`](CHANGELOG.md)
+🌲 **Latest** — [**v0.7.4**](https://github.com/yazelin/mori-desktop/releases/tag/v0.7.4):**Windows Annuli runtime path hotfix**(Annuli runtime 改回 `%USERPROFILE%\.mori\annuli`,Deps 指令可搬移 v0.7.3 錯放的 `%USERPROFILE%\mori-universe\annuli`,文件同步)· v0.7.3 → Annuli token setup + FLAC recordings 修補 · v0.7.2 → Release gate + 角色背板預設修正 · v0.7.0 → Windows port 全面修補 + verifier-trained wake-word · v0.6.6 → Annuli transparent setup + 召喚師身分 · 完整 changelog 看 [`CHANGELOG.md`](CHANGELOG.md)
 
 ---
 

--- a/crates/mori-tauri/src/deps.rs
+++ b/crates/mori-tauri/src/deps.rs
@@ -1026,7 +1026,8 @@ pub fn registry() -> Vec<DepSpec> {
                     commands: &[
                         "# Windows PowerShell(需 git + Python 3.11 + uv):",
                         "mkdir $env:USERPROFILE\\.mori -Force",
-                        "git clone https://github.com/yazelin/annuli $env:USERPROFILE\\.mori\\annuli",
+                        "if ((Test-Path $env:USERPROFILE\\mori-universe\\annuli) -and !(Test-Path $env:USERPROFILE\\.mori\\annuli)) { Move-Item $env:USERPROFILE\\mori-universe\\annuli $env:USERPROFILE\\.mori\\annuli }",
+                        "if (!(Test-Path $env:USERPROFILE\\.mori\\annuli)) { git clone https://github.com/yazelin/annuli $env:USERPROFILE\\.mori\\annuli }",
                         "cd $env:USERPROFILE\\.mori\\annuli",
                         "uv venv .venv --python 3.11",
                         "uv pip install --python .venv\\Scripts\\python.exe -e .",

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -2357,8 +2357,8 @@ async fn annuli_quick_enable(
     // 1. 驗 runtime
     if !annuli_runtime_installed() {
         return Err(
-            "annuli runtime 沒裝 — 先到 DepsTab 裝「Annuli 反思服務 runtime」(等同 \
-             git clone ~/mori-universe/annuli + uv venv + pip install -e .)"
+            "annuli runtime 沒裝 — 先到 DepsTab 裝「Annuli 反思服務 runtime」(Windows: \
+             %USERPROFILE%\\.mori\\annuli; Linux/macOS: ~/mori-universe/annuli)"
                 .into(),
         );
     }

--- a/crates/mori-tauri/tauri.conf.json
+++ b/crates/mori-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Mori",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "identifier": "ai.yazelin.mori",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/docs/annuli.html
+++ b/docs/annuli.html
@@ -55,16 +55,23 @@
 
 <p>
   Annuli 不是雲端服務。預設路徑在你的電腦:
-  <code>~/mori-universe/annuli</code> 與
-  <code>~/mori-universe/spirits/mori</code>。
+  Windows runtime 在 <code>%USERPROFILE%\.mori\annuli</code>;
+  Linux / macOS runtime 在 <code>~/mori-universe/annuli</code>。
+  vault 預設在 <code>~/mori-universe/spirits/mori</code>。
 </p>
 
 <h2>2. Windows 手動安裝 Annuli runtime</h2>
 
 <p>如果 Deps tab 還沒有自動安裝功能,在 PowerShell 執行:</p>
 
-<pre><code>git clone https://github.com/yazelin/annuli $env:USERPROFILE\mori-universe\annuli
-cd $env:USERPROFILE\mori-universe\annuli
+<pre><code>mkdir $env:USERPROFILE\.mori -Force
+if ((Test-Path $env:USERPROFILE\mori-universe\annuli) -and !(Test-Path $env:USERPROFILE\.mori\annuli)) {
+  Move-Item $env:USERPROFILE\mori-universe\annuli $env:USERPROFILE\.mori\annuli
+}
+if (!(Test-Path $env:USERPROFILE\.mori\annuli)) {
+  git clone https://github.com/yazelin/annuli $env:USERPROFILE\.mori\annuli
+}
+cd $env:USERPROFILE\.mori\annuli
 uv venv .venv --python 3.11
 uv pip install --python .venv\Scripts\python.exe -e .
 
@@ -112,7 +119,7 @@ fi</code></pre>
     <td><code>annuli.soul_token</code></td>
   </tr>
   <tr>
-    <td><code>~/mori-universe/annuli/.env</code> 或 <code>%USERPROFILE%\mori-universe\annuli\.env</code></td>
+    <td><code>~/mori-universe/annuli/.env</code> 或 <code>%USERPROFILE%\.mori\annuli\.env</code></td>
     <td><code>ANNULI_SOUL_TOKEN</code></td>
   </tr>
 </table>
@@ -136,7 +143,7 @@ fi</code></pre>
 </p>
 
 <pre><code># Windows PowerShell
-cd $env:USERPROFILE\mori-universe\annuli
+cd $env:USERPROFILE\.mori\annuli
 .\.venv\Scripts\python.exe main.py admin --port 5000
 
 # Linux / macOS

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mori-desktop",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mori-desktop",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mori-desktop",
   "private": true,
-  "version": "0.7.3",
+  "version": "0.7.4",
   "type": "module",
   "scripts": {
     "predev": "cargo build -p mori-cli && node scripts/stage-mori-cli-for-bundle.mjs debug",


### PR DESCRIPTION
## Summary
- Fix Windows Annuli runtime path to use `%USERPROFILE%\.mori\annuli`.
- Add Deps/manual install migration from the v0.7.3 wrong path `%USERPROFILE%\mori-universe\annuli`.
- Update Annuli docs, README, CHANGELOG, and bump app/workspace versions to 0.7.4.

## Verification
- cargo check -p mori-tauri --all-targets
- bash scripts/verify.sh

## Platform impact
- Windows behavior touched: Annuli runtime install/detect/spawn path.
- Linux/macOS behavior unchanged for Annuli dev layout (`~/mori-universe/annuli`).