### PR TITLE
chore(ui): define missing --c-* color tokens

### DIFF
--- a/crates/mori-tauri/themes/dark.json
+++ b/crates/mori-tauri/themes/dark.json
@@ -6,6 +6,7 @@
     "page-bg": "#1f3329",
     "sidebar-bg": "#172620",
     "surface-bg": "#243a31",
+    "bg": "#243a31",
     "input-bg": "rgba(0, 0, 0, 0.30)",
     "input-focus-bg": "rgba(0, 0, 0, 0.42)",
     "divider": "rgba(230, 222, 202, 0.08)",
@@ -19,6 +20,7 @@
     "sidebar-text": "rgba(243, 240, 230, 0.65)",
     "sidebar-text-active": "rgba(243, 240, 230, 0.98)",
     "sidebar-hover-bg": "rgba(230, 222, 202, 0.05)",
+    "sidebar-active-bg": "rgba(106, 143, 114, 0.22)",
     "active-bg": "rgba(106, 143, 114, 0.22)",
     "active-border": "rgba(168, 197, 162, 0.45)",
     "primary-bg": "rgba(106, 143, 114, 0.28)",
@@ -35,7 +37,10 @@
     "warning-border": "rgba(255, 200, 100, 0.25)",
     "warning-text": "rgba(255, 220, 170, 0.95)",
     "success-bg": "rgba(170, 230, 185, 0.10)",
+    "success-border": "rgba(170, 230, 185, 0.30)",
     "success-text": "rgba(190, 240, 200, 0.95)",
+    "mono-bg": "rgba(168, 197, 162, 0.10)",
+    "mono-border": "rgba(168, 197, 162, 0.25)",
     "mono-color": "rgba(168, 197, 162, 0.92)",
     "kbd-bg": "rgba(230, 222, 202, 0.08)",
     "kbd-border": "rgba(230, 222, 202, 0.18)",
@@ -50,6 +55,8 @@
     "recording-progress-bg": "rgba(106, 143, 114, 0.14)",
     "recording-progress-border": "rgba(168, 197, 162, 0.35)",
     "meter-from": "rgba(106, 143, 114, 0.80)",
-    "meter-to": "rgba(168, 197, 162, 0.90)"
+    "meter-to": "rgba(168, 197, 162, 0.90)",
+    "forest": "#6a8c5a",
+    "forest-light": "#8db077"
   }
 }

--- a/crates/mori-tauri/themes/light.json
+++ b/crates/mori-tauri/themes/light.json
@@ -6,6 +6,7 @@
     "page-bg": "#F3F0E6",
     "sidebar-bg": "#E6DECA",
     "surface-bg": "#FFFFFF",
+    "bg": "#FFFFFF",
     "input-bg": "#FFFFFF",
     "input-focus-bg": "#FFFFFF",
     "divider": "rgba(184, 169, 142, 0.30)",
@@ -19,6 +20,7 @@
     "sidebar-text": "rgba(59, 47, 47, 0.70)",
     "sidebar-text-active": "#2C4A3D",
     "sidebar-hover-bg": "rgba(184, 169, 142, 0.22)",
+    "sidebar-active-bg": "rgba(106, 143, 114, 0.18)",
     "active-bg": "rgba(106, 143, 114, 0.18)",
     "active-border": "rgba(106, 143, 114, 0.55)",
     "primary-bg": "#6A8F72",
@@ -35,7 +37,10 @@
     "warning-border": "rgba(245, 158, 11, 0.45)",
     "warning-text": "#945A0A",
     "success-bg": "rgba(106, 143, 114, 0.12)",
+    "success-border": "rgba(106, 143, 114, 0.55)",
     "success-text": "#2C4A3D",
+    "mono-bg": "rgba(106, 143, 114, 0.10)",
+    "mono-border": "rgba(106, 143, 114, 0.30)",
     "mono-color": "#2C4A3D",
     "kbd-bg": "rgba(184, 169, 142, 0.20)",
     "kbd-border": "rgba(184, 169, 142, 0.55)",
@@ -50,6 +55,8 @@
     "recording-progress-bg": "rgba(106, 143, 114, 0.18)",
     "recording-progress-border": "rgba(106, 143, 114, 0.55)",
     "meter-from": "rgba(106, 143, 114, 0.95)",
-    "meter-to": "rgba(168, 197, 162, 0.95)"
+    "meter-to": "rgba(168, 197, 162, 0.95)",
+    "forest": "#6a8c5a",
+    "forest-light": "#8db077"
   }
 }

--- a/src/shell.css
+++ b/src/shell.css
@@ -9,6 +9,7 @@
   --c-page-bg:             #1f3329;
   --c-sidebar-bg:          #172620;
   --c-surface-bg:          #243a31;
