### PR TITLE
release: v0.7.5

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@
 
 ---
 
+## v0.7.5 — Annuli process controls + release toolchain cleanup(2026-05-27)
+
+這版補上 Mori Desktop 內建的 Annuli process 控制面板，收斂 v0.7.3/v0.7.4 後使用者最容易卡住的狀態:localhost 上已經有舊 Annuli process 在跑，但 Mori 不能接管、也沒有 UI 能清楚告訴你下一步。
+
+### Annuli process controls
+
+- **Annuli tab 新增 process 區塊** — 顯示 supervisor state、runtime root、port、reason，讓 `spawned` / `already-running` / `failed` 這類狀態不用再猜。
+- **同步 token 並重啟** — `Sync token & restart` 會補齊 `annuli.soul_token`、同步 Annuli `.env`，再重啟 Mori 自己管理的 Annuli process。
+- **停止 Mori-managed Annuli** — `Stop Mori-managed Annuli` 只會停止 Mori spawn 的 child process，不會誤殺外部手動啟動的 Annuli。
+- **外部 process 保護** — 若 port 上是 external `already-running` Annuli，Mori 會明確提示先手動停止；等外部 process 停掉後，可再由 Mori 接管啟動。
+- **startup token migration 補強** — runtime 已安裝但 config 缺 token 時，啟動流程會自動補 `annuli.soul_token` 並同步 `.env`。
+
+### Build / CI cleanup
+
+- **Windows hidden process imports 清理** — 移除兩個已不需要的 local `CommandExt` import。
+- **frontend import cleanup** — `MainShell` / `ConfigTab` 改用 top-level import，減少不必要 dynamic import。
+- **Vite chunk warning threshold** — 調整 build warning limit，避免目前 bundle size 在正常範圍內產生 noise。
+- **CI Node 22** — GitHub check / release workflows 升到 Node 22。
+
+### Verified
+
+- `npm run build`
+- `cargo test -p mori-core --lib`
+- `cargo check --workspace --all-targets`
+
+### 遷移
+
+無 breaking change。若本機已經有舊路徑或手動啟動的 Annuli 佔住 `localhost:5000`，新版 Annuli tab 會顯示 `already-running`；請先停止該外部 process，再按 `Sync token & restart` 讓 Mori 用 `.mori\annuli` runtime 與同步後的 token 接管。
+
+---
+
 ## v0.7.4 — Windows Annuli runtime path hotfix(2026-05-26)
 
 這版修掉 v0.7.3 發現的 Windows Annuli runtime 路徑錯置。Windows installer 版不該把 Annuli clone 到 `%USERPROFILE%\mori-universe\annuli`;它應該跟 Mori 其他 runtime 一樣放在 `%USERPROFILE%\.mori\annuli`。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "mori-cli"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "mori-core"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "mori-file-loader"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "calamine",
  "chrono",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "mori-gmail"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "mori-mcp"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "rmcp",
  "serde",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "mori-tauri"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "mori-time"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "chrono",
  "chrono-english",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 license = "MIT"
 authors = ["yazelin"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Tauri 2 + Rust + React,Whisper 是耳朵,LLM 是腦袋,你是同伴。
 
 📖 **完整介紹 + 互動 demo**:[**yazelin.github.io/mori-desktop**](https://yazelin.github.io/mori-desktop/)
 
-🌲 **Latest** — [**v0.7.4**](https://github.com/yazelin/mori-desktop/releases/tag/v0.7.4):**Windows Annuli runtime path hotfix**(Annuli runtime 改回 `%USERPROFILE%\.mori\annuli`,Deps 指令可搬移 v0.7.3 錯放的 `%USERPROFILE%\mori-universe\annuli`,文件同步)· v0.7.3 → Annuli token setup + FLAC recordings 修補 · v0.7.2 → Release gate + 角色背板預設修正 · v0.7.0 → Windows port 全面修補 + verifier-trained wake-word · v0.6.6 → Annuli transparent setup + 召喚師身分 · 完整 changelog 看 [`CHANGELOG.md`](CHANGELOG.md)
+🌲 **Latest** — [**v0.7.5**](https://github.com/yazelin/mori-desktop/releases/tag/v0.7.5):**Annuli process controls + release toolchain cleanup**(Annuli tab 可查看 supervisor state、同步 token 並重啟 Mori-managed Annuli、保護 external process 不被誤殺)· v0.7.4 → Windows Annuli runtime path hotfix · v0.7.3 → Annuli token setup + FLAC recordings 修補 · v0.7.2 → Release gate + 角色背板預設修正 · v0.7.0 → Windows port 全面修補 + verifier-trained wake-word · 完整 changelog 看 [`CHANGELOG.md`](CHANGELOG.md)
 
 ---
 

--- a/crates/mori-core/src/skill/python_runner.rs
+++ b/crates/mori-core/src/skill/python_runner.rs
@@ -92,7 +92,6 @@ pub async fn run_python_script(
     // 是 mori-core 自身一部分,直接 inline OS-conditional 比較乾淨。
     #[cfg(windows)]
     {
-        use std::os::windows::process::CommandExt;
         const CREATE_NO_WINDOW: u32 = 0x0800_0000;
         cmd.creation_flags(CREATE_NO_WINDOW);
     }

--- a/crates/mori-tauri/src/annuli_supervisor.rs
+++ b/crates/mori-tauri/src/annuli_supervisor.rs
@@ -103,7 +103,6 @@ impl AnnuliSupervisor {
 
         #[cfg(target_os = "windows")]
         {
-            use std::os::windows::process::CommandExt;
             const CREATE_NO_WINDOW: u32 = 0x0800_0000;
             cmd.creation_flags(CREATE_NO_WINDOW);
         }

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -2236,6 +2236,153 @@ async fn sync_supervisor_to_config(state: &AppState, cfg: &annuli_config::Annuli
     *state.annuli_supervisor.lock() = Some(sup);
 }
 
+fn annuli_supervisor_snapshot(state: &AppState) -> annuli_supervisor::SupervisorInfo {
+    state
+        .annuli_supervisor
+        .lock()
+        .as_ref()
+        .map(|s| s.info.clone())
+        .unwrap_or(annuli_supervisor::SupervisorInfo {
+            state: "none",
+            annuli_root: None,
+            python: None,
+            port: None,
+            reason: "supervisor has not settled yet".into(),
+        })
+}
+
+fn apply_annuli_config_to_state(
+    state: &AppState,
+    annuli_cfg: &annuli_config::AnnuliConfig,
+) -> Result<String, String> {
+    if annuli_cfg.is_ready() {
+        let client = mori_core::annuli::AnnuliClient::new(annuli_cfg.to_client_config())
+            .map_err(|e| format!("build annuli client: {e:#}"))?;
+        let client = Arc::new(client);
+        let store: Arc<dyn mori_core::memory::MemoryStore> = Arc::new(
+            mori_core::memory::annuli::AnnuliMemoryStore::new(client.clone()),
+        );
+        *state.memory.write() = store;
+        *state.annuli.write() = Some(client);
+        tracing::info!(
+            endpoint = %annuli_cfg.endpoint,
+            spirit = %annuli_cfg.spirit_name,
+            user_id = %annuli_cfg.user_id,
+            "annuli hot-reload -> AnnuliMemoryStore"
+        );
+        Ok(format!(
+            "reloaded: annuli enabled @ {} (spirit={}, user_id={})",
+            annuli_cfg.endpoint, annuli_cfg.spirit_name, annuli_cfg.user_id
+        ))
+    } else {
+        let memory_root = mori_core::memory::markdown::LocalMarkdownMemoryStore::default_root()
+            .map_err(|e| format!("locate ~/.mori/memory: {e:#}"))?;
+        let store = mori_core::memory::markdown::LocalMarkdownMemoryStore::new(memory_root.clone())
+            .map_err(|e| format!("init LocalMarkdown store: {e:#}"))?;
+        *state.memory.write() = Arc::new(store);
+        *state.annuli.write() = None;
+        tracing::info!(
+            path = %memory_root.display(),
+            "annuli hot-reload -> LocalMarkdownMemoryStore (annuli disabled)"
+        );
+        Ok(format!(
+            "reloaded: annuli disabled, fallback LocalMarkdown @ {}",
+            memory_root.display()
+        ))
+    }
+}
+
+#[tauri::command]
+fn annuli_supervisor_status(
+    state: tauri::State<'_, Arc<AppState>>,
+) -> annuli_supervisor::SupervisorInfo {
+    annuli_supervisor_snapshot(&state)
+}
+
+#[tauri::command]
+fn annuli_supervisor_stop(
+    app: AppHandle,
+    state: tauri::State<'_, Arc<AppState>>,
+) -> Result<String, String> {
+    let cur_state = state
+        .annuli_supervisor
+        .lock()
+        .as_ref()
+        .map(|s| s.info.state);
+    match cur_state {
+        Some("spawned") | Some("spawned-not-ready") => {
+            *state.annuli_supervisor.lock() = None;
+            let _ = app.emit(
+                "annuli-supervisor-changed",
+                serde_json::json!({ "from": "supervisor_stop" }),
+            );
+            Ok("stopped Mori-managed Annuli process".into())
+        }
+        Some("already-running") => Err(
+            "Annuli is an external process on this port; Mori will not stop it. Stop that process manually, then restart from Mori."
+                .into(),
+        ),
+        Some(other) => Ok(format!("no Mori-managed Annuli process to stop (state={other})")),
+        None => Ok("no Annuli supervisor process is registered yet".into()),
+    }
+}
+
+#[tauri::command]
+async fn annuli_supervisor_resync_restart(
+    app: AppHandle,
+    state: tauri::State<'_, Arc<AppState>>,
+) -> Result<String, String> {
+    let config_path = mori_core::llm::groq::GroqProvider::bootstrap_mori_config()
+        .map_err(|e| format!("locate config.json: {e:#}"))?;
+    if ensure_annuli_config_soul_token(&config_path).is_some() {
+        tracing::info!(path = %config_path.display(), "annuli control: filled missing token");
+    }
+    let annuli_cfg = annuli_config::AnnuliConfig::load(&config_path);
+    if !annuli_cfg.is_ready() {
+        return Err(
+            "Annuli config is not ready; enable Annuli and set endpoint/spirit/user_id first"
+                .into(),
+        );
+    }
+    if !annuli_cfg.soul_token.trim().is_empty() {
+        sync_annuli_env_soul_token(&annuli_cfg.soul_token)?;
+    }
+
+    apply_annuli_config_to_state(&state, &annuli_cfg)?;
+
+    let cur_state = state
+        .annuli_supervisor
+        .lock()
+        .as_ref()
+        .map(|s| s.info.state);
+    if matches!(cur_state, Some("already-running")) {
+        let external_still_alive =
+            match mori_core::annuli::AnnuliClient::new(annuli_cfg.to_client_config()) {
+                Ok(client) => client.health().await.map(|h| h.ok).unwrap_or(false),
+                Err(_) => false,
+            };
+        if external_still_alive {
+            return Err(
+                "Annuli is already running as an external process. Token was synced, but Mori cannot restart it; stop the external process first."
+                    .into(),
+            );
+        }
+    }
+
+    *state.annuli_supervisor.lock() = None;
+    let sup = annuli_supervisor::AnnuliSupervisor::maybe_spawn(&annuli_cfg).await;
+    let info = sup.info.clone();
+    *state.annuli_supervisor.lock() = Some(sup);
+    let _ = app.emit(
+        "annuli-supervisor-changed",
+        serde_json::json!({ "from": "supervisor_resync_restart" }),
+    );
+    Ok(format!(
+        "Annuli supervisor state={} ({})",
+        info.state, info.reason
+    ))
+}
+
 /// 偵測 annuli runtime 在不在。
 /// - Windows install build:`%USERPROFILE%\.mori\annuli\.venv\Scripts\python.exe`
 /// - Linux/macOS dev layout:`~/mori-universe/annuli/.venv/bin/python`
@@ -2340,6 +2487,47 @@ fn sync_annuli_env_soul_token(token: &str) -> Result<String, String> {
     Ok(format!("ANNULI_SOUL_TOKEN 已存在於 {}", env_path.display()))
 }
 
+fn ensure_annuli_config_soul_token(config_path: &std::path::Path) -> Option<String> {
+    let mut json: serde_json::Value = std::fs::read_to_string(config_path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())?;
+    let annuli = json.get_mut("annuli")?.as_object_mut()?;
+    if annuli
+        .get("soul_token")
+        .and_then(|v| v.as_str())
+        .map(|s| !s.trim().is_empty())
+        .unwrap_or(false)
+    {
+        return None;
+    }
+
+    let token = read_annuli_env_soul_token().unwrap_or_else(generate_soul_token);
+    annuli.insert("soul_token".to_string(), serde_json::json!(token.clone()));
+    if let Err(e) = sync_annuli_env_soul_token(&token) {
+        tracing::warn!(error = %e, "annuli token migration: sync .env failed");
+    }
+    match serde_json::to_string_pretty(&json)
+        .map_err(|e| e.to_string())
+        .and_then(|text| std::fs::write(config_path, text).map_err(|e| e.to_string()))
+    {
+        Ok(()) => {
+            tracing::info!(
+                path = %config_path.display(),
+                "annuli token migration: filled missing annuli.soul_token"
+            );
+            Some(token)
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                path = %config_path.display(),
+                "annuli token migration: write config failed"
+            );
+            None
+        }
+    }
+}
+
 /// 一鍵啟用 annuli(DepsTab 裝完後給 user 的「直接打開」入口)。流程:
 /// 1. 驗 runtime 已裝(否則早回 err)
 /// 2. 寫 `annuli.enabled = true` + sane defaults(endpoint / spirit_name / user_id /
@@ -2380,10 +2568,16 @@ async fn annuli_quick_enable(
         .ok_or_else(|| "config.json /annuli 不是 object".to_string())?;
     a.insert("enabled".to_string(), serde_json::json!(true));
     let str_empty = |a: &serde_json::Map<String, serde_json::Value>, k: &str| -> bool {
-        a.get(k).and_then(|v| v.as_str()).map(|s| s.is_empty()).unwrap_or(true)
+        a.get(k)
+            .and_then(|v| v.as_str())
+            .map(|s| s.is_empty())
+            .unwrap_or(true)
     };
     if str_empty(a, "endpoint") {
-        a.insert("endpoint".to_string(), serde_json::json!("http://localhost:5000"));
+        a.insert(
+            "endpoint".to_string(),
+            serde_json::json!("http://localhost:5000"),
+        );
     }
     if str_empty(a, "spirit_name") {
         a.insert("spirit_name".to_string(), serde_json::json!("mori"));
@@ -2405,8 +2599,7 @@ async fn annuli_quick_enable(
             .to_string()
     };
     let env_sync_msg = sync_annuli_env_soul_token(&token)?;
-    std::fs::create_dir_all(mori_dir())
-        .map_err(|e| format!("mkdir ~/.mori: {e}"))?;
+    std::fs::create_dir_all(mori_dir()).map_err(|e| format!("mkdir ~/.mori: {e}"))?;
     std::fs::write(
         &config_path,
         serde_json::to_string_pretty(&json).map_err(|e| format!("serialize: {e}"))?,
@@ -2416,13 +2609,16 @@ async fn annuli_quick_enable(
     // 3. Reload AnnuliClient / store(同 annuli_reload 的 if-ready 分支)
     let annuli_cfg = annuli_config::AnnuliConfig::load(&config_path);
     if !annuli_cfg.is_ready() {
-        return Err("config 寫好了但 is_ready=false — endpoint/spirit/user_id 還是空(不該發生)".into());
+        return Err(
+            "config 寫好了但 is_ready=false — endpoint/spirit/user_id 還是空(不該發生)".into(),
+        );
     }
     let client = mori_core::annuli::AnnuliClient::new(annuli_cfg.to_client_config())
         .map_err(|e| format!("build annuli client: {e:#}"))?;
     let client = Arc::new(client);
-    let store: Arc<dyn mori_core::memory::MemoryStore> =
-        Arc::new(mori_core::memory::annuli::AnnuliMemoryStore::new(client.clone()));
+    let store: Arc<dyn mori_core::memory::MemoryStore> = Arc::new(
+        mori_core::memory::annuli::AnnuliMemoryStore::new(client.clone()),
+    );
     *state.memory.write() = store;
     *state.annuli.write() = Some(client.clone());
 
@@ -2444,7 +2640,9 @@ async fn annuli_quick_enable(
         "annuli-supervisor-changed",
         serde_json::json!({ "from": "quick_enable" }),
     );
-    Ok(format!("✓ Annuli 已啟用。{info_msg}。{env_sync_msg}。{token_health_msg}"))
+    Ok(format!(
+        "✓ Annuli 已啟用。{info_msg}。{env_sync_msg}。{token_health_msg}"
+    ))
 }
 
 /// C — annuli 熱重載 command。
@@ -2463,42 +2661,7 @@ async fn annuli_reload(state: tauri::State<'_, Arc<AppState>>) -> Result<String,
     let config_path = mori_core::llm::groq::GroqProvider::bootstrap_mori_config()
         .map_err(|e| format!("locate config.json: {e:#}"))?;
     let annuli_cfg = annuli_config::AnnuliConfig::load(&config_path);
-
-    let result_msg = if annuli_cfg.is_ready() {
-        let client = mori_core::annuli::AnnuliClient::new(annuli_cfg.to_client_config())
-            .map_err(|e| format!("build annuli client: {e:#}"))?;
-        let client = Arc::new(client);
-        let store: Arc<dyn mori_core::memory::MemoryStore> = Arc::new(
-            mori_core::memory::annuli::AnnuliMemoryStore::new(client.clone()),
-        );
-        *state.memory.write() = store;
-        *state.annuli.write() = Some(client);
-        tracing::info!(
-            endpoint = %annuli_cfg.endpoint,
-            spirit = %annuli_cfg.spirit_name,
-            user_id = %annuli_cfg.user_id,
-            "annuli hot-reload → AnnuliMemoryStore"
-        );
-        format!(
-            "reloaded: annuli enabled @ {} (spirit={}, user_id={})",
-            annuli_cfg.endpoint, annuli_cfg.spirit_name, annuli_cfg.user_id
-        )
-    } else {
-        let memory_root = mori_core::memory::markdown::LocalMarkdownMemoryStore::default_root()
-            .map_err(|e| format!("locate ~/.mori/memory: {e:#}"))?;
-        let store = mori_core::memory::markdown::LocalMarkdownMemoryStore::new(memory_root.clone())
-            .map_err(|e| format!("init LocalMarkdown store: {e:#}"))?;
-        *state.memory.write() = Arc::new(store);
-        *state.annuli.write() = None;
-        tracing::info!(
-            path = %memory_root.display(),
-            "annuli hot-reload → LocalMarkdownMemoryStore (annuli disabled)"
-        );
-        format!(
-            "reloaded: annuli disabled, fallback LocalMarkdown @ {}",
-            memory_root.display()
-        )
-    };
+    let result_msg = apply_annuli_config_to_state(&state, &annuli_cfg)?;
 
     // 把 supervisor 對齊 config(enable→啟動 / disable→殺我們 spawn 的 child)
     sync_supervisor_to_config(&state, &annuli_cfg).await;
@@ -5779,6 +5942,10 @@ fn main() {
     if !annuli_section_present && annuli_runtime_installed() {
         if let Some(cfg_path) = &config_path {
             let default_uid = pick_annuli_user_id_default(cfg_path);
+            let token = read_annuli_env_soul_token().unwrap_or_else(generate_soul_token);
+            if let Err(e) = sync_annuli_env_soul_token(&token) {
+                tracing::warn!(error = %e, "annuli auto-detect: sync .env token failed");
+            }
             let mut json: serde_json::Value = std::fs::read_to_string(cfg_path)
                 .ok()
                 .and_then(|s| serde_json::from_str(&s).ok())
@@ -5791,6 +5958,7 @@ fn main() {
                         "endpoint": "http://localhost:5000",
                         "spirit_name": "mori",
                         "user_id": default_uid,
+                        "soul_token": token,
                     }),
                 );
                 if let Ok(text) = serde_json::to_string_pretty(&json) {
@@ -5809,6 +5977,13 @@ fn main() {
                 }
             }
             annuli_cfg = annuli_config::AnnuliConfig::load(cfg_path);
+        }
+    }
+    if annuli_cfg.enabled && annuli_cfg.soul_token.trim().is_empty() && annuli_runtime_installed() {
+        if let Some(cfg_path) = &config_path {
+            if ensure_annuli_config_soul_token(cfg_path).is_some() {
+                annuli_cfg = annuli_config::AnnuliConfig::load(cfg_path);
+            }
         }
     }
     let annuli_cfg = annuli_cfg; // 從這之後 immutable
@@ -6117,6 +6292,9 @@ fn main() {
             wake_word_restart_listener,
             annuli_runtime_installed,
             annuli_quick_enable,
+            annuli_supervisor_status,
+            annuli_supervisor_stop,
+            annuli_supervisor_resync_restart,
             notification_config::get_notification_config,
             notification_config::set_notification_config,
             correction_audit_config::get_correction_audit_config,

--- a/crates/mori-tauri/tauri.conf.json
+++ b/crates/mori-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Mori",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "identifier": "ai.yazelin.mori",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mori-desktop",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mori-desktop",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mori-desktop",
   "private": true,
-  "version": "0.7.4",
+  "version": "0.7.5",
   "type": "module",
   "scripts": {
     "predev": "cargo build -p mori-cli && node scripts/stage-mori-cli-for-bundle.mjs debug",

--- a/src/MainShell.tsx
+++ b/src/MainShell.tsx
@@ -11,6 +11,7 @@
 // - 每個 tab 一個 React component;只 mount 當前選中的 tab,避免重複 IPC
 
 import { useEffect, useState, type ComponentType, type SVGProps } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useTranslation } from "react-i18next";
 import ChatPanel from "./ChatPanel";
@@ -74,19 +75,17 @@ function MainShell() {
   // 空 → 不顯示(老 user 沒過 Quickstart 也不會看到亂跳)。
   const [userName, setUserName] = useState<string>("");
   useEffect(() => {
-    import("@tauri-apps/api/core").then(({ invoke }) =>
-      invoke<string>("config_read")
-        .then((text) => {
-          try {
-            const cfg = JSON.parse(text);
-            const n = (cfg?.user?.name ?? "") as string;
-            if (typeof n === "string") setUserName(n.trim());
-          } catch {
-            // 不擋
-          }
-        })
-        .catch(() => {}),
-    );
+    invoke<string>("config_read")
+      .then((text) => {
+        try {
+          const cfg = JSON.parse(text);
+          const n = (cfg?.user?.name ?? "") as string;
+          if (typeof n === "string") setUserName(n.trim());
+        } catch {
+          // 不擋
+        }
+      })
+      .catch(() => {});
   }, [quickstartOpen]); // Quickstart 關閉後重抓(user 改名後即時反映)
 
   useEffect(() => {

--- a/src/tabs/AnnuliTab.tsx
+++ b/src/tabs/AnnuliTab.tsx
@@ -35,6 +35,14 @@ type AnnuliStatus = {
   error: string | null;
 };
 
+type SupervisorInfo = {
+  state: string;
+  annuli_root: string | null;
+  python: string | null;
+  port: number | null;
+  reason: string;
+};
+
 type MemorySection = {
   header: string;
   index: number;
@@ -70,10 +78,13 @@ function previewData(json: string, max = 80): string {
 export default function AnnuliTab() {
   const { t } = useTranslation();
   const [status, setStatus] = useState<AnnuliStatus | null>(null);
+  const [supervisor, setSupervisor] = useState<SupervisorInfo | null>(null);
   const [soul, setSoul] = useState<string | null>(null);
   const [sections, setSections] = useState<MemorySection[]>([]);
   const [events, setEvents] = useState<AnnuliEvent[]>([]);
   const [loading, setLoading] = useState(false);
+  const [controlBusy, setControlBusy] = useState<"stop" | "restart" | null>(null);
+  const [controlMsg, setControlMsg] = useState<string | null>(null);
   const [sleepBusy, setSleepBusy] = useState(false);
   const [sleepResult, setSleepResult] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
@@ -88,6 +99,7 @@ export default function AnnuliTab() {
     try {
       const st = await invoke<AnnuliStatus>("annuli_status");
       setStatus(st);
+      invoke<SupervisorInfo>("annuli_supervisor_status").then(setSupervisor).catch(() => {});
       if (!st.configured || !st.reachable) {
         setSoul(null);
         setSections([]);
@@ -126,6 +138,7 @@ export default function AnnuliTab() {
     const id = setInterval(() => {
       // 只 refresh status / events,不重 fetch SOUL / sections(那兩個基本不變)
       invoke<AnnuliStatus>("annuli_status").then(setStatus).catch(() => {});
+      invoke<SupervisorInfo>("annuli_supervisor_status").then(setSupervisor).catch(() => {});
       invoke<AnnuliEvent[]>("annuli_list_events_today").then(setEvents).catch(() => {});
     }, 30_000);
     return () => clearInterval(id);
@@ -140,12 +153,32 @@ export default function AnnuliTab() {
       // 等 supervisor 跑(spawn + health-check 最多 15s),再 refresh
       setTimeout(() => {
         refresh();
+        invoke<SupervisorInfo>("annuli_supervisor_status").then(setSupervisor).catch(() => {});
         invoke<boolean>("annuli_runtime_installed").then(setRuntimeInstalled).catch(() => {});
       }, 2000);
     } catch (e) {
       setEnableMsg(`❌ ${String(e)}`);
     } finally {
       setEnableBusy(false);
+    }
+  };
+
+  const runControl = async (kind: "stop" | "restart") => {
+    setControlBusy(kind);
+    setControlMsg(null);
+    try {
+      const command = kind === "stop" ? "annuli_supervisor_stop" : "annuli_supervisor_resync_restart";
+      const out = await invoke<string>(command);
+      setControlMsg(out);
+      setTimeout(() => {
+        refresh();
+        invoke<SupervisorInfo>("annuli_supervisor_status").then(setSupervisor).catch(() => {});
+      }, kind === "restart" ? 2000 : 300);
+    } catch (e) {
+      setControlMsg(`Error: ${String(e)}`);
+      invoke<SupervisorInfo>("annuli_supervisor_status").then(setSupervisor).catch(() => {});
+    } finally {
+      setControlBusy(null);
     }
   };
 
@@ -260,6 +293,52 @@ export default function AnnuliTab() {
           </div>
         )}
       </div>
+
+      <section className="mori-annuli-section">
+        <h2 className="mori-annuli-section-title">Annuli process</h2>
+        <div className="mori-annuli-status">
+          <div className="mori-annuli-status-main">
+            supervisor: <code>{supervisor?.state ?? "loading"}</code>
+            {supervisor?.port ? <> · port: <code>{supervisor.port}</code></> : null}
+          </div>
+          <div className="mori-annuli-status-sub">
+            {supervisor?.reason ?? "checking supervisor state"}
+          </div>
+          {supervisor?.annuli_root && (
+            <div className="mori-annuli-status-sub">
+              root: <code>{supervisor.annuli_root}</code>
+            </div>
+          )}
+          {supervisor?.state === "already-running" && (
+            <div className="mori-annuli-status-err">
+              This Annuli process was not started by Mori. Stop the external process first if you want Mori to restart it with the synced token.
+            </div>
+          )}
+          <div className="mori-annuli-sleep-row">
+            <button
+              className="mori-btn"
+              onClick={() => runControl("restart")}
+              disabled={controlBusy !== null || !status.configured}
+              title="Sync config/.env token, then restart Mori-managed Annuli"
+            >
+              {controlBusy === "restart" ? "Restarting..." : "Sync token & restart"}
+            </button>
+            <button
+              className="mori-btn"
+              onClick={() => runControl("stop")}
+              disabled={controlBusy !== null}
+              title="Stop only the Annuli process spawned by Mori"
+            >
+              {controlBusy === "stop" ? "Stopping..." : "Stop Mori-managed Annuli"}
+            </button>
+            {controlMsg && (
+              <div className={`mori-annuli-sleep-result ${controlMsg.startsWith("Error:") ? "bad" : ""}`}>
+                {controlMsg}
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
 
       {/* Sleep button */}
       <div className="mori-annuli-sleep-row">

--- a/src/tabs/ConfigTab.tsx
+++ b/src/tabs/ConfigTab.tsx
@@ -14,6 +14,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { emit, listen } from "@tauri-apps/api/event";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { useTranslation } from "react-i18next";
+import { setLocale } from "../i18n";
 import { listThemes, setActiveTheme, themesDir, loadActiveTheme, type ThemeEntry } from "../theme";
 import { Select } from "../Select";
 import {
@@ -1957,7 +1958,7 @@ function ConfigTab({
                 onChange={(v) => {
                   applyPatch((c) => setStrOrUndef(c, "locale", v));
                   // 立即切 i18next(不用等 save 才看到)
-                  import("../i18n").then((m) => m.setLocale(v as "zh-TW" | "en")).catch(() => {});
+                  setLocale(v as "zh-TW" | "en").catch(() => {});
                 }}
                 options={[
                   { value: "zh-TW", label: "繁體中文 (zh-TW)" },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,4 +31,7 @@ export default defineConfig({
       ],
     },
   },
+  build: {
+    chunkSizeWarningLimit: 700,
+  },
 });


### PR DESCRIPTION
## Summary
- Add Annuli process controls in the Annuli tab
- Bump app/workspace version to v0.7.5
- Update changelog and README latest release note

## Verified
- npm run build
- cargo test -p mori-core --lib
- cargo check --workspace --all-targets

## Notes
- The local bash verifier hit a Windows PATH issue for cargo, so the verifier steps were run individually in the working shell and passed.