### PR TITLE
feat(bi-0): MoriPack artifact handoff — Body Interface 第一刀

### DIFF
--- a/crates/mori-core/src/body/artifact.rs
+++ b/crates/mori-core/src/body/artifact.rs
@@ -1,0 +1,159 @@
+//! Body Interface 的 semantic artifact envelope。
+//!
+//! 對應 `docs/mori-body-interface.md` §Semantic schema 的 `MoriArtifactMetadata`
+//! 與 `docs/moripack-integration.md` 的 Artifact Contract。raw 內容留在來源,
+//! 這個 envelope 只描述「它是什麼、在哪、能對它做什麼」。
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use uuid::Uuid;
+
+/// character pack artifact 的 kind 常數。
+pub const KIND_CHARACTER_PACK: &str = "mori.character-pack";
+
+/// 一個可在 body part 之間 handoff 的 artifact 的 metadata。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MoriArtifact {
+    pub artifact_id: String,
+    /// 開放詞彙的 kind,例如 `mori.character-pack`。
+    pub kind: String,
+    pub path: String,
+    pub visibility: Visibility,
+    pub mime: String,
+    pub suggested_actions: Vec<SuggestedAction>,
+}
+
+/// 資料可見度。對應 body-interface 的 data policy。BI-0 只用到 `Local`,
+/// 其餘三層是鎖定契約的一部分,先列出(schema 保留,非 build)。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Visibility {
+    Local,
+    Public,
+    Internal,
+    Private,
+}
+
+/// Mori 對這個 artifact 建議可做的動作。BI-0 只有 character pack 的三個。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SuggestedAction {
+    Validate,
+    Import,
+    Activate,
+}
+
+impl MoriArtifact {
+    /// 產生帶新 id 的 artifact envelope。
+    pub fn new(
+        kind: impl Into<String>,
+        path: impl Into<String>,
+        visibility: Visibility,
+        mime: impl Into<String>,
+        suggested_actions: Vec<SuggestedAction>,
+    ) -> Self {
+        Self {
+            artifact_id: format!("artifact_{}", Uuid::new_v4().simple()),
+            kind: kind.into(),
+            path: path.into(),
+            visibility,
+            mime: mime.into(),
+            suggested_actions,
+        }
+    }
+}
+
+/// 看一個本機檔案路徑,判斷 Mori 認不認得它、能對它做什麼。
+/// 認得 → artifact envelope;不認得 → `None`。
+///
+/// BI-0 只認 character pack(`.moripack.zip` / `.moripack` / `.zip`)。
+/// 真正的內容驗證仍在 import 時做(manifest / required sprites / zip-slip)。
+pub fn classify_artifact(path: &Path) -> Option<MoriArtifact> {
+    let name = path.file_name()?.to_str()?.to_ascii_lowercase();
+    if name.ends_with(".moripack.zip") || name.ends_with(".moripack") || name.ends_with(".zip") {
+        return Some(MoriArtifact::new(
+            KIND_CHARACTER_PACK,
+            path.to_string_lossy().into_owned(),
+            Visibility::Local,
+            "application/zip",
+            vec![
+                SuggestedAction::Validate,
+                SuggestedAction::Import,
+                SuggestedAction::Activate,
+            ],
+        ));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn artifact_serializes_to_doc_contract_shape() {
+        let a = MoriArtifact {
+            artifact_id: "character_pack_001".into(),
+            kind: KIND_CHARACTER_PACK.into(),
+            path: "/tmp/mori.moripack.zip".into(),
+            visibility: Visibility::Local,
+            mime: "application/zip".into(),
+            suggested_actions: vec![
+                SuggestedAction::Validate,
+                SuggestedAction::Import,
+                SuggestedAction::Activate,
+            ],
+        };
+        let v: serde_json::Value = serde_json::to_value(&a).unwrap();
+        assert_eq!(v["kind"], "mori.character-pack");
+        assert_eq!(v["visibility"], "local");
+        assert_eq!(
+            v["suggested_actions"],
+            serde_json::json!(["validate", "import", "activate"])
+        );
+        let back: MoriArtifact = serde_json::from_value(v).unwrap();
+        assert_eq!(back, a);
+    }
+
+    #[test]
+    fn new_generates_prefixed_unique_id() {
+        let a = MoriArtifact::new(
+            KIND_CHARACTER_PACK,
+            "/x.zip",
+            Visibility::Local,
+            "application/zip",
+            vec![],
+        );
+        let b = MoriArtifact::new(
+            KIND_CHARACTER_PACK,
+            "/y.zip",
+            Visibility::Local,
+            "application/zip",
+            vec![],
+        );
+        assert!(a.artifact_id.starts_with("artifact_"));
+        assert_ne!(a.artifact_id, b.artifact_id);
+    }
+
+    #[test]
+    fn classify_recognizes_moripack_zip() {
+        let a = classify_artifact(Path::new("/home/u/Downloads/mori.moripack.zip")).unwrap();
+        assert_eq!(a.kind, KIND_CHARACTER_PACK);
+        assert_eq!(a.visibility, Visibility::Local);
+        assert_eq!(a.mime, "application/zip");
+        assert_eq!(a.path, "/home/u/Downloads/mori.moripack.zip");
+        assert!(a.suggested_actions.contains(&SuggestedAction::Activate));
+    }
+
+    #[test]
+    fn classify_recognizes_plain_zip_and_moripack_ext() {
+        assert!(classify_artifact(Path::new("/x/pack.zip")).is_some());
+        assert!(classify_artifact(Path::new("/x/pack.moripack")).is_some());
+    }
+
+    #[test]
+    fn classify_rejects_unknown_extension() {
+        assert!(classify_artifact(Path::new("/x/notes.txt")).is_none());
+        assert!(classify_artifact(Path::new("/x/no-extension")).is_none());
+    }
+}

--- a/crates/mori-core/src/body/artifact.rs
+++ b/crates/mori-core/src/body/artifact.rs
@@ -66,10 +66,13 @@ impl MoriArtifact {
 /// 看一個本機檔案路徑,判斷 Mori 認不認得它、能對它做什麼。
 /// 認得 → artifact envelope;不認得 → `None`。
 ///
+/// **Extension-based candidate detection only** — 只看副檔名,不讀檔案內容。
 /// BI-0 只認 character pack(`.moripack.zip` / `.moripack` / `.zip`)。
-/// 真正的內容驗證仍在 import 時做(manifest / required sprites / zip-slip)。
-/// `.zip` 是 speculative 接受(任何 zip 都可能是角色包);真正的內容驗證
-/// (manifest / required sprites / zip-slip)在 import 時做,會濾掉誤判。
+///
+/// 真正的內容驗證分兩層:
+/// - inspect 層(`inspect_artifact` Tauri command):peek zip 確認 `manifest.json` 存在,
+///   拒絕無 manifest 的一般 zip,確保 UI 呈現真實。
+/// - import 層(`import_zip`):完整 manifest schema + 6 required sprites + zip-slip 防護。
 pub fn classify_artifact(path: &Path) -> Option<MoriArtifact> {
     let name = path.file_name()?.to_str()?.to_ascii_lowercase();
     if name.ends_with(".moripack.zip") || name.ends_with(".moripack") || name.ends_with(".zip") {

--- a/crates/mori-core/src/body/artifact.rs
+++ b/crates/mori-core/src/body/artifact.rs
@@ -68,6 +68,8 @@ impl MoriArtifact {
 ///
 /// BI-0 只認 character pack(`.moripack.zip` / `.moripack` / `.zip`)。
 /// 真正的內容驗證仍在 import 時做(manifest / required sprites / zip-slip)。
+/// `.zip` 是 speculative 接受(任何 zip 都可能是角色包);真正的內容驗證
+/// (manifest / required sprites / zip-slip)在 import 時做,會濾掉誤判。
 pub fn classify_artifact(path: &Path) -> Option<MoriArtifact> {
     let name = path.file_name()?.to_str()?.to_ascii_lowercase();
     if name.ends_with(".moripack.zip") || name.ends_with(".moripack") || name.ends_with(".zip") {
@@ -155,5 +157,11 @@ mod tests {
     fn classify_rejects_unknown_extension() {
         assert!(classify_artifact(Path::new("/x/notes.txt")).is_none());
         assert!(classify_artifact(Path::new("/x/no-extension")).is_none());
+    }
+
+    #[test]
+    fn classify_is_case_insensitive() {
+        assert!(classify_artifact(Path::new("/x/PACK.ZIP")).is_some());
+        assert!(classify_artifact(Path::new("/x/Mori.MoriPack.Zip")).is_some());
     }
 }

--- a/crates/mori-core/src/body/mod.rs
+++ b/crates/mori-core/src/body/mod.rs
@@ -1,0 +1,9 @@
+//! Body Interface — Mori universe 各身體部件接入 Mori 的 semantic 契約。
+//! 見 `docs/mori-body-interface.md`。BI-0 只放 artifact;BI-1+ 再加
+//! manifest / event / permission / cue 等型別。
+
+pub mod artifact;
+
+pub use artifact::{
+    classify_artifact, MoriArtifact, SuggestedAction, Visibility, KIND_CHARACTER_PACK,
+};

--- a/crates/mori-core/src/lib.rs
+++ b/crates/mori-core/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod agent;
 pub mod agent_profile;
 pub mod annuli;
+pub mod body;
 pub mod context;
 pub mod correction_audit;
 pub mod correction_inbox;

--- a/crates/mori-tauri/src/character_pack.rs
+++ b/crates/mori-tauri/src/character_pack.rs
@@ -324,6 +324,19 @@ pub fn import_zip(zip_bytes: &[u8]) -> Result<CharacterEntry> {
     })
 }
 
+/// 輕量確認一個檔案是不是角色包候選:能當 zip 打開且裡面有 `manifest.json`。
+/// 不做完整 schema / sprite 驗證(那是 import_zip 的事),只回答「值不值得當角色包對待」。
+pub fn zip_has_character_manifest(path: &std::path::Path) -> bool {
+    let Ok(file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let Ok(mut archive) = zip::ZipArchive::new(file) else {
+        return false;
+    };
+    let has_manifest = archive.by_name("manifest.json").is_ok();
+    has_manifest
+}
+
 fn validate_manifest(m: &CharacterManifest) -> Result<()> {
     if !m.schema_version.starts_with("1.") {
         anyhow::bail!(
@@ -512,5 +525,41 @@ mod tests {
         // 但 backup 階段已執行(若 ~/.mori/characters/test-pack/ 存在會 rename)— 在 CI / test env 通常不存在,OK。
         let res = import_zip(&zip_bytes);
         assert!(res.is_err(), "should reject path traversal");
+    }
+
+    // ── zip_has_character_manifest tests ────────────────────────────────────
+
+    #[test]
+    fn zip_has_character_manifest_returns_true_when_manifest_present() {
+        let m = make_valid_manifest();
+        let zip_bytes = build_zip_with(&m, &[], &[]);
+        let tmp = tempfile::TempDir::new().unwrap();
+        let zip_path = tmp.path().join("pack.zip");
+        std::fs::write(&zip_path, &zip_bytes).unwrap();
+        assert!(super::zip_has_character_manifest(&zip_path));
+    }
+
+    #[test]
+    fn zip_has_character_manifest_returns_false_when_manifest_absent() {
+        let mut buf = Vec::new();
+        {
+            let mut w = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+            let opts: zip::write::SimpleFileOptions = Default::default();
+            w.start_file("some_other_file.txt", opts).unwrap();
+            w.write_all(b"no manifest here").unwrap();
+            w.finish().unwrap();
+        }
+        let tmp = tempfile::TempDir::new().unwrap();
+        let zip_path = tmp.path().join("no_manifest.zip");
+        std::fs::write(&zip_path, &buf).unwrap();
+        assert!(!super::zip_has_character_manifest(&zip_path));
+    }
+
+    #[test]
+    fn zip_has_character_manifest_returns_false_for_non_zip_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let fake_path = tmp.path().join("not_a_zip.zip");
+        std::fs::write(&fake_path, b"not a zip").unwrap();
+        assert!(!super::zip_has_character_manifest(&fake_path));
     }
 }

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -2184,6 +2184,15 @@ fn character_dir() -> String {
         .to_string()
 }
 
+/// BI-0:看一個本機檔案,回傳 Mori 認得的 artifact envelope(目前只有 character
+/// pack)。認不得回 Err,讓 UI 顯示「Mori 不認得這個檔案」並讓使用者取消。
+/// 這是 Body Interface「handoff 要可見、可取消」原則的入口。
+#[tauri::command]
+fn inspect_artifact(path: String) -> Result<mori_core::body::MoriArtifact, String> {
+    mori_core::body::classify_artifact(std::path::Path::new(&path))
+        .ok_or_else(|| format!("Mori 不認得這個檔案:{path}"))
+}
+
 /// C — annuli 熱重載 command。
 ///
 /// 流程:
@@ -6278,6 +6287,7 @@ fn main() {
             character_pack_import_zip,
             character_sprite_data_url,
             character_dir,
+            inspect_artifact,
             file_loader_cmd::read_file_text_cmd,
             reminders_cmd::remind_me_cmd,
             reminders_cmd::list_reminders_cmd,

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -2189,8 +2189,15 @@ fn character_dir() -> String {
 /// 這是 Body Interface「handoff 要可見、可取消」原則的入口。
 #[tauri::command]
 fn inspect_artifact(path: String) -> Result<mori_core::body::MoriArtifact, String> {
-    mori_core::body::classify_artifact(std::path::Path::new(&path))
-        .ok_or_else(|| format!("Mori 不認得這個檔案:{path}"))
+    let p = std::path::Path::new(&path);
+    let artifact = mori_core::body::classify_artifact(p)
+        .ok_or_else(|| format!("Mori 不認得這個檔案:{path}"))?;
+    if artifact.kind == mori_core::body::KIND_CHARACTER_PACK
+        && !crate::character_pack::zip_has_character_manifest(p)
+    {
+        return Err(format!("這個檔案不是角色包(zip 裡找不到 manifest.json):{path}"));
+    }
+    Ok(artifact)
 }
 
 /// C — annuli 熱重載 command。

--- a/docs/body-interface-backlog.md
+++ b/docs/body-interface-backlog.md
@@ -1,0 +1,147 @@
+# Body Interface 實作 Backlog
+
+> **狀態**:decisions locked(2026-05-27 — A1 / B1 / D1 採用,章節名暫掛 placeholder)。**這是 build-now 的執行線,不是再一份架構文件。**
+> **目的**:把四份 body-interface 系列決議收斂成「一條可執行、有順序、有依賴」的實作
+> backlog;統一編號;畫清「現在做 vs 北極星」;並列出需要 yazelin 拍板的決定點。
+> **上游決議**(都已 freeze):
+> - [Mori Instance Direction](mori-instance-direction.md) — 最高層北極星
+> - [Mori Body Interface](mori-body-interface.md) — 核心契約(manifest / provisioning / transport / permission / ingestion)
+> - [MoriPack Integration](moripack-integration.md) — 第一個 artifact-first 樣板
+> - [Meeting Recorder](meeting-recorder.md) — 第一個要「移出」的獨立部件
+
+---
+
+## 0. 為什麼有這份文件
+
+四份決議定義的是**架構與契約**,不是**順序**。它們各自暗示了不同的起手順序,而且彼此
+對不上(見 [§3 順序收斂](#3-順序收斂a)）。同時 repo 裡已經有三套並存的編號
+(`Wave` / `Phase` / 詩意章節),進度永遠對不上。
+
+這份文件做四件事:
+
+1. **畫線**:build-now(desktop body parts)vs 北極星(robot / fleet / ROS2,只影響設計、現在不做)。
+2. **收斂順序**:把三份文件互相打架的順序收成一條 canonical sequence。
+3. **統一編號**:本軌一律用 `BI-N`(Body Interface stage N)。
+4. **列決定點**:把需要 yazelin 拍板的 A / B / D 列成勾選清單。
+
+---
+
+## 1. 範圍紀律 — build-now vs 北極星(決定 E)
+
+> 這套架構橫跨到 AGV / 捷運站 / 機器人車隊。**當北極星極好**(讓今天的每個決定都不會
+> 結構性擋住未來);但**接下來幾個月的實作必須狠狠限縮在 desktop body parts**。最大的
+> 風險是「在 0 個實作時,先把通用層(registry / broker / ROS2 schema)蓋滿」。
+
+| 層 | 例子 | 現在的態度 |
+|---|---|---|
+| **Build now** | MoriPack 整合、Body Registry(讀)、最小 Permission Broker、Agent Plus observer、Cue surface、Meeting Recorder | **做**,但每個都 standalone-first、最小可用 |
+| **設計影響、現在不做** | manifest 的 transport-agnostic 結構、ingestion-as-log-level 欄位 | schema **保留欄位**,但只實作 HTTP/SSE/CLI binding 與 desktop 需要的部分 |
+| **北極星(不寫 code)** | Mori Instance identity model、Mori Hub envelope、ROS2/DDS adapter、Zenoh bus、多 Mori fleet、robot perception/actuation、safety controller | **不做**。只當「新功能設計時的對照」,確保不畫死未來 |
+
+**判準**:一個欄位 / 抽象,如果現在沒有 ≥1 個真實 desktop body part 會用到,就**不實作**,
+最多在 schema 裡保留位置 + 註明 `reserved`。
+
+---
+
+## 2. 編號收斂(決定 C)
+
+| 舊編號 | 出處 | 之後怎麼處理 |
+|---|---|---|
+| `Wave 1-8` | 2026-05 大爆發 + 各 stream | **歷史**。已 ship,不再新增 Wave 編號 |
+| `Wave 0-5`(annuli 軌)| `implementation/CHECKLIST.md` | annuli 對接軌,Wave 4 done、Wave 5(creator 拆 repo)延後。**獨立軌,不混進本文件** |
+| `Phase 0-5`(body-interface)| `mori-body-interface.md` Migration Plan | 對應到本文件 `BI-N`,該文件保留為「契約」,本文件是「執行順序」 |
+| 詩意章節 | `roadmap.md` | 高層願景視圖。本軌的章節名 **待 yazelin 命名**(見下) |
+
+**本軌一律用 `BI-N`。** 詩意章節名我不自己發明(專有名詞 / 詩意命名是你的領域)——
+暫掛 placeholder「**眾身之森**」(Mori 可以有很多身體 / 身體部件如林),你要改隨你改。
+
+---
+
+## 3. 順序收斂(決定 A)
+
+三份文件的順序對照:
+
+| 文件 | 它暗示的順序 |
+|---|---|
+| `body-interface` Migration Plan | Registry → **Agent Plus** → Permission Broker → **Meeting Recorder** → Multi-session |
+| `moripack` 移出/移入(L276-313)| MoriPack → **Meeting Recorder** → **Agent Plus** → connectors → Mori Ear |
+| `instance-direction` Near-term(L597-606)| schema/provisioning → **Meeting Recorder** → **Agent Plus** → registry/cue shell |
+
+**真矛盾**:`body-interface` 把 Agent Plus 排在 Meeting Recorder **前**;另兩份排在 **後**。
+
+**我的建議解(待你確認)= 採 `body-interface` 的順序,理由:**
+
+1. **Agent Plus 是 observe-only**(只讀 session 狀態、發 cue),風險遠低於 Meeting Recorder 的 `audio.capture`。低風險的先做,讓契約在安全的部件上成熟。
+2. **Agent Plus 對你個人 ROI 最高**:你每天在跑 Codex / Claude / Gemini session,「哪個在等輸入 / 跑完了 / 卡住」直接有用。
+3. **Meeting Recorder 需要 Permission Broker + audio policy**,這些應該先存在(解掉決定 B)。
+4. **MoriPack 第一刀**是 `body-interface` 自己列的 Phase 0 sample(L1010),零權限、runtime 已存在,大家都同意。
+
+> ⚠️ 這推翻了 `moripack` / `instance-direction` 把 Meeting Recorder 排第二的寫法。
+> 如果你**主觀上最想先要 Meeting Recorder**(它可能是你最有感的功能),這是你的偏好
+> 拍板權 —— 見 [§5 決定點 B](#5-決定點請-yazelin-勾)。
+
+---
+
+## 4. Canonical Backlog(BI-0 → BI-6 + 北極星)
+
+> 每個 stage 標:**驗證什麼契約** / **依賴** / **repo** / **build-now?**。
+> 順序是依賴排出來的,不是拍腦袋。
+
+| Stage | 範圍 | 驗證的契約 | 依賴 | repo | tag |
+|---|---|---|---|---|---|
+| **BI-0** | **MoriPack artifact-first 整合**:Appearance UI 加 Open Studio / Import / Validate / Activate,把 `.moripack.zip` 正式建模成 artifact handoff envelope(`artifact_id/kind/path/visibility/suggested_actions`)| **Artifact handoff** 那半 | 無(character pack runtime + sprite studio #107 已存在)| mori-desktop | ✅ now |
+| **BI-1** | **Body Registry(讀)**:manifest reader(`~/.mori/body-parts/*/manifest.json` + `<repo>/.mori-body/`)+ body list/health UI,read-only,**不執行任何高風險操作**。把 BI-0 的 MoriPack 回填成第一個 registered manifest | **Discovery + manifest v1** | BI-0(有真實 manifest 可註冊)| mori-desktop | ✅ now |
+| **BI-2** | **Permission Broker(最小版)**:permission request schema + allow/deny/ask + audit log。**刻意提前到 Meeting Recorder 之前**(解決定 B)| **Permission** envelope | BI-1 | mori-desktop | ✅ now |
+| **BI-3** | **Agent Plus(observer)**:獨立 repo/sidecar,提供 manifest + `/sessions` + `/events`(SSE);偵測 waiting_input/done/failed。Desktop 顯示 session list + **最小 cue surface** | **Event stream + cue** | BI-1, BI-2 | 新 repo + mori-desktop | ✅ now |
+| **BI-4** | **Cue Center**:把 BI-3 的 cue surface 升級成可操作(acknowledge / snooze / jump / dismiss)| Cue lifecycle | BI-3 | mori-desktop | ✅ now |
+| **BI-5** | **Meeting Recorder standalone**:依 [meeting-recorder.md](meeting-recorder.md),standalone-first repo;Desktop 只做 launch / recent sessions / public·internal artifact handoff。**此時 broker + event + handoff 都已就緒** | 整套契約合流(audio + 敏感資料邊界 + ingestion policy)| BI-1, BI-2, BI-4 | 新 repo + mori-desktop | ✅ now(大)|
+| **BI-6** | **Multi-session / Schedule**:Session Registry、Schedule Manager、sub-agent launcher | 編排層 | BI-3, BI-4 | mori-desktop | 🟡 later |
+| **北極星** | Mori Instance identity model、Hub envelope、ROS2/DDS/Zenoh adapter、多 Mori fleet、robot perception/actuation/safety gate | — | — | — | ⭐ 不做,只別擋 |
+
+### 各 stage 的「完成判準」(避免 scope 漂)
+
+- **BI-0 done** = 能從 Appearance 開 Studio → 匯入 zip → 驗證(zip-slip / manifest / required sprites)→ 套用 → floating sprite reload;且匯入流程內部走的是**正式 artifact envelope**(不是隨手寫的 import 函式),這樣才真的驗到契約。
+- **BI-1 done** = Desktop 掃到 ≥1 個 manifest(含 BI-0 的 MoriPack)並顯示 install/health,**完全不能**觸發任何 write/exec。
+- **BI-2 done** = 有一條 fake 高風險請求被 broker 攔下並寫 audit log;allow/deny/ask 三路徑都有 test。
+- **BI-3 done** = 跑一個 Codex session,Desktop 能收到 waiting_input / done cue(不重複)。
+- **BI-5 done** = 依 meeting-recorder.md 的 e2e,public/internal 軌分流 + handoff 不自動讀 private raw audio。
+
+---
+
+## 5. 決定點(已鎖定 2026-05-27)
+
+> yazelin 2026-05-27 拍板:A1 / B1 / D1。章節名暫留 placeholder。
+
+### A — Agent Plus vs Meeting Recorder 先後
+
+- [x] **A1(採用)**:採 `body-interface` 順序 = Agent Plus(BI-3)先,Meeting Recorder(BI-5)後。
+- [ ] ~~A2:Meeting Recorder 拉前~~
+
+### B — Permission Broker 時機
+
+- [x] **B1(採用)**:Broker 當 BI-2,**在任何 `audio.capture` 部件之前**就位。
+- [ ] ~~B2:Broker 延後 + 簡化 consent~~
+
+### D — manifest v1 範圍
+
+- [x] **D1(採用)**:v1 欄位**只放** desktop 前 2 個部件(MoriPack / Agent Plus)真正需要的:`id / kind / entrypoints / interfaces(http·sse·cli)/ capabilities / permissions / data_policy`。`zenoh/ros2/dds` binding 與 robot 欄位**只在 schema 保留、標 `reserved`、不實作**。
+- [ ] ~~D2:v1 就做全 binding~~
+
+### 章節命名
+
+- [ ] 詩意章節名:暫掛 placeholder「**眾身之森**」,yazelin 之後決定是否改名(你的領域,我不自作主張)。
+
+---
+
+## 6. 跟既有文件的關係
+
+- 本文件 = body-interface 軌的**執行順序 + 進度**(類似 annuli 軌的 `implementation/CHECKLIST.md`,但分開)。
+- `mori-body-interface.md` / 其餘三份 = **契約 source of truth**,不因本文件改動。
+- `roadmap.md` =高層詩意願景;本軌完成的 stage 之後回填到 roadmap 對應章節。
+- 每個 BI-N 開工前,**先針對該 slice 寫一份聚焦的 implementation plan + TDD**,再動 code(本 backlog 只排順序,不取代 per-slice 的設計)。
+
+---
+
+**Last updated**: 2026-05-27
+**Owner**: yazelin
+**Next action**: 寫 BI-0(MoriPack)per-slice implementation plan → TDD → code

--- a/docs/body-interface-backlog.md
+++ b/docs/body-interface-backlog.md
@@ -100,7 +100,7 @@
 
 ### 各 stage 的「完成判準」(避免 scope 漂)
 
-- **BI-0 done** = 能從 Appearance 開 Studio → 匯入 zip → 驗證(zip-slip / manifest / required sprites)→ 套用 → floating sprite reload;且匯入流程內部走的是**正式 artifact envelope**(不是隨手寫的 import 函式),這樣才真的驗到契約。
+- **BI-0 done** ✅(2026-05-27,branch `feat/bi-0-artifact-handoff`,待 Task 4 手測 + merge)= 能從 Appearance 開 Studio → 匯入 zip → 驗證(zip-slip / manifest / required sprites)→ 套用 → floating sprite reload;且匯入前走正式 `mori_core::body::MoriArtifact` envelope(`inspect_artifact`),handoff 可見可取消。
 - **BI-1 done** = Desktop 掃到 ≥1 個 manifest(含 BI-0 的 MoriPack)並顯示 install/health,**完全不能**觸發任何 write/exec。
 - **BI-2 done** = 有一條 fake 高風險請求被 broker 攔下並寫 audit log;allow/deny/ask 三路徑都有 test。
 - **BI-3 done** = 跑一個 Codex session,Desktop 能收到 waiting_input / done cue(不重複)。

--- a/docs/moripack-integration.md
+++ b/docs/moripack-integration.md
@@ -322,6 +322,12 @@ Body Interface、permission、audio policy 成熟後再移出。
 - 是否要支援 signed official packs?
 - 是否要讓 World Tree / public gallery 成為 character pack catalog?
 
+## 實作進度(BI-0)
+
+- ✅ Phase 1 manual artifact handoff(Open Studio / Import / Validate / Activate / reload)— #107 已落地。
+- ✅ Artifact envelope 正式化:`mori_core::body::MoriArtifact` + `classify_artifact` + `inspect_artifact` command;匯入前顯示可見、可取消的 handoff(BI-0,branch `feat/bi-0-artifact-handoff`)。
+- ⏳ Phase 2 custom URL(`mori://character-pack/import`)、Phase 3 local API — 未做(YAGNI,等需求)。
+
 ## 下一步
 
 1. 保留 [Character Pack 規範](character-pack.md) 作為 zip / manifest source of truth。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -253,6 +253,11 @@ input 格式跟 voice transcript 對接。
   [Meeting Recorder 決議](meeting-recorder.md)。mori-desktop 後續只做低耦合整合,
   再接 LLM 整理 action items 與 Annuli `knowledge/` 保存。
 
+> 📋 以上 Body Interface 系列(Instance Direction / Body Interface / MoriPack /
+> Meeting Recorder)的**實作順序、依賴鏈與進度**收斂在
+> [Body Interface 實作 Backlog](body-interface-backlog.md)(`BI-0…BI-6` + 北極星)。
+> 本段是願景描述;要動工看那份 backlog。
+
 ---
 
 ## 更遠

--- a/docs/superpowers/plans/2026-05-27-bi-0-moripack-artifact-handoff.md
+++ b/docs/superpowers/plans/2026-05-27-bi-0-moripack-artifact-handoff.md
@@ -1,0 +1,542 @@
+# BI-0 MoriPack Artifact Handoff Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把已存在的 character pack 匯入流程，正式建模成 Body Interface 的 **artifact handoff envelope**，並讓 handoff「可見、可取消」——使 MoriPack 成為 Body Interface 第一個被驗證的 artifact-first 樣板。
+
+**Architecture:** 新增一個平台無關的 semantic 型別 `MoriArtifact`（對應 `docs/mori-body-interface.md` §Semantic schema 的 `MoriArtifactMetadata`）放在 `mori-core`，加一個純函式 `classify_artifact(path)` 把本機檔案分類成 artifact。`mori-tauri` 加一個 `inspect_artifact` command 讓前端在匯入**前**先看到「這是什麼 / 能做什麼」，使用者確認後才走既有的 `character_pack_import_zip`。**不建** generic artifact dispatcher / registry（只有一種 kind，那是 BI-1+ 的事，YAGNI）。
+
+**Tech Stack:** Rust（mori-core / mori-tauri，serde + uuid + tauri command）、React/TS（ConfigTab `CharacterPicker`）。
+
+**Scope guardrails（來自 backlog 決定 D1 + §1 範圍紀律）:**
+- `MoriArtifact` 欄位**只放** doc contract 需要的：`artifact_id / kind / path / visibility / mime / suggested_actions`。
+- 不做 ROS2/Zenoh binding、不做 manifest reader、不做 permission broker（那些是 BI-1 / BI-2）。
+- 既有的 import / validate / activate / reload **不重寫**，只在它前面接上 artifact inspection + 可見 handoff。
+
+**Spec sources:** `docs/moripack-integration.md`（Artifact Contract L76-112、Desktop Integration Flow L114-152）、`docs/body-interface-backlog.md`（BI-0 row + 完成判準）、`docs/mori-body-interface.md`（§Semantic schema L342-354、§Artifact Handoff L467-481「所有 handoff 都要可見、可取消」）。
+
+---
+
+## File Structure
+
+| 檔案 | 責任 | 動作 |
+|---|---|---|
+| `crates/mori-core/src/body/mod.rs` | Body Interface semantic 型別的 module root（BI-0 只放 artifact）| Create |
+| `crates/mori-core/src/body/artifact.rs` | `MoriArtifact` / `Visibility` / `SuggestedAction` / `classify_artifact` + 測試 | Create |
+| `crates/mori-core/src/lib.rs` | 宣告 `pub mod body;` | Modify(`:14` 後插一行）|
+| `crates/mori-tauri/src/main.rs` | `inspect_artifact` command + 註冊 | Modify(command 加在 character 區附近、`invoke_handler!` 加一行）|
+| `src/tabs/ConfigTab.tsx` | `CharacterPicker`：pick → inspect → 可見/可取消 handoff → confirm import | Modify(`MoriArtifact` interface + 改 `onImport` 拆兩段 + handoff panel）|
+| `docs/moripack-integration.md` | §下一步 標 1-3 done + 註明 artifact envelope 已落地 | Modify |
+| `docs/body-interface-backlog.md` | BI-0 row → in-progress/done + 附 manual e2e | Modify |
+
+---
+
+## Task 1: `MoriArtifact` semantic 型別
+
+**Files:**
+- Create: `crates/mori-core/src/body/artifact.rs`
+- Create: `crates/mori-core/src/body/mod.rs`
+- Modify: `crates/mori-core/src/lib.rs:14`(在 `pub mod annuli;` 後插 `pub mod body;`，維持大致字母序）
+
+- [ ] **Step 1: 建 `body/mod.rs`**
+
+```rust
+//! Body Interface — Mori universe 各身體部件接入 Mori 的 semantic 契約。
+//! 見 `docs/mori-body-interface.md`。BI-0 只放 artifact;BI-1+ 再加
+//! manifest / event / permission / cue 等型別。
+
+pub mod artifact;
+
+pub use artifact::{
+    classify_artifact, MoriArtifact, SuggestedAction, Visibility, KIND_CHARACTER_PACK,
+};
+```
+
+- [ ] **Step 2: 在 `body/artifact.rs` 寫 failing test（型別還不存在）**
+
+```rust
+//! Body Interface 的 semantic artifact envelope。
+//!
+//! 對應 `docs/mori-body-interface.md` §Semantic schema 的 `MoriArtifactMetadata`
+//! 與 `docs/moripack-integration.md` 的 Artifact Contract。raw 內容留在來源,
+//! 這個 envelope 只描述「它是什麼、在哪、能對它做什麼」。
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn artifact_serializes_to_doc_contract_shape() {
+        let a = MoriArtifact {
+            artifact_id: "character_pack_001".into(),
+            kind: KIND_CHARACTER_PACK.into(),
+            path: "/tmp/mori.moripack.zip".into(),
+            visibility: Visibility::Local,
+            mime: "application/zip".into(),
+            suggested_actions: vec![
+                SuggestedAction::Validate,
+                SuggestedAction::Import,
+                SuggestedAction::Activate,
+            ],
+        };
+        let v: serde_json::Value = serde_json::to_value(&a).unwrap();
+        assert_eq!(v["kind"], "mori.character-pack");
+        assert_eq!(v["visibility"], "local");
+        assert_eq!(
+            v["suggested_actions"],
+            serde_json::json!(["validate", "import", "activate"])
+        );
+        let back: MoriArtifact = serde_json::from_value(v).unwrap();
+        assert_eq!(back, a);
+    }
+
+    #[test]
+    fn new_generates_prefixed_unique_id() {
+        let a = MoriArtifact::new(
+            KIND_CHARACTER_PACK,
+            "/x.zip",
+            Visibility::Local,
+            "application/zip",
+            vec![],
+        );
+        let b = MoriArtifact::new(
+            KIND_CHARACTER_PACK,
+            "/y.zip",
+            Visibility::Local,
+            "application/zip",
+            vec![],
+        );
+        assert!(a.artifact_id.starts_with("artifact_"));
+        assert_ne!(a.artifact_id, b.artifact_id);
+    }
+}
+```
+
+- [ ] **Step 3: 跑測試確認 fail（編譯不過）**
+
+Run: `cargo test -p mori-core --lib body::artifact`
+Expected: 編譯失敗 —「cannot find type `MoriArtifact`」之類。
+
+- [ ] **Step 4: 在 test mod 上方寫實作**
+
+```rust
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use uuid::Uuid;
+
+/// character pack artifact 的 kind 常數。
+pub const KIND_CHARACTER_PACK: &str = "mori.character-pack";
+
+/// 一個可在 body part 之間 handoff 的 artifact 的 metadata。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MoriArtifact {
+    pub artifact_id: String,
+    /// 開放詞彙的 kind,例如 `mori.character-pack`。
+    pub kind: String,
+    pub path: String,
+    pub visibility: Visibility,
+    pub mime: String,
+    pub suggested_actions: Vec<SuggestedAction>,
+}
+
+/// 資料可見度。對應 body-interface 的 data policy。BI-0 只用到 `Local`,
+/// 其餘三層是鎖定契約的一部分,先列出(schema 保留,非 build)。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Visibility {
+    Local,
+    Public,
+    Internal,
+    Private,
+}
+
+/// Mori 對這個 artifact 建議可做的動作。BI-0 只有 character pack 的三個。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SuggestedAction {
+    Validate,
+    Import,
+    Activate,
+}
+
+impl MoriArtifact {
+    /// 產生帶新 id 的 artifact envelope。
+    pub fn new(
+        kind: impl Into<String>,
+        path: impl Into<String>,
+        visibility: Visibility,
+        mime: impl Into<String>,
+        suggested_actions: Vec<SuggestedAction>,
+    ) -> Self {
+        Self {
+            artifact_id: format!("artifact_{}", Uuid::new_v4().simple()),
+            kind: kind.into(),
+            path: path.into(),
+            visibility,
+            mime: mime.into(),
+            suggested_actions,
+        }
+    }
+}
+```
+
+- [ ] **Step 5: 加 `pub mod body;` 到 `crates/mori-core/src/lib.rs`**
+
+在 `:14`（`pub mod annuli;`）後插入：
+
+```rust
+pub mod body;
+```
+
+- [ ] **Step 6: 跑測試確認 pass**
+
+Run: `cargo test -p mori-core --lib body::artifact`
+Expected: 2 個 test PASS。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/mori-core/src/body crates/mori-core/src/lib.rs
+git commit -m "feat(bi-0): MoriArtifact semantic envelope type in mori-core"
+```
+
+---
+
+## Task 2: `classify_artifact` 分類器
+
+**Files:**
+- Modify: `crates/mori-core/src/body/artifact.rs`(同檔加函式 + 測試）
+
+- [ ] **Step 1: 在 test mod 加 failing test**
+
+加進 `mod tests`：
+
+```rust
+    #[test]
+    fn classify_recognizes_moripack_zip() {
+        let a = classify_artifact(Path::new("/home/u/Downloads/mori.moripack.zip")).unwrap();
+        assert_eq!(a.kind, KIND_CHARACTER_PACK);
+        assert_eq!(a.visibility, Visibility::Local);
+        assert_eq!(a.mime, "application/zip");
+        assert_eq!(a.path, "/home/u/Downloads/mori.moripack.zip");
+        assert!(a.suggested_actions.contains(&SuggestedAction::Activate));
+    }
+
+    #[test]
+    fn classify_recognizes_plain_zip_and_moripack_ext() {
+        assert!(classify_artifact(Path::new("/x/pack.zip")).is_some());
+        assert!(classify_artifact(Path::new("/x/pack.moripack")).is_some());
+    }
+
+    #[test]
+    fn classify_rejects_unknown_extension() {
+        assert!(classify_artifact(Path::new("/x/notes.txt")).is_none());
+        assert!(classify_artifact(Path::new("/x/no-extension")).is_none());
+    }
+```
+
+注意：`Path` 已在實作區 `use std::path::Path;`，test mod 的 `use super::*;` 會帶進來。
+
+- [ ] **Step 2: 跑測試確認 fail**
+
+Run: `cargo test -p mori-core --lib body::artifact`
+Expected: 編譯失敗 —「cannot find function `classify_artifact`」。
+
+- [ ] **Step 3: 在 `impl MoriArtifact` 下方寫實作**
+
+```rust
+/// 看一個本機檔案路徑,判斷 Mori 認不認得它、能對它做什麼。
+/// 認得 → artifact envelope;不認得 → `None`。
+///
+/// BI-0 只認 character pack(`.moripack.zip` / `.moripack` / `.zip`)。
+/// 真正的內容驗證仍在 import 時做(manifest / required sprites / zip-slip)。
+pub fn classify_artifact(path: &Path) -> Option<MoriArtifact> {
+    let name = path.file_name()?.to_str()?.to_ascii_lowercase();
+    if name.ends_with(".moripack.zip") || name.ends_with(".moripack") || name.ends_with(".zip") {
+        return Some(MoriArtifact::new(
+            KIND_CHARACTER_PACK,
+            path.to_string_lossy().into_owned(),
+            Visibility::Local,
+            "application/zip",
+            vec![
+                SuggestedAction::Validate,
+                SuggestedAction::Import,
+                SuggestedAction::Activate,
+            ],
+        ));
+    }
+    None
+}
+```
+
+- [ ] **Step 4: 跑測試確認 pass**
+
+Run: `cargo test -p mori-core --lib body::artifact`
+Expected: 5 個 test 全 PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mori-core/src/body/artifact.rs
+git commit -m "feat(bi-0): classify_artifact recognizes character packs"
+```
+
+---
+
+## Task 3: `inspect_artifact` Tauri command
+
+**Files:**
+- Modify: `crates/mori-tauri/src/main.rs`(command 定義加在 character pack commands 區，約 `:2085-2182`；`invoke_handler!` 在 `:6275` 附近加一行）
+
+> **前置確認**：main.rs 既有對 `mori_core::` 的引用(Wave 4 的 `AnnuliMemoryStore` 等)。動工前先 `grep -n "mori_core::" crates/mori-tauri/src/main.rs | head` 確認 crate 路徑寫法一致（應為 `mori_core::...`）。
+
+- [ ] **Step 1: 加 command 定義**
+
+加在 `character_dir`（約 `:2182`）後面：
+
+```rust
+/// BI-0:看一個本機檔案,回傳 Mori 認得的 artifact envelope(目前只有 character
+/// pack)。認不得回 Err,讓 UI 顯示「Mori 不認得這個檔案」並讓使用者取消。
+/// 這是 Body Interface「handoff 要可見、可取消」原則的入口。
+#[tauri::command]
+fn inspect_artifact(path: String) -> Result<mori_core::body::MoriArtifact, String> {
+    mori_core::body::classify_artifact(std::path::Path::new(&path))
+        .ok_or_else(|| format!("Mori 不認得這個檔案:{path}"))
+}
+```
+
+- [ ] **Step 2: 在 `invoke_handler![...]` 註冊**
+
+在 `:6275` 附近的 `character_dir,` 那行後面加：
+
+```rust
+            inspect_artifact,
+```
+
+- [ ] **Step 3: 編譯確認**
+
+Run: `cargo check -p mori-tauri`
+Expected: 編譯通過（command 簽名與註冊一致）。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/mori-tauri/src/main.rs
+git commit -m "feat(bi-0): inspect_artifact tauri command"
+```
+
+> command 是 thin wrapper，邏輯已在 Task 2 的 `classify_artifact` 被測過；wrapper 行為在 Task 4 的 manual e2e 一起驗。
+
+---
+
+## Task 4: 前端 — 可見/可取消的 handoff
+
+**Files:**
+- Modify: `src/tabs/ConfigTab.tsx`（`MoriArtifact` interface + 改 `CharacterPicker` 的 `onImport` 為兩段 + handoff panel）
+
+> 此 task 走 **integration + manual verify**：ConfigTab 目前無 vitest 測試，且流程重度依賴 Tauri `invoke`/`openDialog`（repo 對 UI 的慣例是手測，見 CLAUDE.md「Manual test 等 yazelin」）。契約邏輯已在 Rust Task 1-2 用 TDD 守住。
+
+- [ ] **Step 1: 加 `MoriArtifact` TS interface**
+
+在 ConfigTab.tsx 模組頂部、`MORI_SPRITE_STUDIO_URL`(約 `:40`)附近加：
+
+```typescript
+interface MoriArtifact {
+  artifact_id: string;
+  kind: string;
+  path: string;
+  visibility: string;
+  mime: string;
+  suggested_actions: string[];
+}
+```
+
+- [ ] **Step 2: 在 `CharacterPicker` 加 pending handoff state**
+
+在 `const [importError, setImportError] = useState<string | null>(null);`(`:513`)後加：
+
+```typescript
+  const [pending, setPending] = useState<MoriArtifact | null>(null);
+```
+
+- [ ] **Step 3: 把 `onImport`(`:547-568`)換成「pick → inspect」**
+
+整段 `onImport` 改成 `onPickFile`：
+
+```typescript
+  const onPickFile = async () => {
+    const selected = await openDialog({
+      multiple: false,
+      filters: [{ name: "Mori character pack", extensions: ["zip", "moripack"] }],
+    });
+    if (!selected || typeof selected !== "string") return;
+    setImportError(null);
+    try {
+      const artifact = await invoke<MoriArtifact>("inspect_artifact", { path: selected });
+      setPending(artifact); // 顯示可見、可取消的 handoff 確認，先不動 vault/角色
+    } catch (e: any) {
+      setImportError(String(e));
+    }
+  };
+
+  const onConfirmImport = async () => {
+    if (!pending) return;
+    setImporting(true);
+    setImportError(null);
+    try {
+      const entry = await invoke<CharacterEntry>("character_pack_import_zip", {
+        zipPath: pending.path,
+      });
+      await refresh();
+      setActive(entry.stem);
+      setMsg(`✅ 已匯入:${entry.display_name} by ${entry.author}`);
+      setTimeout(() => setMsg(null), 4000);
+      setPending(null);
+    } catch (e: any) {
+      setImportError(String(e));
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const onCancelImport = () => {
+    setPending(null);
+    setImportError(null);
+  };
+```
+
+- [ ] **Step 4: 改匯入按鈕的 onClick + 加 handoff panel**
+
+把 `:608-610` 的匯入按鈕 onClick 從 `onImport` 改成 `onPickFile`：
+
+```tsx
+            <button className="mori-btn" onClick={onPickFile} disabled={importing || busy}>
+              {importing ? "匯入中…" : "匯入 .moripack.zip"}
+            </button>
+```
+
+並在 `importError` 區塊(`:616-620`)之前插入 handoff 確認 panel：
+
+```tsx
+          {pending && (
+            <div
+              style={{
+                border: "1px solid var(--c-border)",
+                borderRadius: 8,
+                padding: 10,
+                display: "flex",
+                flexDirection: "column",
+                gap: 8,
+                fontSize: 12,
+              }}
+            >
+              <div>
+                Mori 認得這個檔案:<strong>角色包</strong>(<code>{pending.kind}</code>)
+              </div>
+              <div style={{ opacity: 0.8 }}>
+                可見度:{pending.visibility} · 可做:{pending.suggested_actions.join(" → ")}
+              </div>
+              <div style={{ opacity: 0.6, wordBreak: "break-all" }}>{pending.path}</div>
+              <div style={{ display: "flex", gap: 8 }}>
+                <button className="mori-btn" onClick={onConfirmImport} disabled={importing}>
+                  {importing ? "匯入中…" : "確認匯入並套用"}
+                </button>
+                <button className="mori-btn ghost" onClick={onCancelImport} disabled={importing}>
+                  取消
+                </button>
+              </div>
+            </div>
+          )}
+```
+
+- [ ] **Step 5: build + 既有測試不破**
+
+Run: `npm run build && npm test`
+Expected: build 成功；vitest 既有 `shellTabs.test.ts` / `FloatingMori.test.ts` 全綠（無回歸）。
+
+- [ ] **Step 6: Manual verify(BI-0 e2e — happy path)**
+
+```bash
+npm run tauri dev
+```
+1. 開 Config → Floating/Appearance section 找到角色匯入。
+2. 點「匯入 .moripack.zip」→ 選一個 Sprite Studio 匯出的 `.moripack.zip`。
+3. **預期出現 handoff panel**：顯示「角色包(mori.character-pack)· 可做:validate → import → activate · <path>」+「確認匯入並套用 / 取消」。
+4. 點「取消」→ panel 消失,**角色沒變**(驗 handoff 可取消)。
+5. 重來,點「確認匯入並套用」→ 匯入成功訊息 → floating Mori sprite 即時 reload 成新角色(驗既有 `character-changed` 仍 work)。
+6. 選一個非 zip 檔(若 dialog filter 擋住,可暫時放寬 filter 測 `inspect_artifact` 的 Err 路徑)→ 預期顯示「Mori 不認得這個檔案」,不進匯入。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/tabs/ConfigTab.tsx
+git commit -m "feat(bi-0): visible/cancellable character-pack handoff via inspect_artifact"
+```
+
+---
+
+## Task 5: 文件收尾 + backlog 進度
+
+**Files:**
+- Modify: `docs/moripack-integration.md`(§下一步 L327-330）
+- Modify: `docs/body-interface-backlog.md`(BI-0 row + 附 manual e2e）
+
+- [ ] **Step 1: 標 moripack 文件的 Phase 1 進度**
+
+在 `docs/moripack-integration.md` §下一步(L325 起)上方加一段狀態：
+
+```markdown
+## 實作進度(BI-0)
+
+- ✅ Phase 1 manual artifact handoff(Open Studio / Import / Validate / Activate / reload)— #107 已落地。
+- ✅ Artifact envelope 正式化:`mori_core::body::MoriArtifact` + `classify_artifact` + `inspect_artifact` command;匯入前顯示可見、可取消的 handoff(BI-0)。
+- ⏳ Phase 2 custom URL(`mori://character-pack/import`)、Phase 3 local API — 未做(YAGNI,等需求)。
+```
+
+- [ ] **Step 2: 更新 backlog BI-0 row 狀態**
+
+在 `docs/body-interface-backlog.md` §4 表格的 BI-0 row 後，於 §4 末尾「各 stage 的完成判準」區把 **BI-0 done** 那條改成已勾：
+
+```markdown
+- **BI-0 done** ✅(2026-05-27)= 能從 Appearance 開 Studio → 匯入 zip → 驗證 → 套用 → reload;且匯入前走正式 `MoriArtifact` envelope（`inspect_artifact`），handoff 可見可取消。
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/moripack-integration.md docs/body-interface-backlog.md
+git commit -m "docs(bi-0): mark MoriPack artifact handoff done + backlog progress"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage**（對 `moripack-integration.md` + backlog BI-0）：
+- Artifact Contract（artifact_id/kind/path/visibility/mime/suggested_actions）→ Task 1 ✓
+- 認得 `.moripack.zip` → Task 2 ✓
+- Desktop flow：開 Studio(已存在)/ Import / Validate / Activate / reload → 既有 + Task 4 confirm ✓
+- 「handoff 要可見、可取消」(body-interface §481)→ Task 4 handoff panel + 取消 ✓
+- 「匯入流程內部走正式 artifact envelope」(backlog 完成判準)→ Task 3 `inspect_artifact` 回 `MoriArtifact`，Task 4 前端據它走 ✓
+- 本地驗證不信任外部 Studio（zip-slip / manifest / required sprites）→ 既有 `character_pack::import_zip` 不動，仍生效 ✓
+
+**2. Placeholder scan:** 無 TBD / 「適當處理」/ 空 test。每個 code step 都有完整 code。✓
+（唯一外部依賴：Task 3 的 `mori_core::` 路徑寫法 — 已加前置 grep 確認步驟，非 placeholder。）
+
+**3. Type consistency:** `MoriArtifact` 欄位（Rust snake_case ↔ TS interface 同名）一致；`Visibility`/`SuggestedAction` 走 `#[serde(rename_all="lowercase")]` ↔ TS 端用 `string` 收 lowercase；command 名 `inspect_artifact` 在 Rust 定義 / 註冊 / 前端 `invoke` 三處一致；既有 `character_pack_import_zip` 參數 `zipPath`、回傳 `CharacterEntry` 沿用不變。✓
+
+**4. 範圍紀律複查:** 沒有 generic dispatcher / registry / manifest reader / permission broker / 非 HTTP transport。只引入 1 個 semantic 型別 + 1 個分類器 + 1 個 thin command + 前端可見 handoff。符合 D1 與 backlog §1。✓
+
+---
+
+## 全套驗證(收工前)
+
+```bash
+bash scripts/verify.sh
+```
+預設涵蓋:`npm run build` / `npm test`(vitest)/ `cargo test -p mori-core --lib`(含 `body::artifact` 5 test)/ `cargo test -p mori-tauri --bin mori-tauri` / `cargo check --workspace --all-targets`。
+
+---
+
+**Plan saved:** `docs/superpowers/plans/2026-05-27-bi-0-moripack-artifact-handoff.md`
+**Branch 建議:** `feat/bi-0-artifact-handoff`(對齊 repo 慣例)

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^4.3.4",
         "typescript": "~5.7",
-        "vite": "^6"
+        "vite": "^6",
+        "vitest": "^4.1.7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1166,6 +1167,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
@@ -1447,6 +1455,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1502,11 +1528,134 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.27",
@@ -1576,6 +1725,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1614,6 +1773,13 @@
       "integrity": "sha512-9D7Iqx8RImSvCnOsj86rCH6eQjZFQoM04Jn6HnZVM0Nu/G58/gmKYQ1d12MZTbjQbQSTGI8nwEy07ErsA2slLA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1665,6 +1831,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1802,6 +1988,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1832,6 +2028,24 @@
       "version": "2.0.38",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2003,6 +2217,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2011,6 +2232,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -2028,6 +2280,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -2159,6 +2421,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -2166,6 +2518,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "prebuild": "cargo build -p mori-cli --release && node scripts/stage-mori-cli-for-bundle.mjs release",
     "build": "tsc -b && vite build",
+    "test": "vitest run",
     "preview": "vite preview",
     "tauri": "tauri",
     "dev:restart": "bash scripts/restart-dev.sh"
@@ -28,6 +29,7 @@
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4.3.4",
     "typescript": "~5.7",
-    "vite": "^6"
+    "vite": "^6",
+    "vitest": "^4.1.7"
   }
 }

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -13,7 +13,11 @@ run() {
 }
 
 run npm run build
+run npm test
 run cargo test -p mori-core --lib
+run cargo test -p mori-time --lib
+run cargo test -p mori-file-loader --lib --tests
+run cargo test -p mori-tauri --bin mori-tauri
 run cargo check --workspace --all-targets
 
 if [ "${VERIFY_STRICT:-0}" = "1" ]; then

--- a/src/FloatingMori.test.ts
+++ b/src/FloatingMori.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { spriteStyle, visualFor } from "./FloatingMori";
+
+const manifest = {
+  schema_version: "1.2",
+  package_name: "mori",
+  display_name: "Mori",
+  states: ["idle", "recording", "thinking", "done", "error"],
+  sprite_spec: {
+    format: "png",
+    grid: "4x4",
+    total_size: "1024x1024",
+    frame_size: "256x256",
+    frame_order: "row-major",
+    background: "transparent",
+  },
+  loop_durations_ms: {
+    idle: 1200,
+  },
+};
+
+describe("Floating Mori visual state", () => {
+  it("keeps background mode sleeping regardless of active phase", () => {
+    expect(visualFor("background", { kind: "recording", started_at_ms: 1 }, null, false, false)).toBe("sleeping");
+  });
+
+  it("prioritizes transient and drag states before phase visuals", () => {
+    expect(visualFor("agent", { kind: "idle" }, "done", false, true)).toBe("done");
+    expect(visualFor("agent", { kind: "idle" }, null, false, true)).toBe("dragging");
+  });
+
+  it("uses walking only for idle wander mode", () => {
+    expect(visualFor("agent", { kind: "idle" }, null, true, false)).toBe("walking");
+    expect(visualFor("agent", { kind: "responding", transcript: "hi" }, null, true, false)).toBe("thinking");
+  });
+});
+
+describe("Floating Mori sprite style", () => {
+  it("falls back to a static public sprite before IPC sprite data arrives", () => {
+    expect(spriteStyle("idle", undefined, manifest, true)).toMatchObject({
+      backgroundImage: 'url("/floating/mori-idle.png")',
+      backgroundSize: "100% 100%",
+      backgroundRepeat: "no-repeat",
+    });
+  });
+
+  it("freezes 4x4 sprites on frame one when animation is disabled", () => {
+    expect(spriteStyle("idle", "data:image/png;base64,abc", manifest, false)).toMatchObject({
+      backgroundImage: 'url("data:image/png;base64,abc")',
+      backgroundSize: "400% 400%",
+      backgroundPosition: "0% 0%",
+      backgroundRepeat: "no-repeat",
+    });
+  });
+
+  it("animates 4x4 sprites with paired x/y keyframes when enabled", () => {
+    expect(spriteStyle("idle", "data:image/png;base64,abc", manifest, true)).toMatchObject({
+      animationName: "mori-sprite-x, mori-sprite-y",
+      animationDuration: "300ms, 1200ms",
+      animationTimingFunction: "steps(4, jump-none), steps(4, jump-none)",
+      animationIterationCount: "infinite, infinite",
+    });
+  });
+});

--- a/src/FloatingMori.tsx
+++ b/src/FloatingMori.tsx
@@ -62,7 +62,7 @@ const RIPPLE_LIFETIME_MS = 1200;
 // - 兩軸都 steps(4) jump-end,以 (0, 0) → (-400%, -400%) wrap 回 (0, 0) 完成 loop
 // - 這版簡化 不分 loop / one-shot,全 infinite(commit 4 toggle 時可改)
 // - grid "1x1" → 不跑 animation,純 static
-function spriteStyle(
+export function spriteStyle(
   visual: Visual,
   spriteUrl: string | undefined,
   manifest: CharacterManifest | null,
@@ -107,7 +107,7 @@ function spriteStyle(
   };
 }
 
-function visualFor(
+export function visualFor(
   mode: Mode,
   phase: Phase,
   transient: Visual | null,

--- a/src/MainShell.tsx
+++ b/src/MainShell.tsx
@@ -32,11 +32,7 @@ import {
 import { toggleTheme, loadActiveTheme } from "./theme";
 import { setLocale, nextLocale } from "./i18n";
 import { Quickstart, shouldShowQuickstart } from "./Quickstart";
-
-type NavPayload = { tab: TabId | HiddenTabId; subTab?: string };
-
-type TabId = "chat" | "profiles" | "config" | "memory" | "annuli" | "skills" | "deps" | "logs" | "transcribe" | "recordings" | "corrections";
-type HiddenTabId = "self_dev";
+import { coerceVisibleNavPayload, type NavPayload, type TabId } from "./shellTabs";
 
 type TabDef = {
   id: TabId;
@@ -90,11 +86,10 @@ function MainShell() {
 
   useEffect(() => {
     const u = listen<NavPayload>("mori-nav", (e) => {
-      // Release build 先不把自我開發入口提供給一般使用者。
-      // SelfDevTab 與後端流程仍保留,之後恢復時再加回 sidebar route。
-      if (e.payload.tab === "self_dev") return;
-      setTab(e.payload.tab);
-      setPendingSubTab(e.payload.subTab ?? null);
+      const visibleNav = coerceVisibleNavPayload(e.payload);
+      if (!visibleNav) return;
+      setTab(visibleNav.tab);
+      setPendingSubTab(visibleNav.subTab);
     });
     return () => {
       u.then((fn) => fn()).catch(() => {});

--- a/src/shellTabs.test.ts
+++ b/src/shellTabs.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { coerceVisibleNavPayload, isVisibleTabId, SHELL_TAB_IDS } from "./shellTabs";
+
+describe("shell tab gate", () => {
+  it("keeps the public sidebar tab list free of internal self-dev", () => {
+    expect(SHELL_TAB_IDS).not.toContain("self_dev");
+  });
+
+  it("accepts visible navigation payloads and normalizes missing subTab", () => {
+    expect(coerceVisibleNavPayload({ tab: "config" })).toEqual({
+      tab: "config",
+      subTab: null,
+    });
+    expect(coerceVisibleNavPayload({ tab: "config", subTab: "voice" })).toEqual({
+      tab: "config",
+      subTab: "voice",
+    });
+  });
+
+  it("rejects hidden self-dev navigation events", () => {
+    expect(coerceVisibleNavPayload({ tab: "self_dev" })).toBeNull();
+  });
+
+  it("guards arbitrary string tab ids before state updates", () => {
+    expect(isVisibleTabId("chat")).toBe(true);
+    expect(isVisibleTabId("unknown")).toBe(false);
+  });
+});

--- a/src/shellTabs.ts
+++ b/src/shellTabs.ts
@@ -1,0 +1,40 @@
+export const SHELL_TAB_IDS = [
+  "chat",
+  "profiles",
+  "config",
+  "memory",
+  "annuli",
+  "skills",
+  "deps",
+  "logs",
+  "transcribe",
+  "recordings",
+  "corrections",
+] as const;
+
+export type TabId = (typeof SHELL_TAB_IDS)[number];
+export type HiddenTabId = "self_dev";
+
+export type NavPayload = {
+  tab: TabId | HiddenTabId;
+  subTab?: string;
+};
+
+export type VisibleNavPayload = {
+  tab: TabId;
+  subTab: string | null;
+};
+
+const visibleTabs = new Set<string>(SHELL_TAB_IDS);
+
+export function isVisibleTabId(tab: string): tab is TabId {
+  return visibleTabs.has(tab);
+}
+
+export function coerceVisibleNavPayload(payload: NavPayload): VisibleNavPayload | null {
+  if (!isVisibleTabId(payload.tab)) return null;
+  return {
+    tab: payload.tab,
+    subTab: payload.subTab ?? null,
+  };
+}

--- a/src/tabs/ConfigTab.tsx
+++ b/src/tabs/ConfigTab.tsx
@@ -39,6 +39,15 @@ type CharacterEntry = {
 
 const MORI_SPRITE_STUDIO_URL = "https://mori-sprite-studio.vercel.app/";
 
+interface MoriArtifact {
+  artifact_id: string;
+  kind: string;
+  path: string;
+  visibility: string;
+  mime: string;
+  suggested_actions: string[];
+}
+
 type SaveStatus =
   | { kind: "idle" }
   | { kind: "saving" }
@@ -511,6 +520,7 @@ function CharacterPicker() {
   const [msg, setMsg] = useState<string | null>(null);
   const [importing, setImporting] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
+  const [pending, setPending] = useState<MoriArtifact | null>(null);
 
   const refresh = async () => {
     try {
@@ -544,27 +554,44 @@ function CharacterPicker() {
     }
   };
 
-  const onImport = async () => {
+  const onPickFile = async () => {
     const selected = await openDialog({
       multiple: false,
       filters: [{ name: "Mori character pack", extensions: ["zip", "moripack"] }],
     });
     if (!selected || typeof selected !== "string") return;
+    setImportError(null);
+    try {
+      const artifact = await invoke<MoriArtifact>("inspect_artifact", { path: selected });
+      setPending(artifact); // 顯示可見、可取消的 handoff 確認，先不動 vault/角色
+    } catch (e: any) {
+      setImportError(String(e));
+    }
+  };
+
+  const onConfirmImport = async () => {
+    if (!pending) return;
     setImporting(true);
     setImportError(null);
     try {
       const entry = await invoke<CharacterEntry>("character_pack_import_zip", {
-        zipPath: selected,
+        zipPath: pending.path,
       });
       await refresh();
       setActive(entry.stem);
       setMsg(`✅ 已匯入:${entry.display_name} by ${entry.author}`);
       setTimeout(() => setMsg(null), 4000);
+      setPending(null);
     } catch (e: any) {
       setImportError(String(e));
     } finally {
       setImporting(false);
     }
+  };
+
+  const onCancelImport = () => {
+    setPending(null);
+    setImportError(null);
   };
 
   const onOpenSpriteStudio = () => {
@@ -605,7 +632,7 @@ function CharacterPicker() {
       >
         <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
           <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <button className="mori-btn" onClick={onImport} disabled={importing || busy}>
+            <button className="mori-btn" onClick={onPickFile} disabled={importing || busy}>
               {importing ? "匯入中…" : "匯入 .moripack.zip"}
             </button>
             <button className="mori-btn ghost" onClick={onOpenSpriteStudio}>
@@ -613,6 +640,35 @@ function CharacterPicker() {
             </button>
             {msg && <span style={{ fontSize: 12, opacity: 0.8 }}>{msg}</span>}
           </div>
+          {pending && (
+            <div
+              style={{
+                border: "1px solid var(--c-border)",
+                borderRadius: 8,
+                padding: 10,
+                display: "flex",
+                flexDirection: "column",
+                gap: 8,
+                fontSize: 12,
+              }}
+            >
+              <div>
+                Mori 認得這個檔案:<strong>角色包</strong>(<code>{pending.kind}</code>)
+              </div>
+              <div style={{ opacity: 0.8 }}>
+                可見度:{pending.visibility} · 可做:{pending.suggested_actions.join(" → ")}
+              </div>
+              <div style={{ opacity: 0.6, wordBreak: "break-all" }}>{pending.path}</div>
+              <div style={{ display: "flex", gap: 8 }}>
+                <button className="mori-btn" onClick={onConfirmImport} disabled={importing}>
+                  {importing ? "匯入中…" : "確認匯入並套用"}
+                </button>
+                <button className="mori-btn ghost" onClick={onCancelImport} disabled={importing}>
+                  取消
+                </button>
+              </div>
+            </div>
+          )}
           {importError && (
             <div style={{ color: "rgba(255, 160, 160, 0.95)", fontSize: 12 }}>
               ❌ 匯入失敗:{importError}


### PR DESCRIPTION
## Summary

啟動 **Body Interface 軌**(身體部件 standalone-first 架構)的第一個 slice(BI-0):把 character pack 匯入正式建模成 artifact handoff envelope,讓「認得 / handoff」名副其實。

- **`mori_core::body::MoriArtifact`** — semantic artifact envelope(`artifact_id/kind/path/visibility/mime/suggested_actions`)+ `classify_artifact` 副檔名候選偵測。
- **`inspect_artifact` Tauri command** — peek zip 內 `manifest.json`,確認真的是角色包才認;隨便的 zip 會被擋(不再只看副檔名)。
- **前端** — 匯入前顯示「**可見、可取消**」的 handoff 確認(落實 Body Interface「handoff 要可見可取消」原則),取代原本一選檔就 auto-import。
- **docs** — `body-interface-backlog.md`(BI-0…BI-6 canonical 執行線 + build-now vs 北極星)、BI-0 per-slice plan、moripack/roadmap 進度。

> 範圍紀律(D1):只引入 1 個 semantic 型別 + 候選分類器 + 1 個 thin command + 前端可見 handoff。**沒有** generic dispatcher / registry / permission broker(那些是 BI-1/BI-2)。pack 管理(刪除/匯出/開資料夾)是後續獨立 branch,不在本 PR。

## Test Plan

- [x] mori-core lib:353 passed(含 7 個 artifact 測試)
- [x] mori-tauri bin:162 passed(含 3 個 zip manifest-peek 測試)
- [x] `cargo check --workspace --all-targets`、vitest 10/10、`scripts/verify.sh` 全套綠
- [x] 多輪 review(per-task spec + code quality + final 整體 review)
- [x] 人工 e2e:真 pack → handoff panel → 套用 → floating sprite reload;隨便的 zip → 「不是角色包」被擋;取消不殘留 pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)