### PR TITLE
release: v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@
 
 ---
 
+## v0.8.0 — 身體介面(Body Interface)+ STT 委派給 mori-ear(2026-06-04)
+
+把「身體部件」架構(Body Interface, BI-0~5)落地,並把轉錄 / 會議錄音拆給專責 organ,mori-desktop 自身瘦身。
+
+### 新功能
+- **BI-0 MoriArtifact** — 語意化 artifact 信封;角色包(character pack)可視 / 可取消交付 + 管理 UI(匯出 / 刪除)。
+- **BI-1 Body Registry** — 唯讀 Body 分頁,掃描並顯示已註冊的身體部件(BodyManifest)。
+- **BI-2 Permission Broker** — 唯讀 Permissions 分頁(policy + audit);risk policy 評估 + 稽核紀錄。
+- **BI-3 Pulse 分頁** — 接 AgentPulse `/sessions` + `/events` SSE,監看 AI session 活動。
+- **BI-4 Cue Center** — 可操作的 cue surface。
+- **BI-5 Meeting Recorder MVP(Observer Mode)** — 設計落地;實際會議錄音改由獨立的 mori-meeting-recorder 負責。
+
+### 變更
+- **STT 委派給 mori-ear** — 不再自行 spawn `whisper_local`;轉錄統一交給 mori-ear。
+- **移除內建 Transcribe 分頁**(檔案 / 批次轉錄)+ 移出會議錄音模式 → recorder 成唯一轉錄入口,mori-desktop 淨刪約 400 行。
+- **UI** — 補齊缺的 `--c-*` color token;Body / Permissions / Pulse 分頁對齊 `.mori-tab` 版面。
+
+無 breaking change(設定 / vault 格式不變)。
+
 ## v0.7.6 — Deps 修復 + CLI 偵測補強(2026-05-27)
 
 這版修掉 Linux 本機 Whisper 與 Bash CLI provider 在桌面 app 環境下的兩個實際踩坑:whisper.cpp 官方 release 目前沒有 Linux `whisper-server` 預編譯 binary,以及 GUI app 啟動時不一定吃得到 shell / nvm / wrapper 裡的 CLI 路徑。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "mori-cli"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "mori-core"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "mori-file-loader"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "calamine",
  "chrono",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "mori-gmail"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "mori-mcp"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "rmcp",
  "serde",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "mori-tauri"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "mori-time"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "chrono-english",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.6"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 authors = ["yazelin"]

--- a/crates/mori-tauri/tauri.conf.json
+++ b/crates/mori-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Mori",
-  "version": "0.7.6",
+  "version": "0.8.0",
   "identifier": "ai.yazelin.mori",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mori-desktop",
-  "version": "0.7.6",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mori-desktop",
-      "version": "0.7.6",
+      "version": "0.8.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mori-desktop",
   "private": true,
-  "version": "0.7.6",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "predev": "cargo build -p mori-cli && node scripts/stage-mori-cli-for-bundle.mjs debug",


### PR DESCRIPTION
Body Interface 整批(BI-0~5)+ STT 委派 mori-ear + 移除內建 Transcribe 分頁 + 會議錄音移出 recorder。版號 0.7.6 → 0.8.0(Cargo / tauri.conf / package + 兩個 lock + CHANGELOG)。合併後推 v0.8.0 tag → CI 出 Linux(deb/AppImage/rpm)+ Windows(msi/exe)draft release。詳見 CHANGELOG。