+  --c-bg:                  #243a31;
   --c-input-bg:            rgba(0, 0, 0, 0.30);
   --c-input-focus-bg:      rgba(0, 0, 0, 0.42);
   --c-divider:             rgba(230, 222, 202, 0.08);
@@ -22,6 +23,7 @@
   --c-sidebar-text:        rgba(243, 240, 230, 0.65);
   --c-sidebar-text-active: rgba(243, 240, 230, 0.98);
   --c-sidebar-hover-bg:    rgba(230, 222, 202, 0.05);
+  --c-sidebar-active-bg:   rgba(106, 143, 114, 0.22);
   --c-active-bg:           rgba(106, 143, 114, 0.22);
   --c-active-border:       rgba(168, 197, 162, 0.45);
   --c-primary-bg:          rgba(106, 143, 114, 0.28);
@@ -38,7 +40,10 @@
   --c-warning-border:      rgba(255, 200, 100, 0.25);
   --c-warning-text:        rgba(255, 220, 170, 0.95);
   --c-success-bg:          rgba(170, 230, 185, 0.10);
+  --c-success-border:      rgba(170, 230, 185, 0.30);
   --c-success-text:        rgba(190, 240, 200, 0.95);
+  --c-mono-bg:             rgba(168, 197, 162, 0.10);
+  --c-mono-border:         rgba(168, 197, 162, 0.25);
   --c-mono-color:          rgba(168, 197, 162, 0.92);
   --c-kbd-bg:              rgba(230, 222, 202, 0.08);
   --c-kbd-border:          rgba(230, 222, 202, 0.18);
@@ -57,6 +62,9 @@
   /* level meter gradient */
   --c-meter-from:            rgba(106, 143, 114, 0.80);
   --c-meter-to:              rgba(168, 197, 162, 0.90);
+  /* brand greens — 之前散在 .tsx 用 hex fallback(#6a8c5a / #8db077),提成 token */
+  --c-forest:                #6a8c5a;
+  --c-forest-light:          #8db077;
 }
 
 .mori-shell {
@@ -1720,8 +1728,7 @@
 }
 .mori-pill-badge.tone-success {
   background: var(--c-success-bg);
-  /* palette 沒有 --c-success-border token(warning/danger 才有);dark 用字面值,light 在下方覆寫 */
-  border-color: rgba(170, 230, 185, 0.30);
+  border-color: var(--c-success-border);
   color: var(--c-success-text);
 }
 .mori-pill-badge.tone-warning {


### PR DESCRIPTION
## 補齊缺失的 CSS color token

接 #131(BI-2)review 抓到的 `--c-success-border` 缺口,順手把整個 palette 掃過。`theme.ts::applyTheme()` 只 `setProperty('--c-${key}')`(無 alias),所以 token 只在它是 theme JSON key(或 `:root` fallback)時才存在。審計發現有 7 個 `var(--c-*)` 被引用但兩處都沒定義:

| Token | 狀況 |
|---|---|
| `--c-bg` | `shell.css` ×4 + `chat-panel.css` **裸用無 fallback** → chip 背景變透明(pre-existing bug) |
| `--c-success-border` | palette 不對稱(danger/warning 有 bg+border+text 三件組,success 只有 bg+text)|
| `--c-mono-bg` / `--c-mono-border` | dangling,但只當已定義 token 的 fallback → 死碼 |
| `--c-sidebar-active-bg` | 有 fallback → active 側欄項目其實一直用 hover 色 |
| `--c-forest` / `--c-forest-light` | 品牌綠,之前散在 .tsx 用 hex fallback(`#6a8c5a` / `#8db077`)|

## 改動
- 7 個 token 全定義進 `dark.json` + `light.json` + `shell.css :root`(三處同步,各 55 keys)。
- 品牌綠直接把現有 hex fallback 提成 token(行為不變,現在可 theme 化)。
- `--c-bg` 先 alias 成 `surface-bg`(dark `#243a31` / light `#FFFFFF`)當安全預設 —— 這幾個 chip 之前是透明,沒有「原樣」可對,**值請在 app 裡看一眼再於 theme JSON 微調**。
- BI-2 的 `.mori-pill-badge.tone-success` border 從寫死 rgba 改成 `var(--c-success-border)`(移除 #131 留的 hardcode 註記)。

## 驗證
- `python3 json.load` 兩檔皆 valid;dark/light key parity 一致(55 = 48 + 7)。
- 全 src 掃描:**已無 dangling `var(--c-*)`**(除 theme.ts 的 doc 範例 `--c-xxx`)。
- `bash scripts/verify.sh` 全綠(npm build / mori-core / mori-tauri 175 / workspace check);theme include_str! test 綠。

## Manual(待 yazelin,PR 不靠它)
切深/淺色 + 自訂 theme,確認 chip / badge 背景不再透明、配色一致;若 `--c-bg` 的 surface 預設不合意,改 `themes/*.json` 的 `bg` 值即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)