### PR TITLE
chore: release v0.8.2 — 移除沒用的 hub presence marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ---
 
+## v0.8.2 — 收尾:移除 desktop 沒用的 hub presence marker(2026-06-04)
+
+recorder v0.1.4 起改成普通 app、沒有自己的 tray,不再需要偵測「desktop 是否在執行」,所以 desktop 那個 `~/.mori/body-parts/mori.desktop/manifest.json` presence marker(v0.8.1 寫入)已沒人讀。本版移除其寫入 / 移除 / 序列化 code(`.run` 還原成簡單形式 + 移除對應 test)。tray「會議錄音」launcher + Body 分頁啟動鈕不受影響。無 breaking change。
+
+---
+
 ## v0.8.1 — Recorder ↔ Desktop 雙向偵測 + tray 整合(2026-06-04)
 
 把 BI-5 當初延後的「desktop 端」補上:桌面與 mori-meeting-recorder 互相偵測對方在不在,在場時各自調整 UI(雙向偵測 + 自適應 UI)。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "mori-cli"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "mori-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "mori-file-loader"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "calamine",
  "chrono",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "mori-gmail"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "mori-mcp"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "rmcp",
  "serde",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "mori-tauri"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "mori-time"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "chrono",
  "chrono-english",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 license = "MIT"
 authors = ["yazelin"]

--- a/crates/mori-tauri/src/main.rs
+++ b/crates/mori-tauri/src/main.rs
@@ -2219,66 +2219,9 @@ fn body_registry_list() -> Result<Vec<mori_core::body::DiscoveredBodyPart>, Stri
     ))
 }
 
-// ── BI-5 follow-up:Recorder ↔ Desktop 雙向偵測 + tray 整合 ──────────────
-// desktop(hub)啟動寫 presence marker、結束移除;recorder 偵測它在不在跑來決定要不要長
-// 自己的 tray。desktop 這邊偵測 recorder 是否安裝 → tray / Body 分頁出「會議錄音」啟動入口。
-// 偵測一律走 ~/.mori 檔案 marker,不開 IPC;任一邊單獨存在時行為不變(standalone-first)。
-
-/// hub presence marker 路徑。同時是合法 BodyManifest(desktop 自己 Body 分頁會列它)
-/// + 額外 pid/started_at 供其他部件偵測。
-fn desktop_marker_path() -> std::path::PathBuf {
-    mori_dir()
-        .join("body-parts")
-        .join("mori.desktop")
-        .join("manifest.json")
-}
-
-/// 純函式:產生 hub presence marker 的 JSON 字串。抽出來好測(見 tests)。
-/// 合法 v1 BodyManifest(BodyKind 無 hub 變體 → 用 standalone_app)+ 額外 pid/started_at。
-/// BodyManifest 無 deny_unknown_fields,額外欄位被忽略;recorder 只讀 pid。
-/// 不放 entrypoints.app → Body 分頁不會給 hub 自己一顆「啟動」鈕。
-fn desktop_marker_json(pid: u32, started_at: u64) -> String {
-    let marker = serde_json::json!({
-        "schema_version": 1,
-        "id": "mori.desktop",
-        "name": "Mori Desktop",
-        "kind": "standalone_app",
-        "description": "Mori 桌面本體(hub)—— 身體部件中樞。此檔同時是 presence marker(pid 供偵測 hub 是否在執行)。",
-        "interfaces": [],
-        "capabilities": [],
-        "permissions": [],
-        "data_policy": { "owns_raw_data": false, "default_ingestion": "off" },
-        "pid": pid,
-        "started_at": started_at
-    });
-    serde_json::to_string_pretty(&marker).unwrap_or_else(|_| "{}".to_string())
-}
-
-/// 啟動時寫 presence marker(pid 供 recorder 偵測 hub「正在執行」)。失敗只 warn 不致命。
-fn write_desktop_presence_marker() {
-    let path = desktop_marker_path();
-    if let Some(parent) = path.parent() {
-        if let Err(e) = std::fs::create_dir_all(parent) {
-            tracing::warn!(path = %parent.display(), error = %e, "create mori.desktop marker dir failed");
-            return;
-        }
-    }
-    let pid = std::process::id();
-    let started_at = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    if let Err(e) = std::fs::write(&path, desktop_marker_json(pid, started_at)) {
-        tracing::warn!(path = %path.display(), error = %e, "write mori.desktop marker failed");
-    } else {
-        tracing::info!(pid, "mori.desktop presence marker written");
-    }
-}
-
-/// app 結束時移除 marker,讓之後 standalone 啟動的 recorder 不誤判 desktop 還在跑。
-fn remove_desktop_presence_marker() {
-    let _ = std::fs::remove_file(desktop_marker_path());
-}
+// ── BI-5 follow-up:Desktop 偵測 recorder 是否安裝 → tray / Body 分頁出「會議錄音」啟動入口 ──
+// 走 ~/.mori 的 body-part manifest;recorder 沒裝就不顯示(自適應)。recorder v0.1.4 起是普通 app、
+// 沒有自己的 tray,所以 desktop 不再需要寫「hub 在執行」的 marker 給它偵測(該 marker 已移除)。
 
 /// 找已安裝的 mori-meeting-recorder 可執行檔(它 body-part manifest 的 entrypoints.app)。
 /// 沒裝 / 沒 app entrypoint → None。tray 與 Body 分頁據此決定要不要顯示「會議錄音」入口。
