### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@
 
 ---
 
+## v0.8.1 — Recorder ↔ Desktop 雙向偵測 + tray 整合(2026-06-04)
+
+把 BI-5 當初延後的「desktop 端」補上:桌面與 mori-meeting-recorder 互相偵測對方在不在,在場時各自調整 UI(雙向偵測 + 自適應 UI)。
+
+### 新功能
+- **tray「會議錄音」入口** — 偵測到 recorder 安裝(其 body-part manifest 有 `entrypoints.app`)就在 tray 顯示,點了 spawn recorder(帶 `--no-tray`);沒裝不顯示。
+- **Body 分頁啟動鈕** — 對有 app entrypoint 的身體部件顯示「啟動」鈕(`launch_recorder_cmd`)。
+- **hub presence marker** — 啟動寫 `~/.mori/body-parts/mori.desktop/manifest.json`(合法 BodyManifest + `pid`/`started_at`),結束移除;讓其他部件偵測 hub 是否「正在執行」。
+
+### 變更
+- 跨平台 spawn recorder 帶 `--no-tray`;Windows 用 `CREATE_NO_WINDOW` 防 console 一閃;tray「會議錄音」點擊時即時重查路徑。
+
+無 breaking change。完整雙向 tray 行為需搭配 **mori-meeting-recorder v0.1.3**(recorder 端:偵測到 desktop 在跑就收起自己 tray、展開膠囊)。plan 見 `docs/superpowers/plans/2026-06-04-bi-5-recorder-tray-launch.md`。
+
+---
+
 ## v0.8.0 — 身體介面(Body Interface)+ STT 委派給 mori-ear(2026-06-04)
 
 把「身體部件」架構(Body Interface, BI-0~5)落地,並把轉錄 / 會議錄音拆給專責 organ,mori-desktop 自身瘦身。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "mori-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "mori-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "mori-file-loader"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "calamine",
  "chrono",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "mori-gmail"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "mori-mcp"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "rmcp",
  "serde",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "mori-tauri"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "mori-time"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "chrono",
  "chrono-english",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license = "MIT"
 authors = ["yazelin"]

--- a/crates/mori-tauri/tauri.conf.json
+++ b/crates/mori-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Mori",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "identifier": "ai.yazelin.mori",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mori-desktop",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mori-desktop",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mori-desktop",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "scripts": {
     "predev": "cargo build -p mori-cli && node scripts/stage-mori-cli-for-bundle.mjs debug",


### PR DESCRIPTION
Release v0.8.1 — BI-5 tray 整合(desktop #146 + recorder #96)。

- tray「會議錄音」+ Body 啟動鈕 + hub presence marker
- 搭配 mori-meeting-recorder v0.1.3
- bump 0.8.0 -> 0.8.1 + CHANGELOG v0.8.1

release body 已備(待 tag 後套到 draft);實作待 yazelin 明天驗收。