@@ -7471,41 +7414,15 @@ fn main() {
 
             tracing::info!("hotkey path ready (toggle + cancel + picker + Alt+0~9 + Ctrl+Alt+0~9) + tray icon");
 
-            // BI-5 follow-up:寫 hub presence marker(pid),讓其他身體部件偵測 desktop「正在執行」。
-            write_desktop_presence_marker();
-
             Ok(())
         })
-        .build(tauri::generate_context!())
-        .expect("error while running tauri application")
-        .run(|_app, event| {
-            // BI-5 follow-up:app 真正結束時移除 hub presence marker,
-            // 讓之後 standalone 啟動的 recorder 不誤判 desktop 還在跑。
-            if let tauri::RunEvent::Exit = event {
-                remove_desktop_presence_marker();
-            }
-        });
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn desktop_marker_json_is_valid_body_manifest() {
-        let json = desktop_marker_json(4321, 1000);
-        // 必須能被 mori-core 當合法 v1 BodyManifest 解析(否則 desktop 自己 Body 分頁會 parse_error)。
-        let m = mori_core::body::parse_manifest(&json).expect("hub marker must parse as BodyManifest");
-        assert_eq!(m.id, "mori.desktop");
-        assert_eq!(m.kind, mori_core::body::BodyKind::StandaloneApp);
-        assert_eq!(
-            mori_core::body::manifest_status(&m),
-            mori_core::body::ManifestStatus::Valid
-        );
-        // pid 必須是 recorder 端(desktop_presence)讀得到的數字欄位。
-        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(v["pid"].as_u64(), Some(4321));
-    }
 
     // ─── Phase 6 polish A: check_provider_binary ─────────────────────
     // 驗 provider name → binary mapping + 各 helper return 結構。

--- a/crates/mori-tauri/tauri.conf.json
+++ b/crates/mori-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Mori",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "identifier": "ai.yazelin.mori",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mori-desktop",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mori-desktop",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mori-desktop",
   "private": true,
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "scripts": {
     "predev": "cargo build -p mori-cli && node scripts/stage-mori-cli-for-bundle.mjs debug",


### PR DESCRIPTION
收尾:recorder v0.1.4 起無 tray、不偵測 desktop → desktop 的 mori.desktop presence marker 沒人讀,移除之。

- 移除 marker 寫/移除/序列化 code + setup 呼叫 + .run Exit handler + test;.run 還原簡單形式
- 保留 tray「會議錄音」+ Body 啟動鈕(A 側 launcher 不動)
- cargo check 過;bump v0.8.2 + CHANGELOG